### PR TITLE
CS: Fix spectator team index not being set in specific situation

### DIFF
--- a/amxmodx/emsg.cpp
+++ b/amxmodx/emsg.cpp
@@ -112,6 +112,20 @@ void Client_TeamInfo(void* mValue)
 			g_players[index].team.assign(msg);
 			g_teamsIds.registerTeam(msg, -1);
 			g_players[index].teamId = g_teamsIds.findTeamId(msg);
+
+			/**
+			* CS fix for SPECTATOR team. 
+			* -
+			* When a player chooses spectator, ScoreInfo is sent before TeamInfo and with 0 as index.
+			* This means for the first round of first spectator, SPECTATOR name is not associated with its index.
+			* The following fix manually sets the team index when we hit SPECTATOR team.
+			*/
+			if (g_players[index].teamId == -1 && g_bmod_cstrike && !strcmp(msg, "SPECTATOR"))
+			{
+				g_players[index].teamId = 3;
+				g_teamsIds.registerTeam(msg, 3);
+			}
+
 			break;
 	}
 }

--- a/amxmodx/modules.cpp
+++ b/amxmodx/modules.cpp
@@ -1761,7 +1761,13 @@ int MNF_SetPlayerTeamInfo(int player, int teamid, const char *teamname)
 
 	pPlayer->teamId = teamid;
 	if (teamname != NULL)
+	{
 		pPlayer->team.assign(teamname);
+
+		// Make sure team is registered, otherwise
+		// natives relying on team id will return wrong result.
+		g_teamsIds.registerTeam(teamname, teamid);
+	}
 
 	return 1;
 }


### PR DESCRIPTION
The first time a player chooses spectator team, the team index can't be retrieved by AMXX until next round.
It's specific to CS. For some reason TeamInfo  is sent after ScoreInfo and latter is returning 0 as index.
This means some natives relying on team id won't work properly.

The patch fixes two things : 
- Manually set spectator team index the first time TeamInfo sends `SPECTATOR`.
- Make sure a team passed with `MF_SetPlayerTeamInfo` from AMXX API, is registered.
