### PR TITLE
Update copyright year

### DIFF
--- a/amxmodx/meta_api.cpp
+++ b/amxmodx/meta_api.cpp
@@ -1469,7 +1469,7 @@ C_DLLEXPORT	int	Meta_Attach(PLUG_LOADTIME now, META_FUNCTIONS *pFunctionTable, m
 		g_coloredmenus = false;
 
 	// ###### Print short GPL
-	print_srvconsole("\n   AMX Mod X version %s Copyright (c) 2004-2006 AMX Mod X Development Team \n"
+	print_srvconsole("\n   AMX Mod X version %s Copyright (c) 2004-2014 AMX Mod X Development Team \n"
 					 "   AMX Mod X comes with ABSOLUTELY NO WARRANTY; for details type `amxx gpl'.\n", SVN_VERSION_STRING);
 	print_srvconsole("   This is free software and you are welcome to redistribute it under \n"
 					 "   certain conditions; type 'amxx gpl' for details.\n  \n");

--- a/amxmodx/version.rc
+++ b/amxmodx/version.rc
@@ -52,7 +52,7 @@ BEGIN
             VALUE "FileDescription", "AMX Mod X"
             VALUE "FileVersion", SVN_VERSION_STRING
             VALUE "InternalName", "amxmodx"
-            VALUE "LegalCopyright", "Copyright (c) 2004-2007, AMX Mod X Dev Team"
+            VALUE "LegalCopyright", "Copyright (c) 2004-2014, AMX Mod X Dev Team"
             VALUE "OriginalFilename", "amxmodx_mm.dll"
             VALUE "ProductName", "AMX Mod X"
             VALUE "ProductVersion", SVN_VERSION

--- a/compiler/compile/version.rc
+++ b/compiler/compile/version.rc
@@ -17,7 +17,7 @@ BEGIN
 			VALUE "FileDescription", "AMXXPC compile.exe\0"
 			VALUE "FileVersion", "1.5\0"
 			VALUE "InternalName", "AMXXPC compile.exe\0"
-			VALUE "LegalCopyright", "(c) 2004-2005, AMXX Development Team\0"
+			VALUE "LegalCopyright", "(c) 2004-2014, AMXX Development Team\0"
 			//VALUE "LegalTrademarks", "\0"
 			VALUE "OriginalFilename", "compile.exe\0"
 			//VALUE "PrivateBuild", "\0"

--- a/plugins/BinLogReader/Properties/AssemblyInfo.cs
+++ b/plugins/BinLogReader/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("AlliedModders, LLC")]
 [assembly: AssemblyProduct("AMXX BinLog Reader")]
-[assembly: AssemblyCopyright("(C)Copyright 2004-2008 AlliedModders, LLC")]
+[assembly: AssemblyCopyright("(C)Copyright 2004-2014 AlliedModders, LLC")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 


### PR DESCRIPTION
It also might be worth looking into having version.rc for each module and amxxpc (they don't have any amxx details right now).

compile.exe's version.rc probably should be updated, since it's stuck at version 1.5.0
