### PR TITLE
Introduce Trie Iterators

### DIFF
--- a/amxmodx/meta_api.cpp
+++ b/amxmodx/meta_api.cpp
@@ -417,8 +417,11 @@ int	C_Spawn(edict_t *pent)
 	g_TrieSnapshotHandles.clear();
 
 	CellTrieIter *i;
-	for (int index = 0; (i = g_TrieIterHandles.lookup(index++)) != NULL; index++)
-		delete i->iter;
+	for (size_t index = 1; index <= g_TrieIterHandles.size(); index++)
+	{
+		if ((i = g_TrieIterHandles.lookup(index)) != NULL)
+			delete i->iter;
+	}
 
 	g_TrieIterHandles.clear();
 	g_DataPackHandles.clear();

--- a/amxmodx/meta_api.cpp
+++ b/amxmodx/meta_api.cpp
@@ -415,6 +415,12 @@ int	C_Spawn(edict_t *pent)
 
 	g_TrieHandles.clear();
 	g_TrieSnapshotHandles.clear();
+
+	CellTrieIter *i;
+	for (int index = 0; (i = g_TrieIterHandles.lookup(index++)) != NULL; index++)
+		delete i->iter;
+
+	g_TrieIterHandles.clear();
 	g_DataPackHandles.clear();
 
 	char map_pluginsfile_path[256];

--- a/amxmodx/sm_stringhashmap.h
+++ b/amxmodx/sm_stringhashmap.h
@@ -197,6 +197,11 @@ public:
 		return internal_.iter();
 	}
 
+	iterator *iter_()
+	{
+		return internal_.iter_();
+	}
+
 	size_t mem_usage() const
 	{
 		return internal_.estimateMemoryUse() + memory_used_;

--- a/amxmodx/sm_stringhashmap.h
+++ b/amxmodx/sm_stringhashmap.h
@@ -197,9 +197,9 @@ public:
 		return internal_.iter();
 	}
 
-	iterator *iter_()
+	iterator *p_iter()
 	{
-		return internal_.iter_();
+		return internal_.p_iter();
 	}
 
 	size_t mem_usage() const

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -591,6 +591,32 @@ static cell AMX_NATIVE_CALL TrieIterRefresh(AMX *amx, cell *params)
 	return true;
 }
 
+// native TrieIterGetSize(TrieIter:handle)
+static cell AMX_NATIVE_CALL TrieIterGetSize(AMX *amx, cell *params)
+{
+	CellTrieIter *i = g_TrieIterHandles.lookup(params[1]);
+
+	if (i == NULL)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Invalid map iterator handle provided (%d)", params[1]);
+		return 0;
+	}
+
+	if (i->trie == NULL)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Underlying map to iterator handle (%d) has been closed", params[1]);
+		return 0;
+	}
+
+	if (!i->iter->valid_strict())
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Underlying map to iterator handle (%d) is outdated", params[1]);
+		return 0;
+	}
+
+	return i->trie->map.elements();
+}
+
 // native bool:TrieIterGetCell(TrieIter:handle, &any:value)
 static cell AMX_NATIVE_CALL TrieIterGetCell(AMX *amx, cell *params)
 {
@@ -774,6 +800,7 @@ AMX_NATIVE_INFO trie_Natives[] =
 	{ "TrieIterGetKey", TrieIterGetKey },
 	{ "TrieIterGetStatus", TrieIterGetStatus },
 	{ "TrieIterRefresh", TrieIterRefresh },
+	{ "TrieIterGetSize", TrieIterGetSize },
 	{ "TrieIterGetCell", TrieIterGetCell },
 	{ "TrieIterGetString", TrieIterGetString },
 	{ "TrieIterGetArray", TrieIterGetArray },

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -447,7 +447,20 @@ static cell AMX_NATIVE_CALL TrieSnapshotDestroy(AMX *amx, cell *params)
 // native TrieIter:TrieIterCreate(Trie:handle)
 static cell AMX_NATIVE_CALL TrieIterCreate(AMX *amx, cell *params)
 {
-	return 0;
+	CellTrie *t = g_TrieHandles.lookup(params[1]);
+
+	if (t == NULL)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Invalid map handle provided (%d)", params[1]);
+		return 0;
+	}
+
+	int index = g_TrieIterHandles.create();
+	CellTrieIter *i = g_TrieIterHandles.lookup(index);
+	i->trie = t;
+	i->iter = t->map.iter_();
+
+	return static_cast<cell>(index);
 }
 
 // native TrieIterNext(TrieIter:handle, key[] = "", maxlen = 0)

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -319,6 +319,11 @@ static cell AMX_NATIVE_CALL TrieDestroy(AMX *amx, cell *params)
 		return 0;
 	}
 
+	int index = 0;
+	CellTrieIter *i;
+	while ((i = g_TrieIterHandles.lookup(index++)) != NULL)
+		i->trie = NULL;
+
 	if (g_TrieHandles.destroy(*ptr))
 	{
 		*ptr = 0;

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -320,8 +320,14 @@ static cell AMX_NATIVE_CALL TrieDestroy(AMX *amx, cell *params)
 	}
 
 	CellTrieIter *i;
-	for (int index = 0; (i = g_TrieIterHandles.lookup(index++)) != NULL; index++)
-		delete i->iter;
+	for (size_t index = 1; index <= g_TrieIterHandles.size(); index++)
+	{
+		if ((i = g_TrieIterHandles.lookup(index)) != NULL)
+		{
+			if (i->trie == t)
+				i->trie = NULL;
+		}
+	}
 
 	if (g_TrieHandles.destroy(*ptr))
 	{

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -468,7 +468,7 @@ static cell AMX_NATIVE_CALL TrieIterCreate(AMX *amx, cell *params)
 	int index = g_TrieIterHandles.create();
 	CellTrieIter *i = g_TrieIterHandles.lookup(index);
 	i->trie = t;
-	i->iter = t->map.iter_();
+	i->iter = t->map.p_iter();
 
 	return static_cast<cell>(index);
 }

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -466,7 +466,20 @@ static cell AMX_NATIVE_CALL TrieIterCreate(AMX *amx, cell *params)
 // native TrieIterNext(TrieIter:handle, key[] = "", maxlen = 0)
 static cell AMX_NATIVE_CALL TrieIterNext(AMX *amx, cell *params)
 {
-	return 0;
+	CellTrieIter *i = g_TrieIterHandles.lookup(params[1]);
+
+	if (i == NULL)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Invalid map iterator handle provided (%d)", params[1]);
+		return 0;
+	}
+
+	if (i->trie == NULL || !i->iter->valid() || i->iter->empty())
+		return set_amxstring_utf8(amx, params[2], "", 0, params[3] + 1);
+
+	i->iter->next();
+
+	return set_amxstring_utf8(amx, params[2], (*i->iter)->key.chars(), (*i->iter)->key.length(), params[3] + 1);
 }
 
 // native TrieIterStatus:TrieIterGetStatus(TrieIter:handle)

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -490,7 +490,7 @@ static cell AMX_NATIVE_CALL TrieIterNext(AMX *amx, cell *params)
 		return false;
 	}
 
-	if (!i->iter->valid())
+	if (!i->iter->valid_strict())
 	{
 		LogError(amx, AMX_ERR_NATIVE, "Underlying map to iterator handle (%d) is outdated", params[1]);
 		return false;
@@ -531,7 +531,7 @@ static cell AMX_NATIVE_CALL TrieIterGetKey(AMX *amx, cell *params)
 		return false;
 	}
 
-	if (!i->iter->valid())
+	if (!i->iter->valid_strict())
 	{
 		LogError(amx, AMX_ERR_NATIVE, "Underlying map to iterator handle (%d) is outdated", params[1]);
 		return false;
@@ -564,7 +564,7 @@ static cell AMX_NATIVE_CALL TrieIterGetStatus(AMX *amx, cell *params)
 	if (i->trie == NULL)
 		return IterStatus_Closed;
 
-	if (!i->iter->valid())
+	if (!i->iter->valid_strict())
 		return IterStatus_Outdated;
 
 	return IterStatus_Valid;
@@ -608,7 +608,7 @@ static cell AMX_NATIVE_CALL TrieIterGetCell(AMX *amx, cell *params)
 		return false;
 	}
 
-	if (!i->iter->valid())
+	if (!i->iter->valid_strict())
 	{
 		LogError(amx, AMX_ERR_NATIVE, "Underlying map to iterator handle (%d) is outdated", params[1]);
 		return false;
@@ -645,7 +645,7 @@ static cell AMX_NATIVE_CALL TrieIterGetString(AMX *amx, cell *params)
 		return false;
 	}
 
-	if (!i->iter->valid())
+	if (!i->iter->valid_strict())
 	{
 		LogError(amx, AMX_ERR_NATIVE, "Underlying map to iterator handle (%d) is outdated", params[1]);
 		return false;
@@ -681,7 +681,7 @@ static cell AMX_NATIVE_CALL TrieIterGetArray(AMX *amx, cell *params)
 		return false;
 	}
 
-	if (!i->iter->valid())
+	if (!i->iter->valid_strict())
 	{
 		LogError(amx, AMX_ERR_NATIVE, "Underlying map to iterator handle (%d) is outdated", params[1]);
 		return false;

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -725,7 +725,7 @@ static cell AMX_NATIVE_CALL TrieIterDestroy(AMX *amx, cell *params)
 {
 	cell *ptr = get_amxaddr(amx, params[1]);
 
-	CellTrieIter *i = g_TrieIterHandles.lookup(params[1]);
+	CellTrieIter *i = g_TrieIterHandles.lookup(*ptr);
 
 	if (i == NULL)
 	{

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -473,7 +473,7 @@ static cell AMX_NATIVE_CALL TrieIterCreate(AMX *amx, cell *params)
 	return static_cast<cell>(index);
 }
 
-// native TrieIterNext(TrieIter:handle, key[] = "", outputsize = 0, &size = 0)
+// native bool:TrieIterNext(TrieIter:handle, key[] = "", outputsize = 0, &size = 0)
 static cell AMX_NATIVE_CALL TrieIterNext(AMX *amx, cell *params)
 {
 	CellTrieIter *i = g_TrieIterHandles.lookup(params[1]);
@@ -481,7 +481,7 @@ static cell AMX_NATIVE_CALL TrieIterNext(AMX *amx, cell *params)
 	if (i == NULL)
 	{
 		LogError(amx, AMX_ERR_NATIVE, "Invalid map iterator handle provided (%d)", params[1]);
-		return 0;
+		return false;
 	}
 
 	if (i->trie == NULL)
@@ -516,7 +516,7 @@ static cell AMX_NATIVE_CALL TrieIterNext(AMX *amx, cell *params)
 	return true;
 }
 
-// native TrieIterGetKey(TrieIter:handle, key[] = "", outputsize = 0, &size = 0)
+// native bool:TrieIterGetKey(TrieIter:handle, key[] = "", outputsize = 0, &size = 0)
 static cell AMX_NATIVE_CALL TrieIterGetKey(AMX *amx, cell *params)
 {
 	CellTrieIter *i = g_TrieIterHandles.lookup(params[1]);
@@ -619,6 +619,29 @@ static cell AMX_NATIVE_CALL TrieIterGetSize(AMX *amx, cell *params)
 	}
 
 	return i->trie->map.elements();
+}
+
+// native bool:TrieIterSetPos(TrieIter:handle, const key[])
+static cell AMX_NATIVE_CALL TrieIterSetPos(AMX *amx, cell *params)
+{
+	CellTrieIter *i = g_TrieIterHandles.lookup(params[1]);
+
+	if (i == NULL)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Invalid map iterator handle provided (%d)", params[1]);
+		return false;
+	}
+
+	if (i->trie == NULL)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Closed map iterator handle provided (%d)", params[1]);
+		return false;
+	}
+
+	int len;
+	const char *key = get_amxstring(amx, params[2], 0, len);
+
+	return i->iter->setpos(i->trie->map.find(key));
 }
 
 // native bool:TrieIterGetCell(TrieIter:handle, &any:value)
@@ -802,6 +825,7 @@ AMX_NATIVE_INFO trie_Natives[] =
 	{ "TrieIterGetStatus", TrieIterGetStatus },
 	{ "TrieIterRefresh", TrieIterRefresh },
 	{ "TrieIterGetSize", TrieIterGetSize },
+	{ "TrieIterSetPos", TrieIterSetPos },
 	{ "TrieIterGetCell", TrieIterGetCell },
 	{ "TrieIterGetString", TrieIterGetString },
 	{ "TrieIterGetArray", TrieIterGetArray },

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -646,7 +646,26 @@ static cell AMX_NATIVE_CALL TrieIterGetArray(AMX *amx, cell *params)
 // native TrieIterDestroy(&TrieIter:handle)
 static cell AMX_NATIVE_CALL TrieIterDestroy(AMX *amx, cell *params)
 {
-	return 0;
+	cell *ptr = get_amxaddr(amx, params[1]);
+
+	CellTrieIter *i = g_TrieIterHandles.lookup(params[1]);
+
+	if (i == NULL)
+	{
+		return false;
+	}
+	
+	delete i->iter;
+	i->iter = NULL;
+	i->trie = NULL;
+
+	if (g_TrieIterHandles.destroy(*ptr))
+	{
+		*ptr = 0;
+		return true;
+	}
+
+	return false;
 }
 
 AMX_NATIVE_INFO trie_Natives[] =

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -505,7 +505,22 @@ static cell AMX_NATIVE_CALL TrieIterGetStatus(AMX *amx, cell *params)
 // native bool:TrieIterRefresh(TrieIter:handle)
 static cell AMX_NATIVE_CALL TrieIterRefresh(AMX *amx, cell *params)
 {
-	return false;
+	CellTrieIter *i = g_TrieIterHandles.lookup(params[1]);
+
+	if (i == NULL)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Invalid map iterator handle provided (%d)", params[1]);
+		return false;
+	}
+
+	if (i->trie == NULL)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Underlying map to iterator handle (%d) has been closed", params[1]);
+		return false;
+	}
+
+	i->iter->refresh();
+	return true;
 }
 
 // native bool:TrieIterGetCell(TrieIter:handle, &any:value)

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -485,6 +485,20 @@ static cell AMX_NATIVE_CALL TrieIterNext(AMX *amx, cell *params)
 // native TrieIterStatus:TrieIterGetStatus(TrieIter:handle)
 static cell AMX_NATIVE_CALL TrieIterGetStatus(AMX *amx, cell *params)
 {
+	CellTrieIter *i = g_TrieIterHandles.lookup(params[1]);
+
+	if (i == NULL)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Invalid map iterator handle provided (%d)", params[1]);
+		return Iter_Invalid;
+	}
+
+	if (i->trie == NULL)
+		return Iter_Invalid;
+
+	if (!i->iter->valid())
+		return Iter_Outdated;
+
 	return Iter_Valid;
 }
 

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -486,13 +486,13 @@ static cell AMX_NATIVE_CALL TrieIterNext(AMX *amx, cell *params)
 
 	if (i->trie == NULL)
 	{
-		LogError(amx, AMX_ERR_NATIVE, "Underlying map to iterator handle (%d) has been closed", params[1]);
+		LogError(amx, AMX_ERR_NATIVE, "Closed map iterator handle provided (%d)", params[1]);
 		return false;
 	}
 
 	if (!i->iter->valid_strict())
 	{
-		LogError(amx, AMX_ERR_NATIVE, "Underlying map to iterator handle (%d) is outdated", params[1]);
+		LogError(amx, AMX_ERR_NATIVE, "Outdated map iterator handle provided (%d)", params[1]);
 		return false;
 	}
 
@@ -529,13 +529,13 @@ static cell AMX_NATIVE_CALL TrieIterGetKey(AMX *amx, cell *params)
 
 	if (i->trie == NULL)
 	{
-		LogError(amx, AMX_ERR_NATIVE, "Underlying map to iterator handle (%d) has been closed", params[1]);
+		LogError(amx, AMX_ERR_NATIVE, "Closed map iterator handle provided (%d)", params[1]);
 		return false;
 	}
 
 	if (!i->iter->valid_strict())
 	{
-		LogError(amx, AMX_ERR_NATIVE, "Underlying map to iterator handle (%d) is outdated", params[1]);
+		LogError(amx, AMX_ERR_NATIVE, "Outdated map iterator handle provided (%d)", params[1]);
 		return false;
 	}
 
@@ -587,7 +587,7 @@ static cell AMX_NATIVE_CALL TrieIterRefresh(AMX *amx, cell *params)
 
 	if (i->trie == NULL)
 	{
-		LogError(amx, AMX_ERR_NATIVE, "Underlying map to iterator handle (%d) has been closed", params[1]);
+		LogError(amx, AMX_ERR_NATIVE, "Closed map iterator handle provided (%d)", params[1]);
 		return false;
 	}
 
@@ -608,13 +608,13 @@ static cell AMX_NATIVE_CALL TrieIterGetSize(AMX *amx, cell *params)
 
 	if (i->trie == NULL)
 	{
-		LogError(amx, AMX_ERR_NATIVE, "Underlying map to iterator handle (%d) has been closed", params[1]);
+		LogError(amx, AMX_ERR_NATIVE, "Closed map iterator handle provided (%d)", params[1]);
 		return 0;
 	}
 
 	if (!i->iter->valid_strict())
 	{
-		LogError(amx, AMX_ERR_NATIVE, "Underlying map to iterator handle (%d) is outdated", params[1]);
+		LogError(amx, AMX_ERR_NATIVE, "Outdated map iterator handle provided (%d)", params[1]);
 		return 0;
 	}
 
@@ -634,13 +634,13 @@ static cell AMX_NATIVE_CALL TrieIterGetCell(AMX *amx, cell *params)
 
 	if (i->trie == NULL)
 	{
-		LogError(amx, AMX_ERR_NATIVE, "Underlying map to iterator handle (%d) has been closed", params[1]);
+		LogError(amx, AMX_ERR_NATIVE, "Closed map iterator handle provided (%d)", params[1]);
 		return false;
 	}
 
 	if (!i->iter->valid_strict())
 	{
-		LogError(amx, AMX_ERR_NATIVE, "Underlying map to iterator handle (%d) is outdated", params[1]);
+		LogError(amx, AMX_ERR_NATIVE, "Outdated map iterator handle provided (%d)", params[1]);
 		return false;
 	}
 
@@ -666,13 +666,13 @@ static cell AMX_NATIVE_CALL TrieIterGetString(AMX *amx, cell *params)
 
 	if (i->trie == NULL)
 	{
-		LogError(amx, AMX_ERR_NATIVE, "Underlying map to iterator handle (%d) has been closed", params[1]);
+		LogError(amx, AMX_ERR_NATIVE, "Closed map iterator handle provided (%d)", params[1]);
 		return false;
 	}
 
 	if (!i->iter->valid_strict())
 	{
-		LogError(amx, AMX_ERR_NATIVE, "Underlying map to iterator handle (%d) is outdated", params[1]);
+		LogError(amx, AMX_ERR_NATIVE, "Outdated map iterator handle provided (%d)", params[1]);
 		return false;
 	}
 
@@ -704,13 +704,13 @@ static cell AMX_NATIVE_CALL TrieIterGetArray(AMX *amx, cell *params)
 
 	if (i->trie == NULL)
 	{
-		LogError(amx, AMX_ERR_NATIVE, "Underlying map to iterator handle (%d) has been closed", params[1]);
+		LogError(amx, AMX_ERR_NATIVE, "Closed map iterator handle provided (%d)", params[1]);
 		return false;
 	}
 
 	if (!i->iter->valid_strict())
 	{
-		LogError(amx, AMX_ERR_NATIVE, "Underlying map to iterator handle (%d) is outdated", params[1]);
+		LogError(amx, AMX_ERR_NATIVE, "Outdated map iterator handle provided (%d)", params[1]);
 		return false;
 	}
 

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -526,6 +526,34 @@ static cell AMX_NATIVE_CALL TrieIterRefresh(AMX *amx, cell *params)
 // native bool:TrieIterGetCell(TrieIter:handle, &any:value)
 static cell AMX_NATIVE_CALL TrieIterGetCell(AMX *amx, cell *params)
 {
+	CellTrieIter *i = g_TrieIterHandles.lookup(params[1]);
+
+	if (i == NULL)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Invalid map iterator handle provided (%d)", params[1]);
+		return false;
+	}
+
+	if (i->trie == NULL)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Underlying map to iterator handle (%d) has been closed", params[1]);
+		return false;
+	}
+
+	if (!i->iter->valid())
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Underlying map to iterator handle (%d) is outdated", params[1]);
+		return false;
+	}
+
+	cell *ptr = get_amxaddr(amx, params[2]);
+
+	if ((*i->iter)->value.isCell())
+	{
+		*ptr = (*i->iter)->value.cell_();
+		return true;
+	}
+
 	return false;
 }
 

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -560,6 +560,33 @@ static cell AMX_NATIVE_CALL TrieIterGetCell(AMX *amx, cell *params)
 // native bool:TrieIterGetString(TrieIter:handle, buffer[], outputsize, &size = 0)
 static cell AMX_NATIVE_CALL TrieIterGetString(AMX *amx, cell *params)
 {
+	CellTrieIter *i = g_TrieIterHandles.lookup(params[1]);
+
+	if (i == NULL)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Invalid map iterator handle provided (%d)", params[1]);
+		return false;
+	}
+
+	if (i->trie == NULL)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Underlying map to iterator handle (%d) has been closed", params[1]);
+		return false;
+	}
+
+	if (!i->iter->valid())
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Underlying map to iterator handle (%d) is outdated", params[1]);
+		return false;
+	}
+
+	cell *pSize = get_amxaddr(amx, params[4]);
+
+	if ((*i->iter)->value.isString())
+	{
+		*pSize = (cell) set_amxstring_utf8(amx, params[2], (*i->iter)->value.chars(), strlen((*i->iter)->value.chars()), params[3] + 1);
+	}
+	
 	return false;
 }
 

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -443,6 +443,54 @@ static cell AMX_NATIVE_CALL TrieSnapshotDestroy(AMX *amx, cell *params)
 	return 0;
 }
 
+// native TrieIter:TrieIterCreate(Trie:handle)
+static cell AMX_NATIVE_CALL TrieIterCreate(AMX *amx, cell *params)
+{
+	return 0;
+}
+
+// native TrieIterNext(TrieIter:handle, key[] = "", maxlen = 0)
+static cell AMX_NATIVE_CALL TrieIterNext(AMX *amx, cell *params)
+{
+	return 0;
+}
+
+// native TrieIterStatus:TrieIterGetStatus(TrieIter:handle)
+static cell AMX_NATIVE_CALL TrieIterGetStatus(AMX *amx, cell *params)
+{
+	return Iter_Valid;
+}
+
+// native bool:TrieIterRefresh(TrieIter:handle)
+static cell AMX_NATIVE_CALL TrieIterRefresh(AMX *amx, cell *params)
+{
+	return false;
+}
+
+// native bool:TrieIterGetCell(TrieIter:handle, &any:value)
+static cell AMX_NATIVE_CALL TrieIterGetCell(AMX *amx, cell *params)
+{
+	return false;
+}
+
+// native bool:TrieIterGetString(TrieIter:handle, buffer[], outputsize, &size = 0)
+static cell AMX_NATIVE_CALL TrieIterGetString(AMX *amx, cell *params)
+{
+	return false;
+}
+
+// native bool:TrieIterGetArray(TrieIter:handle, array[], outputsize, &size = 0)
+static cell AMX_NATIVE_CALL TrieIterGetArray(AMX *amx, cell *params)
+{
+	return false;
+}
+
+// native TrieIterDestroy(&TrieIter:handle)
+static cell AMX_NATIVE_CALL TrieIterDestroy(AMX *amx, cell *params)
+{
+	return 0;
+}
+
 AMX_NATIVE_INFO trie_Natives[] =
 {
 	{ "TrieCreate",		TrieCreate },
@@ -466,6 +514,15 @@ AMX_NATIVE_INFO trie_Natives[] =
 	{ "TrieSnapshotKeyBufferSize",	TrieSnapshotKeyBufferSize },
 	{ "TrieSnapshotGetKey",			TrieSnapshotGetKey },
 	{ "TrieSnapshotDestroy",		TrieSnapshotDestroy },
+
+	{ "TrieIterCreate", TrieIterCreate },
+	{ "TrieIterNext", TrieIterNext },
+	{ "TrieIterGetStatus", TrieIterGetStatus },
+	{ "TrieIterRefresh", TrieIterRefresh },
+	{ "TrieIterGetCell", TrieIterGetCell },
+	{ "TrieIterGetString", TrieIterGetString },
+	{ "TrieIterGetArray", TrieIterGetArray },
+	{ "TrieIterDestroy", TrieIterDestroy },
 
 	{ NULL,			NULL }
 };

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -495,6 +495,9 @@ static cell AMX_NATIVE_CALL TrieIterNext(AMX *amx, cell *params)
 
 	i->iter->next();
 
+	if (i->iter->empty())
+		return false;
+
 	if (params[3] <= 0)
 		return true;
 
@@ -534,10 +537,7 @@ static cell AMX_NATIVE_CALL TrieIterGetKey(AMX *amx, cell *params)
 	cell *pSize = get_amxaddr(amx, params[4]);
 
 	if (i->iter->empty())
-	{
-		*pSize = (cell)set_amxstring_utf8(amx, params[2], "", 0, params[3] + 1);
 		return false;
-	}
 
 	*pSize = set_amxstring_utf8(amx, params[2], (*i->iter)->key.chars(), (*i->iter)->key.length(), params[3] + 1);
 	
@@ -608,6 +608,9 @@ static cell AMX_NATIVE_CALL TrieIterGetCell(AMX *amx, cell *params)
 		return false;
 	}
 
+	if (i->iter->empty())
+		return false;
+
 	cell *ptr = get_amxaddr(amx, params[2]);
 
 	if ((*i->iter)->value.isCell())
@@ -641,6 +644,9 @@ static cell AMX_NATIVE_CALL TrieIterGetString(AMX *amx, cell *params)
 		LogError(amx, AMX_ERR_NATIVE, "Underlying map to iterator handle (%d) is outdated", params[1]);
 		return false;
 	}
+
+	if (i->iter->empty())
+		return false;
 
 	cell *pSize = get_amxaddr(amx, params[4]);
 
@@ -680,6 +686,9 @@ static cell AMX_NATIVE_CALL TrieIterGetArray(AMX *amx, cell *params)
 		LogError(amx, AMX_ERR_NATIVE, "Invalid array size (%d)", params[4]);
 		return false;
 	}
+
+	if (i->iter->empty())
+		return false;
 
 	cell *pValue = get_amxaddr(amx, params[2]);
 	cell *pSize = get_amxaddr(amx, params[4]);

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -558,16 +558,16 @@ static cell AMX_NATIVE_CALL TrieIterGetStatus(AMX *amx, cell *params)
 	if (i == NULL)
 	{
 		LogError(amx, AMX_ERR_NATIVE, "Invalid map iterator handle provided (%d)", params[1]);
-		return Iter_Invalid;
+		return IterStatus_Closed;
 	}
 
 	if (i->trie == NULL)
-		return Iter_Invalid;
+		return IterStatus_Closed;
 
 	if (!i->iter->valid())
-		return Iter_Outdated;
+		return IterStatus_Outdated;
 
-	return Iter_Valid;
+	return IterStatus_Valid;
 }
 
 // native bool:TrieIterRefresh(TrieIter:handle)

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -496,6 +496,12 @@ static cell AMX_NATIVE_CALL TrieIterNext(AMX *amx, cell *params)
 		return false;
 	}
 
+	if (params[3] < 0)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Invalid key buffer size (%d)", params[3]);
+		return false;
+	}
+
 	if (i->iter->empty())
 		return false;
 
@@ -503,9 +509,6 @@ static cell AMX_NATIVE_CALL TrieIterNext(AMX *amx, cell *params)
 
 	if (i->iter->empty())
 		return false;
-
-	if (params[3] <= 0)
-		return true;
 
 	cell *pSize = get_amxaddr(amx, params[4]);
 
@@ -537,13 +540,16 @@ static cell AMX_NATIVE_CALL TrieIterGetKey(AMX *amx, cell *params)
 		return false;
 	}
 
-	if (params[3] <= 0)
-		return i->iter->empty();
-
-	cell *pSize = get_amxaddr(amx, params[4]);
+	if (params[3] < 0)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Invalid key buffer size (%d)", params[3]);
+		return false;
+	}
 
 	if (i->iter->empty())
 		return false;
+
+	cell *pSize = get_amxaddr(amx, params[4]);
 
 	*pSize = set_amxstring_utf8(amx, params[2], (*i->iter)->key.chars(), (*i->iter)->key.length(), params[3] + 1);
 	

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -10,6 +10,7 @@ using namespace SourceMod;
 
 TrieHandles<CellTrie> g_TrieHandles;
 TrieHandles<TrieSnapshot> g_TrieSnapshotHandles;
+TrieHandles<CellTrieIter> g_TrieIterHandles;
 
 // native Trie:TrieCreate();
 static cell AMX_NATIVE_CALL TrieCreate(AMX *amx, cell *params)

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -677,6 +677,12 @@ static cell AMX_NATIVE_CALL TrieIterGetString(AMX *amx, cell *params)
 		return false;
 	}
 
+	if (params[3] < 0)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Invalid buffer size (%d)", params[3]);
+		return false;
+	}
+
 	if (i->iter->empty())
 		return false;
 
@@ -715,7 +721,7 @@ static cell AMX_NATIVE_CALL TrieIterGetArray(AMX *amx, cell *params)
 
 	if (params[3] < 0)
 	{
-		LogError(amx, AMX_ERR_NATIVE, "Invalid array size (%d)", params[4]);
+		LogError(amx, AMX_ERR_NATIVE, "Invalid array size (%d)", params[3]);
 		return false;
 	}
 

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -511,7 +511,6 @@ static cell AMX_NATIVE_CALL TrieIterNext(AMX *amx, cell *params)
 		return false;
 
 	cell *pSize = get_amxaddr(amx, params[4]);
-
 	*pSize = (cell)set_amxstring_utf8(amx, params[2], (*i->iter)->key.chars(), (*i->iter)->key.length(), params[3] + 1);
 
 	return true;
@@ -550,7 +549,6 @@ static cell AMX_NATIVE_CALL TrieIterGetKey(AMX *amx, cell *params)
 		return false;
 
 	cell *pSize = get_amxaddr(amx, params[4]);
-
 	*pSize = set_amxstring_utf8(amx, params[2], (*i->iter)->key.chars(), (*i->iter)->key.length(), params[3] + 1);
 	
 	return true;
@@ -646,18 +644,13 @@ static cell AMX_NATIVE_CALL TrieIterGetCell(AMX *amx, cell *params)
 		return false;
 	}
 
-	if (i->iter->empty())
+	if (i->iter->empty() || !(*i->iter)->value.isCell())
 		return false;
 
 	cell *ptr = get_amxaddr(amx, params[2]);
+	*ptr = (*i->iter)->value.cell_();
 
-	if ((*i->iter)->value.isCell())
-	{
-		*ptr = (*i->iter)->value.cell_();
-		return true;
-	}
-
-	return false;
+	return true;
 }
 
 // native bool:TrieIterGetString(TrieIter:handle, buffer[], outputsize, &size = 0)
@@ -689,17 +682,13 @@ static cell AMX_NATIVE_CALL TrieIterGetString(AMX *amx, cell *params)
 		return false;
 	}
 
-	if (i->iter->empty())
+	if (i->iter->empty() || !(*i->iter)->value.isString())
 		return false;
 
 	cell *pSize = get_amxaddr(amx, params[4]);
-
-	if ((*i->iter)->value.isString())
-	{
-		*pSize = (cell) set_amxstring_utf8(amx, params[2], (*i->iter)->value.chars(), strlen((*i->iter)->value.chars()), params[3] + 1);
-	}
-
-	return false;
+	*pSize = (cell) set_amxstring_utf8(amx, params[2], (*i->iter)->value.chars(), strlen((*i->iter)->value.chars()), params[3] + 1);
+	
+	return true;
 }
 
 // native bool:TrieIterGetArray(TrieIter:handle, array[], outputsize, &size = 0)
@@ -731,20 +720,20 @@ static cell AMX_NATIVE_CALL TrieIterGetArray(AMX *amx, cell *params)
 		return false;
 	}
 
-	if (i->iter->empty())
+	if (i->iter->empty() || !(*i->iter)->value.isArray())
 		return false;
 
 	cell *pValue = get_amxaddr(amx, params[2]);
 	cell *pSize = get_amxaddr(amx, params[4]);
-
-	if (!(*i->iter)->value.isArray() || !params[3])
-		return false;
 
 	if (!(*i->iter)->value.array())
 	{
 		*pSize = 0;
 		return true;
 	}
+
+	if (!params[3])
+		return true;
 
 	size_t length = (*i->iter)->value.arrayLength();
 	cell *base = (*i->iter)->value.array();

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -319,10 +319,9 @@ static cell AMX_NATIVE_CALL TrieDestroy(AMX *amx, cell *params)
 		return 0;
 	}
 
-	int index = 0;
 	CellTrieIter *i;
-	while ((i = g_TrieIterHandles.lookup(index++)) != NULL)
-		i->trie = NULL;
+	for (int index = 0; (i = g_TrieIterHandles.lookup(index++)) != NULL; index++)
+		delete i->iter;
 
 	if (g_TrieHandles.destroy(*ptr))
 	{

--- a/amxmodx/trie_natives.h
+++ b/amxmodx/trie_natives.h
@@ -223,6 +223,12 @@ public:
 	}
 };
 
+enum TrieIterStatus
+{
+	Iter_Valid = 0,
+	Iter_Outdated = 1,
+	Iter_Invalid = 2,
+};
 
 extern TrieHandles<CellTrie> g_TrieHandles;
 extern TrieHandles<TrieSnapshot> g_TrieSnapshotHandles;

--- a/amxmodx/trie_natives.h
+++ b/amxmodx/trie_natives.h
@@ -165,6 +165,10 @@ public:
 		this->clear();
 	}
 
+	size_t size()
+	{
+		return m_tries.size();
+	}
 	void clear()
 	{
 		for (size_t i = 0; i < m_tries.size(); i++)

--- a/amxmodx/trie_natives.h
+++ b/amxmodx/trie_natives.h
@@ -229,9 +229,9 @@ public:
 
 enum TrieIterStatus
 {
-	Iter_Valid = 0,
-	Iter_Outdated = 1,
-	Iter_Invalid = 2,
+	IterStatus_Valid = 0,
+	IterStatus_Outdated = 1,
+	IterStatus_Closed = 2,
 };
 
 struct CellTrieIter

--- a/amxmodx/trie_natives.h
+++ b/amxmodx/trie_natives.h
@@ -230,8 +230,15 @@ enum TrieIterStatus
 	Iter_Invalid = 2,
 };
 
+struct CellTrieIter
+{
+	CellTrie *trie;
+	StringHashMap<Entry>::iterator *iter;
+};
+
 extern TrieHandles<CellTrie> g_TrieHandles;
 extern TrieHandles<TrieSnapshot> g_TrieSnapshotHandles;
+extern TrieHandles<CellTrieIter> g_TrieIterHandles;
 extern AMX_NATIVE_INFO trie_Natives[];
 
 #endif

--- a/plugins/include/celltrie.inc
+++ b/plugins/include/celltrie.inc
@@ -13,6 +13,18 @@ enum Snapshot
 	Invalid_Snapshot = 0
 };
 
+enum TrieIter
+{
+	Invalid_Iter = 0
+};
+
+enum TrieIterStatus
+{
+	IterStatus_Valid = 0,
+	IterStatus_Outdated = 1,
+	IterStatus_Closed = 2,
+};
+
 /**
  * Creates a hash map. A hash map is a container that can map strings (called
  * "keys") to arbitrary values (cells, arrays, or strings). Keys in a hash map
@@ -223,24 +235,144 @@ native TrieSnapshotGetKey(Snapshot:handle, index, buffer[], maxlength);
  */
 native TrieSnapshotDestroy(&Snapshot:handle);
 
-enum TrieIter
-{
-	Invalid_Iter = 0
-};
-
-enum TrieIterStatus
-{
-	IterStatus_Valid = 0,
-	IterStatus_Outdated = 1,
-	IterStatus_Closed = 2,
-};
-
+/**
+ * Creates an iterator for a map. An iterator provides very fast, iterative read-only
+ * access to a map.
+ *
+ * Any mutating change (that is key addition or key removal) to the underlying map
+ * will invalidate every iterator operating on it.
+ *
+ * Updating alreadys existing keys will not invalidate an iterator.
+ *
+ * Iterators are designed to be short-lived and not be permanently stored or cached.
+ * Creating new iterators is very fast, exhibiting virtually no overhead, even for
+ * large tries. It is usually recommended to create them on-demand. Value retrieval
+ * is as fast as directly reading from the underlying map.
+ *
+ * @return 				New iterator handle, which must be freed via TrieIterDestroy().
+ * @error				Invalid Handle
+ */
 native TrieIter:TrieIterCreate(Trie:handle);
+
+/**
+ * Advances the iterator to the next key if one is available
+ *
+ * Providing the function with an optional buffer and buffer length will
+ * store the next key inside that buffer.
+ *
+ * @param handle		Iterator handle.
+ * @param key			Optional buffer to store the next key in.
+ * @param outputsize	Maximum size of string buffer.
+ * @param size			Optional parameter to store the number of bytes written to the buffer.
+ *
+ * @return 				True if the iterator is not empty and a new key was made current.
+ * @error				Invalid handle
+ *						Iterator has been closed (underlying map destroyed)
+ *						Iterator is invalid
+*/
 native bool:TrieIterNext(TrieIter:handle, key[] = "", outputsize = 0, &size = 0);
+
+/**
+ * Checks if the iterator currently points to a key and is therefore not empty
+ *
+ * Providing the function with an optional buffer and buffer length will
+ * store the current key inside that buffer.
+ *
+ * @param handle		Iterator handle.
+ * @param key			Optional buffer to store the current key in.
+ * @param outputsize	Maximum size of string buffer.
+ * @param size			Optional parameter to store the number of bytes written to the buffer.
+ *
+ * @return 				True if the iterator is not empty  a new
+ *						was made current.
+ * @error				Invalid handle
+ *						Iterator has been closed (underlying map destroyed)
+ *						Iterator is invalid
+ */
 native bool:TrieIterGetKey(TrieIter:handle, key[] = "", outputsize = 0, &size = 0);
+
+/**
+ * Retrieves the current iterator status
+ *
+ * @param handle		Iterator handle.
+ *
+ * @return 				IterStatus_Valid 		if iterator can be used.
+ *						IterStatus_Outdated		if iterator has to be refreshed because
+ *												the underlying map has been modified.
+ *						IterStatus_Closed		if underlying map has been closed. The iterator
+ *												can't be refreshed and should be destroyed.
+ * @error				Invalid handle
+ */
 native TrieIterStatus:TrieIterGetStatus(TrieIter:handle);
+
+/**
+ * Refreshes the iterator if possible
+ *
+ * This function serves a dual purpose when working with iterators:
+ *
+ * 1) If the underlying map was mutated and the iterator invalidated, calling this function
+ * will allow the iterator to be revalidated without creating a new one.
+ *
+ * 2) After this function has returned the iterator will be starting over at its
+ * initial position, even if it was valid when this function was called.
+ *
+ * @param handle		Iterator handle.
+ *
+ * @return 				True if the iterator has been refreshed.
+ * @error				Invalid handle
+ *						Iterator has been closed (underlying map destroyed)
+ */
 native bool:TrieIterRefresh(TrieIter:handle);
+
+/**
+ * Retrieves a value at the current position of the iterator
+ *
+ * @param handle		Iterator handle.
+ * @param value			Variable to store value.
+ *
+ * @return 				True on success, false if the iterator is empty.
+ * @error				Invalid handle
+ *						Iterator has been closed (underlying map destroyed)
+ *						Iterator is invalid
+ */
 native bool:TrieIterGetCell(TrieIter:handle, &any:value);
+
+/**
+ * Retrieves a string at the current position of the iterator
+ *
+ * @param handle		Iterator handle.
+ * @param buffer		Buffer to store the string..
+ * @param outputsize	Maximum size of string buffer.
+ * @param size			Optional parameter to store the number of bytes written to the buffer.
+ *
+ * @return 				True on success, false if the iterator is empty.
+ * @error				Invalid handle
+ *						Iterator has been closed (underlying map destroyed)
+ *						Iterator is invalid
+ */
 native bool:TrieIterGetString(TrieIter:handle, buffer[], outputsize, &size = 0);
-native bool:TrieIterGetArray(TrieIter:handle, array[], outputsize, &size = 0);
+
+/**
+ * Retrieves an array at the current position of the iterator
+ *
+ * @param handle		Iterator handle.
+ * @param buffer		Buffer to store the array.
+ * @param outputsize	Maximum size of buffer.
+ * @param size			Optional parameter to store the number of bytes written to the buffer.
+ *
+ * @return 				True on success, false if the iterator is empty.
+ * @error				Invalid handle
+ *						Iterator has been closed (underlying map destroyed)
+ *						Iterator is invalid
+ */
+native bool:TrieIterGetArray(TrieIter:handle, any:array[], outputsize, &size = 0);
+
+/**
+ * Destroys an iterator handle.
+ *
+ * @param handle	Iterator handle.
+ *
+ * @return			True on success, false if the value was never set.
+ * @error			Invalid handle
+ */
 native TrieIterDestroy(&TrieIter:handle);

--- a/plugins/include/celltrie.inc
+++ b/plugins/include/celltrie.inc
@@ -237,6 +237,7 @@ enum TrieIterStatus
 
 native TrieIter:TrieIterCreate(Trie:handle);
 native TrieIterNext(TrieIter:handle, key[] = "", maxlen = 0);
+native bool:TrieIterGetKey(TrieIter:handle, key[] = "", outputsize = 0, &size = 0);
 native TrieIterStatus:TrieIterGetStatus(TrieIter:handle);
 native bool:TrieIterRefresh(TrieIter:handle);
 native bool:TrieIterGetCell(TrieIter:handle, &any:value);

--- a/plugins/include/celltrie.inc
+++ b/plugins/include/celltrie.inc
@@ -236,7 +236,7 @@ enum TrieIterStatus
 };
 
 native TrieIter:TrieIterCreate(Trie:handle);
-native TrieIterNext(TrieIter:handle, key[] = "", maxlen = 0);
+native bool:TrieIterNext(TrieIter:handle, key[] = "", outputsize = 0, &size = 0);
 native bool:TrieIterGetKey(TrieIter:handle, key[] = "", outputsize = 0, &size = 0);
 native TrieIterStatus:TrieIterGetStatus(TrieIter:handle);
 native bool:TrieIterRefresh(TrieIter:handle);

--- a/plugins/include/celltrie.inc
+++ b/plugins/include/celltrie.inc
@@ -234,10 +234,10 @@ native TrieSnapshotGetKey(Snapshot:handle, index, buffer[], maxlength);
 native TrieSnapshotDestroy(&Snapshot:handle);
 
 /**
- * Creates an iterator for a map. An iterator provides very fast, iterative read-only
- * access to a map.
+ * Creates an iterator for a map. An iterator provides iterative read-only access to a map.
+ * Just like in snapshots the key/value pairs are not sorted.
  *
- * Any mutating change - key addition or key removal - to the underlying map will
+ * Any mutating change - that is key addition or key removal - to the underlying map will
  * mark every iterator operating on it as outdated. It then needs to be refreshed to
  * make it work again. See TrieIterRefresh for more information.
  *
@@ -246,7 +246,7 @@ native TrieSnapshotDestroy(&Snapshot:handle);
  *
  * Iterators are designed to be short-lived and not be permanently stored or cached.
  * Creating new iterators is very fast, exhibiting virtually no overhead, even for very
- * large tries. It is usually recommended to create them on-demand. Value retrieval
+ * large tries. It is generally recommended to create them on-demand. Value retrieval
  * can be done through the iterator and is as fast as directly reading from the underlying map.
  *
  * @return 				New iterator handle, which must be freed via TrieIterDestroy().
@@ -293,12 +293,12 @@ native bool:TrieIterGetKey(TrieIter:handle, key[] = "", outputsize = 0, &size = 
 /**
  * Retrieves the current iterator status.
  *
- * This function checks if an iterator is in a usable state, which is a pre-requisite
- * to using almost any function that operates on it (the exceptions being GetStatus, Refresh and Destroy).
+ * This function checks if an iterator is in a usable state, which is a pre-requisite to using almost
+ * any function that operates on it (the exceptions being GetStatus, SetPos, Refresh and Destroy).
  *
  * IterStatus_Valid: The iterator is currently in a usable state.
  * This does *not* mean that it currently points to a valid key/value pair, or that there
- * are any values at all.
+ * are any key/value pairs at all.
  *
  * IterStatus_Outdated: The iterator has to be refreshed before being used again.
  * Any key addition or removal to the underlying map will mark the iterator as outdated. To use it
@@ -317,15 +317,16 @@ native bool:TrieIterGetKey(TrieIter:handle, key[] = "", outputsize = 0, &size = 
 native TrieIterStatus:TrieIterGetStatus(TrieIter:handle);
 
 /**
- * Refreshes the iterator if possible
+ * Refreshes the iterator if possible.
  *
  * This function serves a dual purpose when working with iterators:
  *
  * 1) If the underlying map was mutated and the iterator marked as outdated, calling this function
  * will allow the iterator to be revalidated without creating a new one.
  *
- * 2) After this function has returned the iterator will be starting over at its
- * initial position, even if it was valid when this function was called.
+ * 2) After this function has returned the iterator will be starting over from the beginning,
+ * even if it was valid when this function was called. Because key/value pairs are not sorted, the
+ * first value is never guaranteed to stay the same.
  *
  * @param handle		Iterator handle.
  *
@@ -350,11 +351,13 @@ native bool:TrieIterRefresh(TrieIter:handle);
 native TrieIterGetSize(TrieIter:handle);
 
 /**
- * Attempts to set the iterator position to the provided key.
+ * Attempts to set the iterator position to the provided key. It is allowed to use this on an
+ * outdated iterator.
  *
- * It is allowed to use this on an outdated iterator. If the key is found in the underlying map and
- * the iterator is successfully positioned, the iterator will be valid afterwards. However if the key
- * can not be found an outdated iterator will stay outdated, but no error will occur.
+ * If the key is found in the underlying map and the iterator is successfully positioned,
+ * an outdated iterator will be valid afterwards.
+ * If the key can not be found the iterator is not modified so an outdated iterator will stay
+ * outdated, but no error will occur.
  *
  * @param handle		Iterator handle.
  * @param key			Key string.

--- a/plugins/include/celltrie.inc
+++ b/plugins/include/celltrie.inc
@@ -222,3 +222,24 @@ native TrieSnapshotGetKey(Snapshot:handle, index, buffer[], maxlength);
  * @error			Invalid handle.
  */
 native TrieSnapshotDestroy(&Snapshot:handle);
+
+enum TrieIter
+{
+	Invalid_Iter = 0
+};
+
+enum TrieIterStatus
+{
+	Iter_Valid = 0,
+	Iter_Outdated = 1,
+	Iter_Invalid = 2,
+};
+
+native TrieIter:TrieIterCreate(Trie:handle);
+native bool:TrieIterNext(TrieIter:handle, key[] = "", maxlen = 0);
+native TrieIterStatus:TrieIterGetStatus(TrieIter:handle);
+native bool:TrieIterRefresh(TrieIter:handle);
+native bool:TrieIterGetCell(TrieIter:handle, &any:value);
+native bool:TrieIterGetString(TrieIter:handle, buffer[], outputsize, &size = 0);
+native bool:TrieIterGetArray(TrieIter:handle, array[], outputsize, &size = 0);
+native TrieIterDestroy(&TrieIter:handle);

--- a/plugins/include/celltrie.inc
+++ b/plugins/include/celltrie.inc
@@ -350,6 +350,22 @@ native bool:TrieIterRefresh(TrieIter:handle);
 native TrieIterGetSize(TrieIter:handle);
 
 /**
+ * Attempts to set the iterator position to the provided key.
+ *
+ * It is allowed to use this on an outdated iterator. If the key is found in the underlying map and
+ * the iterator is successfully positioned, the iterator will be valid afterwards. However if the key
+ * can not be found an outdated iterator will stay outdated, but no error will occur.
+ *
+ * @param handle		Iterator handle.
+ * @param key			Key string.
+ *
+ * @return				True if key was found and iterator positioned, false if key was not found
+ * @error				Invalid handle
+ *						Iterator has been closed (underlying map destroyed)
+ */
+native bool:TrieIterSetPos(TrieIter:handle, const key[]);
+
+/**
  * Retrieves a value at the current position of the iterator.
  *
  * @param handle		Iterator handle.

--- a/plugins/include/celltrie.inc
+++ b/plugins/include/celltrie.inc
@@ -172,7 +172,7 @@ native TrieDestroy(&Trie:handle);
  *
  * @param handle	Map handle.
  *
- * @return			Number of elements in the trie.
+ * @return			Number of elements in the map.
  * @error			Invalid handle.
  */
 native TrieGetSize(Trie:handle);
@@ -323,6 +323,20 @@ native TrieIterStatus:TrieIterGetStatus(TrieIter:handle);
  *						Iterator has been closed (underlying map destroyed)
  */
 native bool:TrieIterRefresh(TrieIter:handle);
+
+/**
+ * Retrieves the number of elements in the underlying map.
+ *
+ * When used on a valid iterator this is exactly the same as calling TrieGetSize on the map directly.
+ *
+ * @param handle		Iterator handle.
+ *
+ * @return				Number of elements in the map.
+ * @error				Invalid handle
+ *						Iterator has been closed (underlying map destroyed)
+ *						Iterator is invalid
+ */
+native TrieIterGetSize(TrieIter:handle);
 
 /**
  * Retrieves a value at the current position of the iterator

--- a/plugins/include/celltrie.inc
+++ b/plugins/include/celltrie.inc
@@ -20,9 +20,9 @@ enum TrieIter
 
 enum TrieIterStatus
 {
-	IterStatus_Valid = 0,
-	IterStatus_Outdated = 1,
-	IterStatus_Closed = 2,
+	IterStatus_Valid = 0,		// Iterator is in a usable state
+	IterStatus_Outdated = 1,	// Iterator has to be refreshed
+	IterStatus_Closed = 2,		// Iterator map has been closed, iterator should be destroyed
 };
 
 /**
@@ -163,7 +163,6 @@ native bool:TrieKeyExists(Trie:handle, const key[]);
  * @param handle	Map handle.
  *
  * @return			True on success, false if the value was never set.
- * @error			Invalid handle.
  */
 native TrieDestroy(&Trie:handle);
 
@@ -231,7 +230,6 @@ native TrieSnapshotGetKey(Snapshot:handle, index, buffer[], maxlength);
  * @param handle	Map snapshot.
  *
  * @return			True on success, false if the value was never set.
- * @error			Invalid handle.
  */
 native TrieSnapshotDestroy(&Snapshot:handle);
 
@@ -239,15 +237,17 @@ native TrieSnapshotDestroy(&Snapshot:handle);
  * Creates an iterator for a map. An iterator provides very fast, iterative read-only
  * access to a map.
  *
- * Any mutating change (that is key addition or key removal) to the underlying map
- * will invalidate every iterator operating on it.
+ * Any mutating change - key addition or key removal - to the underlying map will
+ * mark every iterator operating on it as outdated. It then needs to be refreshed to
+ * make it work again. See TrieIterRefresh for more information.
  *
- * Updating alreadys existing keys will not invalidate an iterator.
+ * Updating the value of already existing keys will not mark iterators as outdated. Iterators
+ * will immediately reflect updated values. Nothing is cached.
  *
  * Iterators are designed to be short-lived and not be permanently stored or cached.
- * Creating new iterators is very fast, exhibiting virtually no overhead, even for
+ * Creating new iterators is very fast, exhibiting virtually no overhead, even for very
  * large tries. It is usually recommended to create them on-demand. Value retrieval
- * is as fast as directly reading from the underlying map.
+ * can be done through the iterator and is as fast as directly reading from the underlying map.
  *
  * @return 				New iterator handle, which must be freed via TrieIterDestroy().
  * @error				Invalid Handle
@@ -255,7 +255,7 @@ native TrieSnapshotDestroy(&Snapshot:handle);
 native TrieIter:TrieIterCreate(Trie:handle);
 
 /**
- * Advances the iterator to the next key if one is available
+ * Advances the iterator to the next key/value pair if one is available.
  *
  * Providing the function with an optional buffer and buffer length will
  * store the next key inside that buffer.
@@ -268,12 +268,12 @@ native TrieIter:TrieIterCreate(Trie:handle);
  * @return 				True if the iterator is not empty and a new key was made current.
  * @error				Invalid handle
  *						Iterator has been closed (underlying map destroyed)
- *						Iterator is invalid
+ *						Iterator is outdated
 */
 native bool:TrieIterNext(TrieIter:handle, key[] = "", outputsize = 0, &size = 0);
 
 /**
- * Checks if the iterator currently points to a key and is therefore not empty
+ * Checks if the iterator currently points to a valid key/value pair and is therefore not empty
  *
  * Providing the function with an optional buffer and buffer length will
  * store the current key inside that buffer.
@@ -283,24 +283,35 @@ native bool:TrieIterNext(TrieIter:handle, key[] = "", outputsize = 0, &size = 0)
  * @param outputsize	Maximum size of string buffer.
  * @param size			Optional parameter to store the number of bytes written to the buffer.
  *
- * @return 				True if the iterator is not empty  a new
- *						was made current.
+ * @return 				True if the iterator is not empty
  * @error				Invalid handle
  *						Iterator has been closed (underlying map destroyed)
- *						Iterator is invalid
+ *						Iterator is outdated
  */
 native bool:TrieIterGetKey(TrieIter:handle, key[] = "", outputsize = 0, &size = 0);
 
 /**
- * Retrieves the current iterator status
+ * Retrieves the current iterator status.
+ *
+ * This function checks if an iterator is in a usable state, which is a pre-requisite
+ * to using almost any function that operates on it (the exceptions being GetStatus, Refresh and Destroy).
+ *
+ * IterStatus_Valid: The iterator is currently in a usable state.
+ * This does *not* mean that it currently points to a valid key/value pair, or that there
+ * are any values at all.
+ *
+ * IterStatus_Outdated: The iterator has to be refreshed before being used again.
+ * Any key addition or removal to the underlying map will mark the iterator as outdated. To use it
+ * again the iterator has to be refreshed, which also makes it start over from the beginning.
+ *
+ * IterStatus_Closed: The underlying map has been destroyed. The iterator can't be used again.
+ * This happens when TrieDestroy is used on the map that an iterator was created from. The iterator
+ * can't be refreshed because there is nothing to refresh it from. At this point the iterator can
+ * and should be destroyed.
  *
  * @param handle		Iterator handle.
  *
- * @return 				IterStatus_Valid 		if iterator can be used.
- *						IterStatus_Outdated		if iterator has to be refreshed because
- *												the underlying map has been modified.
- *						IterStatus_Closed		if underlying map has been closed. The iterator
- *												can't be refreshed and should be destroyed.
+ * @return 				One of the TrieIterStatus values. See explanation above.
  * @error				Invalid handle
  */
 native TrieIterStatus:TrieIterGetStatus(TrieIter:handle);
@@ -310,7 +321,7 @@ native TrieIterStatus:TrieIterGetStatus(TrieIter:handle);
  *
  * This function serves a dual purpose when working with iterators:
  *
- * 1) If the underlying map was mutated and the iterator invalidated, calling this function
+ * 1) If the underlying map was mutated and the iterator marked as outdated, calling this function
  * will allow the iterator to be revalidated without creating a new one.
  *
  * 2) After this function has returned the iterator will be starting over at its
@@ -334,50 +345,53 @@ native bool:TrieIterRefresh(TrieIter:handle);
  * @return				Number of elements in the map.
  * @error				Invalid handle
  *						Iterator has been closed (underlying map destroyed)
- *						Iterator is invalid
+ *						Iterator is outdated
  */
 native TrieIterGetSize(TrieIter:handle);
 
 /**
- * Retrieves a value at the current position of the iterator
+ * Retrieves a value at the current position of the iterator.
  *
  * @param handle		Iterator handle.
  * @param value			Variable to store value.
  *
- * @return 				True on success, false if the iterator is empty.
+ * @return 				True on success, false if the iterator is empty or the current
+ *						value is an array or a string.
  * @error				Invalid handle
  *						Iterator has been closed (underlying map destroyed)
- *						Iterator is invalid
+ *						Iterator is outdated
  */
 native bool:TrieIterGetCell(TrieIter:handle, &any:value);
 
 /**
- * Retrieves a string at the current position of the iterator
+ * Retrieves a string at the current position of the iterator.
  *
  * @param handle		Iterator handle.
- * @param buffer		Buffer to store the string..
+ * @param buffer		Buffer to store the string.
  * @param outputsize	Maximum size of string buffer.
  * @param size			Optional parameter to store the number of bytes written to the buffer.
  *
- * @return 				True on success, false if the iterator is empty.
+ * @return 				True on success, false if the iterator is empty or the current value
+ *						is not a string.
  * @error				Invalid handle
  *						Iterator has been closed (underlying map destroyed)
- *						Iterator is invalid
+ *						Iterator is outdated
  */
 native bool:TrieIterGetString(TrieIter:handle, buffer[], outputsize, &size = 0);
 
 /**
- * Retrieves an array at the current position of the iterator
+ * Retrieves an array at the current position of the iterator.
  *
  * @param handle		Iterator handle.
  * @param buffer		Buffer to store the array.
  * @param outputsize	Maximum size of buffer.
  * @param size			Optional parameter to store the number of bytes written to the buffer.
  *
- * @return 				True on success, false if the iterator is empty.
+ * @return 				True on success, false if the iterator is empty or the current
+ *						value is not an array.
  * @error				Invalid handle
  *						Iterator has been closed (underlying map destroyed)
- *						Iterator is invalid
+ *						Iterator is outdated
  */
 native bool:TrieIterGetArray(TrieIter:handle, any:array[], outputsize, &size = 0);
 
@@ -387,6 +401,5 @@ native bool:TrieIterGetArray(TrieIter:handle, any:array[], outputsize, &size = 0
  * @param handle	Iterator handle.
  *
  * @return			True on success, false if the value was never set.
- * @error			Invalid handle
  */
 native TrieIterDestroy(&TrieIter:handle);

--- a/plugins/include/celltrie.inc
+++ b/plugins/include/celltrie.inc
@@ -236,7 +236,7 @@ enum TrieIterStatus
 };
 
 native TrieIter:TrieIterCreate(Trie:handle);
-native bool:TrieIterNext(TrieIter:handle, key[] = "", maxlen = 0);
+native TrieIterNext(TrieIter:handle, key[] = "", maxlen = 0);
 native TrieIterStatus:TrieIterGetStatus(TrieIter:handle);
 native bool:TrieIterRefresh(TrieIter:handle);
 native bool:TrieIterGetCell(TrieIter:handle, &any:value);

--- a/plugins/include/celltrie.inc
+++ b/plugins/include/celltrie.inc
@@ -230,9 +230,9 @@ enum TrieIter
 
 enum TrieIterStatus
 {
-	Iter_Valid = 0,
-	Iter_Outdated = 1,
-	Iter_Invalid = 2,
+	IterStatus_Valid = 0,
+	IterStatus_Outdated = 1,
+	IterStatus_Closed = 2,
 };
 
 native TrieIter:TrieIterCreate(Trie:handle);

--- a/plugins/testsuite/trietest.sma
+++ b/plugins/testsuite/trietest.sma
@@ -311,7 +311,7 @@ public trietest()
 	{
 		if (TrieIterGetStatus(iter) != IterStatus_Valid)
 		{
-			server_print("Trie iterator should be valid");
+			server_print("Trie iterator should report itself as valid (create)");
 			ok = false;
 		}
 
@@ -388,6 +388,29 @@ public trietest()
 			ok = false;
 		}
 
+		if (TrieIterSetPos(iter, "monkey"))
+		{
+			if (TrieIterGetStatus(iter) != IterStatus_Valid)
+			{
+				server_print("Trie iterator should report itself as valid (setpos)");
+				ok = false;
+			}
+
+			TrieIterGetKey(iter, key, charsmax(key));
+			TrieIterGetString(iter, value, charsmax(value));
+
+			if (strcmp(key, "monkey") != 0 || strcmp(value, "island") != 0)
+			{
+				server_print("Trie iterator key/value pair doesn't match after setpos |%s|%s|", key, value);
+				ok = false;
+			}
+		}
+		else
+		{
+			server_print("Trie iterator positioning failed");
+			ok = false;
+		}
+
 		TrieIterRefresh(iter);
 		arrayset(valid, false, sizeof(valid));
 
@@ -425,7 +448,7 @@ public trietest()
 
 		if (TrieIterGetStatus(iter) != IterStatus_Valid)
 		{
-			server_print("Trie iterator should report itself as valid");
+			server_print("Trie iterator should report itself as valid (update)");
 			ok = false;
 		}
 

--- a/plugins/testsuite/trietest.sma
+++ b/plugins/testsuite/trietest.sma
@@ -400,6 +400,15 @@ public trietest()
 			ok = false;
 		}
 
+ 		// Overwriting an existing key should not invalidate our iterator
+		TrieSetString(t, "monkey", "island 2");
+
+		if (TrieIterGetStatus(iter) != IterStatus_Valid)
+		{
+			server_print("Trie iterator should report itself as valid");
+			ok = false;
+		}
+
 		TrieDestroy(t);
 
 		if (TrieIterGetStatus(iter) != IterStatus_Closed)

--- a/plugins/testsuite/trietest.sma
+++ b/plugins/testsuite/trietest.sma
@@ -415,6 +415,14 @@ public trietest()
 			ok = false;
 		}
 
+		TrieClear(t);
+
+		if (TrieIterGetStatus(iter) != IterStatus_Outdated)
+		{
+			server_print("Trie iterator should report itself as outdated (clear)");
+			ok = false;
+		}
+
 		TrieDestroy(t);
 
 		if (TrieIterGetStatus(iter) != IterStatus_Closed)

--- a/plugins/testsuite/trietest.sma
+++ b/plugins/testsuite/trietest.sma
@@ -377,6 +377,12 @@ public trietest()
 		TrieIterRefresh(iter);
 		arrayset(valid, false, sizeof(valid));
 
+		if (TrieIterGetSize(iter) != 4)
+		{
+			server_print("Trie iterator size should be 4, is %d", TrieIterGetSize(iter));
+			ok = false;
+		}
+
 		// This tests looping with IterGetKey and doing intermediate calls to TrieNextIter
 		while (TrieIterGetKey(iter, key, charsmax(key)))
 		{

--- a/plugins/testsuite/trietest.sma
+++ b/plugins/testsuite/trietest.sma
@@ -315,10 +315,24 @@ public trietest()
 			ok = false;
 		}
 
-		new key[32], value[32], bool:valid[4], klen, vlen;
-		if (!TrieIterGetKey(iter, key, charsmax(key), klen))
+		if (!TrieIterGetKey(iter))
 		{
-			server_print("Trie iterator should not be empty at this point");
+			server_print("Trie iterator should not be empty at this point (no key retrieval)");
+			ok = false;
+		}
+
+		if (!TrieIterNext(iter))
+		{
+			server_print("Trie iterator should have a next key/value pair at this point");
+			ok = false;
+		}
+
+		TrieIterRefresh(iter);
+
+		new key[32], value[32], bool:valid[4], klen, vlen;
+		if (!TrieIterGetKey(iter, key, charsmax(key), klen) || klen == 0)
+		{
+			server_print("Trie iterator should not be empty at this point (key retrieval)");
 			ok = false;
 		}
 		else

--- a/public/amtl/am-hashmap.h
+++ b/public/amtl/am-hashmap.h
@@ -164,7 +164,7 @@ class HashMap : public AllocPolicy
     return iterator(&table_);
   }
 
-  iterator *iter_() {
+  iterator *p_iter() {
     return new iterator(&table_);
   }
 

--- a/public/amtl/am-hashmap.h
+++ b/public/amtl/am-hashmap.h
@@ -164,6 +164,10 @@ class HashMap : public AllocPolicy
     return iterator(&table_);
   }
 
+  iterator *iter_() {
+    return new iterator(&table_);
+  }
+
   void clear() {
     table_.clear();
   }

--- a/public/amtl/am-hashtable.h
+++ b/public/amtl/am-hashtable.h
@@ -366,6 +366,7 @@ class HashTable : public AllocPolicy
   void removeEntry(Entry &e) {
     assert(e.isLive());
     e.setRemoved();
+    nmodcount_++;
     ndeleted_++;
     nelements_--;
   }
@@ -426,13 +427,11 @@ class HashTable : public AllocPolicy
     if (!r.found())
       return;
 
-    nmodcount_++;
     remove(r);
   }
 
   void remove(Result &r) {
     assert(r.found());
-    nmodcount_++;
     removeEntry(r.entry());
   }
 
@@ -442,7 +441,6 @@ class HashTable : public AllocPolicy
     if (!internalAdd(i))
       return false;
 
-    nmodcount_++;
     i.entry().construct(payload);
     return true;
   }
@@ -450,7 +448,6 @@ class HashTable : public AllocPolicy
     if (!internalAdd(i))
       return false;
 
-    nmodcount_++;
     i.entry().construct(payload);
     return true;
   }
@@ -458,7 +455,6 @@ class HashTable : public AllocPolicy
     if (!internalAdd(i))
       return false;
 
-    nmodcount_++;
 	i.entry().construct();
     return true;
   }

--- a/public/amtl/am-hashtable.h
+++ b/public/amtl/am-hashtable.h
@@ -521,17 +521,29 @@ class HashTable : public AllocPolicy
       } while (i_ < end_ && !i_->isLive());
     }
 
+	bool setpos(Result r) {
+      if (r.entry_->isLive() && r.entry_ >= table_->table_ && r.entry_ < table_->table_ + table_->capacity_) {
+        nstrictmod_ = table_->nstrictmodcount_;
+        i_ = r.entry_;
+        end_ = table_->table_ + table_->capacity_;
+
+        return true;
+      }
+
+      return false;
+    }
+
     bool valid_strict() {
-        return (table_->nstrictmodcount_ == nstrictmod_);
+      return (table_->nstrictmodcount_ == nstrictmod_);
     }
 
     void refresh() {
-        nstrictmod_ = table_->nstrictmodcount_;
-        i_ = table_->table_;
-        end_ = table_->table_ + table_->capacity_;
+      nstrictmod_ = table_->nstrictmodcount_;
+      i_ = table_->table_;
+      end_ = table_->table_ + table_->capacity_;
 
-        while (i_ < end_ && !i_->isLive())
-            i_++;
+      while (i_ < end_ && !i_->isLive())
+          i_++;
     }
 
    private:

--- a/public/amtl/am-hashtable.h
+++ b/public/amtl/am-hashtable.h
@@ -273,7 +273,7 @@ class HashTable : public AllocPolicy
     }
     this->free(oldTable);
 
-    nmodcount_++;
+    nstrictmodcount_++;
     return true;
   }
 
@@ -332,7 +332,7 @@ class HashTable : public AllocPolicy
   bool internalAdd(Insert &i) {
     assert(!i.found());
 
-    nmodcount_++;
+    nstrictmodcount_++;
 
     // If the entry is deleted, just re-use the slot.
     if (i.entry().removed()) {
@@ -366,7 +366,7 @@ class HashTable : public AllocPolicy
   void removeEntry(Entry &e) {
     assert(e.isLive());
     e.setRemoved();
-    nmodcount_++;
+    nstrictmodcount_++;
     ndeleted_++;
     nelements_--;
   }
@@ -473,7 +473,7 @@ class HashTable : public AllocPolicy
     }
     ndeleted_ = 0;
     nelements_ = 0;
-    nmodcount_++;
+    nstrictmodcount_++;
   }
 
   size_t elements() const {
@@ -491,7 +491,7 @@ class HashTable : public AllocPolicy
    public:
     iterator(HashTable *table)
       : table_(table),
-      nmod_(table->nmodcount_),
+      nstrictmod_(table->nstrictmodcount_),
       i_(table->table_),
       end_(table->table_ + table->capacity_)
     {
@@ -521,12 +521,12 @@ class HashTable : public AllocPolicy
       } while (i_ < end_ && !i_->isLive());
     }
 
-    bool valid() {
-        return (table_->nmodcount_ == nmod_);
+    bool valid_strict() {
+        return (table_->nstrictmodcount_ == nstrictmod_);
     }
 
     void refresh() {
-        nmod_ = table_->nmodcount_;
+        nstrictmod_ = table_->nstrictmodcount_;
         i_ = table_->table_;
         end_ = table_->table_ + table_->capacity_;
 
@@ -536,7 +536,7 @@ class HashTable : public AllocPolicy
 
    private:
     HashTable *table_;
-    uint32_t nmod_;
+    uint32_t nstrictmod_;
     Entry *i_;
     Entry *end_;
   };
@@ -549,7 +549,7 @@ class HashTable : public AllocPolicy
   uint32_t capacity_;
   uint32_t nelements_;
   uint32_t ndeleted_;
-  uint32_t nmodcount_;
+  uint32_t nstrictmodcount_;
   Entry *table_;
   uint32_t minCapacity_;
 };

--- a/public/amtl/am-hashtable.h
+++ b/public/amtl/am-hashtable.h
@@ -532,7 +532,10 @@ class HashTable : public AllocPolicy
     void refresh() {
         nmod_ = table_->nmodcount_;
         i_ = table_->table_;
-		end_ = table_->table_ + table_->capacity_;
+        end_ = table_->table_ + table_->capacity_;
+
+        while (i_ < end_ && !i_->isLive())
+            i_++;
     }
 
    private:

--- a/public/amtl/am-hashtable.h
+++ b/public/amtl/am-hashtable.h
@@ -521,7 +521,7 @@ class HashTable : public AllocPolicy
       } while (i_ < end_ && !i_->isLive());
     }
 
-    bool setpos(Result r) {
+    bool setpos(Result &r) {
       if (r.entry_->isLive() && r.entry_ >= table_->table_ && r.entry_ < table_->table_ + table_->capacity_) {
         nstrictmod_ = table_->nstrictmodcount_;
         i_ = r.entry_;

--- a/public/amtl/am-hashtable.h
+++ b/public/amtl/am-hashtable.h
@@ -526,13 +526,13 @@ class HashTable : public AllocPolicy
     }
 
     bool valid() {
-        return (table->nmodcount_ == nmod_);
+        return (table_->nmodcount_ == nmod_);
     }
 
     void refresh() {
-        nmod_ = table->nmodcount_;
-        i_ = table->table_;
-        end_ = table->table_ + table->capacity_
+        nmod_ = table_->nmodcount_;
+        i_ = table_->table_;
+		end_ = table_->table_ + table_->capacity_;
     }
 
    private:

--- a/public/amtl/am-hashtable.h
+++ b/public/amtl/am-hashtable.h
@@ -521,7 +521,7 @@ class HashTable : public AllocPolicy
       } while (i_ < end_ && !i_->isLive());
     }
 
-	bool setpos(Result r) {
+    bool setpos(Result r) {
       if (r.entry_->isLive() && r.entry_ >= table_->table_ && r.entry_ < table_->table_ + table_->capacity_) {
         nstrictmod_ = table_->nstrictmodcount_;
         i_ = r.entry_;

--- a/public/amtl/am-hashtable.h
+++ b/public/amtl/am-hashtable.h
@@ -455,7 +455,7 @@ class HashTable : public AllocPolicy
     if (!internalAdd(i))
       return false;
 
-	i.entry().construct();
+    i.entry().construct();
     return true;
   }
 


### PR DESCRIPTION
This series of commits adds new natives around exposing actual iterators for a hashmap, instead of the compromise that snapshots provide.

I don't know if adding this kind of API has been considered before, so this is as much a request for discussion (is this even a good idea?) as it is a request for review.

Iterators have the obvious drawback of possible breakage after mutating changes to the hashtable have occured. I have added a very strict safety guard for determining an iterators validity. The hashtable now contains a modification counter that is incremented whenever internalAdd and removeEntry have to do work. Iterators store the current modification counter upon creation, so it is possible to detect when a key has been added or removed. I wanted very simple guarantees when exposing iterators, so this strict check - **any** modification breaks the iterator - seemed appropriate.

With this set of natives I wanted to reach a secondary goal: Iterators should provide full read access to a map, but no writing should be possible without actually knowing the handle to the map. This also makes them unlike snapshots which, at least currently, can only extract the keys and have to work together with the default TrieGet* and TrieSet* natives to be useful. Since I've been working on a set of plugins with their own API the idea for read-only access to Tries without having to hand out the original handle (or clone the data) seemed valuable to me. This is also why, although it might seem weird at first, there is the possibility to set the iterator position to a known key.

The test suite has been extended and covers basic usage of the new natives. Arkshine has done a bunch of additional testing and thus far everything looks fine.

In total this adds 11 new natives that are extensively documented in celltrie.inc:
```sourcepawn
enum TrieIter
{
	Invalid_Iter = 0
};
enum TrieIterStatus
{
	IterStatus_Valid = 0,		// Iterator is in a usable state
	IterStatus_Outdated = 1,	// Iterator has to be refreshed
	IterStatus_Closed = 2,		// Iterator map has been closed, iterator should be destroyed
};
native TrieIter:TrieIterCreate(Trie:handle);
native bool:TrieIterNext(TrieIter:handle, key[] = "", outputsize = 0, &size = 0);
native bool:TrieIterGetKey(TrieIter:handle, key[] = "", outputsize = 0, &size = 0);
native TrieIterStatus:TrieIterGetStatus(TrieIter:handle);
native bool:TrieIterRefresh(TrieIter:handle);
native TrieIterGetSize(TrieIter:handle);
native bool:TrieIterSetPos(TrieIter:handle, const key[]);
native bool:TrieIterGetCell(TrieIter:handle, &any:value);
native bool:TrieIterGetString(TrieIter:handle, buffer[], outputsize, &size = 0);
native bool:TrieIterGetArray(TrieIter:handle, any:array[], outputsize, &size = 0);
native TrieIterDestroy(&TrieIter:handle);
```