### PR TITLE
Fix missing Float tag in some DoD forwards headers (bug 6121)

### DIFF
--- a/plugins/include/dodx.inc
+++ b/plugins/include/dodx.inc
@@ -73,13 +73,13 @@ forward dod_client_prone(id, value);
 forward dod_client_weaponswitch(id, wpnew, wpnold);
 
 /* Forward for when a grenade explodes and its location */
-forward dod_grenade_explosion(id, pos[3], wpnid);
+forward dod_grenade_explosion(id, Float:pos[3], wpnid);
 
 /* Forward for when a rocket explodes and its location */
-forward dod_rocket_explosion(id, pos[3], wpnid);
+forward dod_rocket_explosion(id, Float:pos[3], wpnid);
 
 /* Forward for when a player picks up a object */
-forward dod_client_objectpickup(id, objid, pos[3], value);
+forward dod_client_objectpickup(id, objid, Float:pos[3], value);
 
 /* Forward for when a users stamina decreases */
 forward dod_client_stamina(id, stamina);


### PR DESCRIPTION
Reported by diamond-optic at [bug 6121](https://bugs.alliedmods.net/show_bug.cgi?id=6121).

Forwards send float values and `Float:` tag is missing from some headers.
This should be fine to add it now.
