### PR TITLE
Telemenu: Some bug fixes and small improvements

### DIFF
--- a/plugins/telemenu.sma
+++ b/plugins/telemenu.sma
@@ -115,7 +115,6 @@ public actionTelMenu(id, key)
 						|| equal(modname, "czero")	// Counter-Strike: Condition Zero
 						|| equal(modname, "valve")	// Half-Life
 						|| equal(modname, "tfc")	// Team Fortress Classic
-						|| equal(modname, "ns")		// Natural Selection
 						|| equal(modname, "gearbox"))	// Half-Life: Opposing Force
 							VEC_DUCK_VIEW[2] = 12.0
 						else if (equal(modname, "dod"))	// Day of Defeat


### PR DESCRIPTION
This update feature :
-  The use of float version of origin natives instead of integer version :
  This mainly fix problems encountered due to imprecision of integer origin natives : If the origin is saved by an alive player on the ground, sometimes the teleported player can be stuck on ground, especially in slopes.
- The ability to save an origin from an alive player in a crouched area or in a crouch state and teleport to it without risking stuck problems.
- The ability to save the view and use it during teleportion :
  This feature allow you to save the view angles of the player who save the origin and apply them at teleportation on player's angles of teleported player.
- The use of charsmax in place of hardcoded buffer lengths.
- The switch format to formatex.

Tested on Counter-Strike 1.6.
It need testing with other games, i think.
