### PR TITLE
Fix an unicode issue with amx_SetStringOld.

### DIFF
--- a/amxmodx/CForward.cpp
+++ b/amxmodx/CForward.cpp
@@ -100,7 +100,7 @@ cell CForward::execute(cell *params, ForwardPreparedArray *preparedArrays)
 					if (!str)
 						str = "";
 					amx_Allot(iter->pPlugin->getAMX(), (m_ParamTypes[i] == FP_STRING) ? strlen(str) + 1 : STRINGEX_MAXLENGTH, &realParams[i], &tmp);
-					amx_SetStringOld(tmp, str, 0, 1);
+					amx_SetStringOld(tmp, str, 0, 0);
 					physAddrs[i] = tmp;
 				}
 				else if (m_ParamTypes[i] == FP_ARRAY)
@@ -277,7 +277,7 @@ cell CSPForward::execute(cell *params, ForwardPreparedArray *preparedArrays)
 				str = "";
 			cell *tmp;
 			amx_Allot(m_Amx, (m_ParamTypes[i] == FP_STRING) ? strlen(str) + 1 : STRINGEX_MAXLENGTH, &realParams[i], &tmp);
-			amx_SetStringOld(tmp, str, 0, 1);
+			amx_SetStringOld(tmp, str, 0, 0);
 			physAddrs[i] = tmp;
 		}
 		else if (m_ParamTypes[i] == FP_ARRAY)

--- a/amxmodx/amx.cpp
+++ b/amxmodx/amx.cpp
@@ -4141,7 +4141,7 @@ int AMXAPI amx_SetStringOld(cell *dest,const char *source,int pack,int use_wchar
         dest[i]=(cell)(((wchar_t*)source)[i]);
     } else {
       for (i=0; i<len; i++)
-        dest[i]=(cell)source[i];
+        dest[i]=(unsigned char)source[i];
     } /* if */
     dest[len]=0;
   } /* if */

--- a/amxmodx/amxmodx.cpp
+++ b/amxmodx/amxmodx.cpp
@@ -4019,7 +4019,7 @@ static cell AMX_NATIVE_CALL callfunc_push_str(AMX *amx, cell *params)
 	// copy it to the allocated memory
 	// we assume it's unpacked
 	// :NOTE: 4th parameter use_wchar since Small Abstract Machine 2.5.0
-	amx_SetStringOld(phys_addr, str, 0, 1);
+	amx_SetStringOld(phys_addr, str, 0, 0);
 
 	// push the address and set the reference flag so that memory is released after function call.
 	g_CallFunc_ParamInfo[g_CallFunc_CurParam].flags = CALLFUNC_FLAG_BYREF;


### PR DESCRIPTION
Undo last change from #22  and cast same way as `set_amxstring`.
