### PR TITLE
StatsX Language/Translation Update

### DIFF
--- a/plugins/cstrike/statsx.sma
+++ b/plugins/cstrike/statsx.sma
@@ -1378,6 +1378,9 @@ public eventStartRound()
 // Reset killer info on round restart.
 public eventSpawn(id)
 {
+	if (!is_user_alive(id))
+		return HAM_IGNORED
+
 	new args[1]
 	args[0] = id
 


### PR DESCRIPTION
Updates to StatsX for per-user translation support. Fixes [bug 3040](https://bugs.alliedmods.net/show_bug.cgi?id=3040)
- Removed occurances of LANG_SERVER where possible
- And a lot of smaller, general improvements:
  - removed all implicit usage of global buffers
  - formatex used instead of format
  - removed hardcoded string lengths and defines in favor of the charsmax macro
  - fixed a small code piece where player id caching was accidentally not used
  - switched replace_all to the new replace_string
  - moved cvar usage from named access to pcvars
  - moved spawn detection from resethud to Ham_Spawn
  - set_task now uses the smallest possible 0.1 as the timer
