### PR TITLE
Add -mmacosx-version-min=10.5 to compiler flags on OS X.

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -189,6 +189,7 @@ class AMXXConfig(object):
         cfg.postlink += ['-lgcc_eh']
     elif builder.target_platform == 'mac':
       cfg.defines += ['OSX', '_OSX', 'POSIX']
+      cfg.cflags += ['-mmacosx-version-min=10.5']
       cfg.postlink += [
         '-mmacosx-version-min=10.5',
         '-arch', 'i386',


### PR DESCRIPTION
Although AMXX currently appears to load and work on OS X just fine without this, it may not always. So to be safe, this flag should be added so that we don't accidentally pull in some symbol that only exists on 10.9.
