### PR TITLE
Replace all snprintf with UTIL_Format.

### DIFF
--- a/amxmodx/amxmodx.cpp
+++ b/amxmodx/amxmodx.cpp
@@ -1936,7 +1936,7 @@ static cell AMX_NATIVE_CALL set_pcvar_float(AMX *amx, cell *params)
 		return 0;
 	}
 
-	snprintf(CVarTempBuffer,sizeof(CVarTempBuffer)-1,"%f",amx_ctof(params[2]));
+	UTIL_Format(CVarTempBuffer,sizeof(CVarTempBuffer)-1,"%f",amx_ctof(params[2]));
 	(*g_engfuncs.pfnCvar_DirectSet)(ptr, &CVarTempBuffer[0]);
 	return 1;
 }
@@ -1976,7 +1976,7 @@ static cell AMX_NATIVE_CALL set_pcvar_num(AMX *amx, cell *params)
 		return 0;
 	}
 
-	snprintf(CVarTempBuffer,sizeof(CVarTempBuffer)-1,"%d",params[2]);
+	UTIL_Format(CVarTempBuffer,sizeof(CVarTempBuffer)-1,"%d",params[2]);
 	(*g_engfuncs.pfnCvar_DirectSet)(ptr, &CVarTempBuffer[0]);
 
 	return 1;

--- a/amxmodx/amxxlog.cpp
+++ b/amxmodx/amxxlog.cpp
@@ -81,7 +81,7 @@ void CLog::CreateNewFile()
 	
 	while (true)
 	{
-		snprintf(name, sizeof(name), "%s/L%02d%02d%03d.log", g_log_dir.c_str(), curTime->tm_mon + 1, curTime->tm_mday, i);
+		UTIL_Format(name, sizeof(name), "%s/L%02d%02d%03d.log", g_log_dir.c_str(), curTime->tm_mon + 1, curTime->tm_mday, i);
 		build_pathname_r(file, sizeof(file)-1, "%s", name);
 		FILE *pTmpFile = fopen(file, "r");			// open for reading to check whether the file exists
 		
@@ -237,7 +237,7 @@ void CLog::LogError(const char *fmt, ...)
 	va_end(arglst);
 
 	FILE *pF = NULL;
-	snprintf(name, sizeof(name), "%s/error_%04d%02d%02d.log", g_log_dir.c_str(), curTime->tm_year + 1900, curTime->tm_mon + 1, curTime->tm_mday);
+	UTIL_Format(name, sizeof(name), "%s/error_%04d%02d%02d.log", g_log_dir.c_str(), curTime->tm_year + 1900, curTime->tm_mon + 1, curTime->tm_mday);
 	build_pathname_r(file, sizeof(file)-1, "%s", name);
 	pF = fopen(file, "a+");
 

--- a/amxmodx/debugger.cpp
+++ b/amxmodx/debugger.cpp
@@ -11,10 +11,6 @@
 #include "debugger.h"
 #include "binlog.h"
 
-#if !defined WIN32 && !defined _WIN32
-#define _snprintf snprintf
-#endif
-
 /**
  * AMX Mod X Debugging Engine
  *  Written by David "BAILOPAN" Anderson
@@ -371,7 +367,7 @@ int Debugger::FormatError(char *buffer, size_t maxLength)
 	//cell *p_cip = NULL;
 	//int amx_err = AMX_ERR_NONE;
 
-	size += _snprintf(buffer, maxLength, "Run time error %d: %s ", error, gen_err);
+	size += UTIL_Format(buffer, maxLength, "Run time error %d: %s ", error, gen_err);
 	buffer += size;
 	maxLength -= size;
 
@@ -394,7 +390,7 @@ int Debugger::FormatError(char *buffer, size_t maxLength)
 		else 
 			amx_err = AMX_ERR_NOTFOUND;*/
 		//if (!amx_err)
-			size += _snprintf(buffer, maxLength, "(native \"%s\")", native_name);
+			size += UTIL_Format(buffer, maxLength, "(native \"%s\")", native_name);
 	}
 
 	return size;
@@ -621,12 +617,12 @@ void Debugger::FmtGenericMsg(AMX *amx, int error, char buffer[], size_t maxLengt
 
 	if (error == AMX_ERR_EXIT)
 	{
-		_snprintf(buffer, maxLength, "Run time error %d (plugin \"%s\") - %s", error, filename, GenericError(AMX_ERR_EXIT));
+		UTIL_Format(buffer, maxLength, "Run time error %d (plugin \"%s\") - %s", error, filename, GenericError(AMX_ERR_EXIT));
 	} else if (error == AMX_ERR_NATIVE) {
 		amx_GetNative(amx, reinterpret_cast<long>(amx->usertags[UT_NATIVE]), native);
-		_snprintf(buffer, maxLength, "Run time error %d (plugin \"%s\") (native \"%s\") - debug not enabled!", error, filename, native);
+		UTIL_Format(buffer, maxLength, "Run time error %d (plugin \"%s\") (native \"%s\") - debug not enabled!", error, filename, native);
 	} else {
-		_snprintf(buffer, maxLength, "Run time error %d (plugin \"%s\") - debug not enabled!", error, filename);
+		UTIL_Format(buffer, maxLength, "Run time error %d (plugin \"%s\") - debug not enabled!", error, filename);
 	}
 }
 

--- a/amxmodx/file.cpp
+++ b/amxmodx/file.cpp
@@ -798,8 +798,8 @@ static cell AMX_NATIVE_CALL amx_rename(AMX *amx, cell *params)
 		build_pathname_r(f_old_r, sizeof(f_old_r)-1, "%s", fold);
 		build_pathname_r(f_new_r, sizeof(f_new_r)-1, "%s", fnew);
 	} else {
-		snprintf(f_old_r, sizeof(f_old_r)-1, "%s", fold);
-		snprintf(f_new_r, sizeof(f_new_r)-1, "%s", fnew);
+		UTIL_Format(f_old_r, sizeof(f_old_r)-1, "%s", fold);
+		UTIL_Format(f_new_r, sizeof(f_new_r)-1, "%s", fnew);
 	}
 
 #if defined(__linux__) || defined(__APPLE__)

--- a/amxmodx/format.cpp
+++ b/amxmodx/format.cpp
@@ -655,7 +655,7 @@ reswitch:
 				if (!def)
 				{
 					static char buf[255];
-					snprintf(buf, sizeof(buf)-1, "ML_NOTFOUND: %s", key);
+					UTIL_Format(buf, sizeof(buf)-1, "ML_NOTFOUND: %s", key);
 					def = buf;
 				}
 				size_t written = atcprintf(buf_p, llen, def, amx, params, &arg);

--- a/amxmodx/meta_api.cpp
+++ b/amxmodx/meta_api.cpp
@@ -207,7 +207,7 @@ void LoadExtraPluginsToPCALM(const char *initialdir)
 	while (!files.empty())
 	{
 		String *pString = files.front();
-		snprintf(path, sizeof(path)-1, "%s/%s", 
+		UTIL_Format(path, sizeof(path)-1, "%s/%s", 
 			initialdir,
 			pString->c_str());
 		g_plugins.CALMFromFile(path);
@@ -224,7 +224,7 @@ void LoadExtraPluginsFromDir(const char *initialdir)
 	while (!files.empty())
 	{
 		String *pString = files.front();
-		snprintf(path, sizeof(path)-1, "%s/%s", 
+		UTIL_Format(path, sizeof(path)-1, "%s/%s", 
 			initialdir,
 			pString->c_str());
 		g_plugins.loadPluginsFromFile(path);
@@ -313,7 +313,7 @@ const char*	get_localinfo_r(const char *name, const char *def, char buffer[], si
 		SET_LOCALINFO((char*)name, (char*)(b = def));
 	}
 
-	snprintf(buffer, maxlength, "%s", b);
+	UTIL_Format(buffer, maxlength, "%s", b);
 
 	return buffer;
 }
@@ -410,7 +410,7 @@ int	C_Spawn(edict_t *pent)
 	LoadExtraPluginsToPCALM(configs_dir);
 	char temporaryMap[64], *tmap_ptr;
 
-	snprintf(temporaryMap, sizeof(temporaryMap), "%s", STRING(gpGlobals->mapname));
+	UTIL_Format(temporaryMap, sizeof(temporaryMap), "%s", STRING(gpGlobals->mapname));
 
 	prefixed_map_pluginsfile[0] = '\0';
 	if ((tmap_ptr = strchr(temporaryMap, '_')) != NULL)
@@ -418,7 +418,7 @@ int	C_Spawn(edict_t *pent)
 		// this map has a prefix
 
 		*tmap_ptr = '\0';
-		snprintf(prefixed_map_pluginsfile, 
+		UTIL_Format(prefixed_map_pluginsfile, 
 			sizeof(prefixed_map_pluginsfile),
 			"%s/maps/plugins-%s.ini",
 			configs_dir,
@@ -426,7 +426,7 @@ int	C_Spawn(edict_t *pent)
 		g_plugins.CALMFromFile(prefixed_map_pluginsfile);
 	}
 
-	snprintf(map_pluginsfile_path, 
+	UTIL_Format(map_pluginsfile_path, 
 		sizeof(map_pluginsfile_path),
 		"%s/maps/plugins-%s.ini",
 		configs_dir,

--- a/amxmodx/modules.cpp
+++ b/amxmodx/modules.cpp
@@ -691,7 +691,7 @@ char* build_pathname(const char *fmt, ...)
 {
 	static char string[256];
 	int b;
-	int a = b = snprintf(string, 255, "%s%c", g_mod_name.c_str(), PATH_SEP_CHAR);
+	int a = b = UTIL_Format(string, 255, "%s%c", g_mod_name.c_str(), PATH_SEP_CHAR);
 
 	va_list argptr;
 	va_start(argptr, fmt);
@@ -715,7 +715,7 @@ char* build_pathname(const char *fmt, ...)
 
 char *build_pathname_r(char *buffer, size_t maxlen, const char *fmt, ...)
 {
-	snprintf(buffer, maxlen, "%s%c", g_mod_name.c_str(), PATH_SEP_CHAR);
+	UTIL_Format(buffer, maxlen, "%s%c", g_mod_name.c_str(), PATH_SEP_CHAR);
 
 	size_t len = strlen(buffer);
 	char *ptr = buffer + len;

--- a/amxmodx/natives.cpp
+++ b/amxmodx/natives.cpp
@@ -180,7 +180,7 @@ static cell AMX_NATIVE_CALL log_error(AMX *amx, cell *params)
 	int len;
 	char *err = format_amxstring(amx, params, 2, len);
 
-	_snprintf(g_errorStr, sizeof(g_errorStr), "%s", err);
+	UTIL_Format(g_errorStr, sizeof(g_errorStr), "%s", err);
 	g_CurError = params[1];
 
 	return 1;

--- a/amxmodx/newmenus.cpp
+++ b/amxmodx/newmenus.cpp
@@ -289,7 +289,7 @@ bool Menu::Display(int player, page_t page)
 		return false;
 
 	static char buffer[2048];
-	int len = _snprintf(buffer, sizeof(buffer)-1, "%s", str);
+	int len = UTIL_Format(buffer, sizeof(buffer)-1, "%s", str);
 
 	CPlayer *pPlayer = GET_PLAYER_POINTER_I(player);
 
@@ -342,14 +342,14 @@ const char *Menu::GetTextString(int player, page_t page, int &keys)
 	if (items_per_page && (pages != 1))
 	{
 		if (m_AutoColors)
-			_snprintf(buffer, sizeof(buffer)-1, "\\y%s %d/%d\n\\w\n", m_Title.c_str(), page + 1, pages);
+			UTIL_Format(buffer, sizeof(buffer)-1, "\\y%s %d/%d\n\\w\n", m_Title.c_str(), page + 1, pages);
 		else
-			_snprintf(buffer, sizeof(buffer)-1, "%s %d/%d\n\n", m_Title.c_str(), page + 1, pages);
+			UTIL_Format(buffer, sizeof(buffer)-1, "%s %d/%d\n\n", m_Title.c_str(), page + 1, pages);
 	} else {
 		if (m_AutoColors)
-			_snprintf(buffer, sizeof(buffer)-1, "\\y%s\n\\w\n", m_Title.c_str());
+			UTIL_Format(buffer, sizeof(buffer)-1, "\\y%s\n\\w\n", m_Title.c_str());
 		else
-			_snprintf(buffer, sizeof(buffer)-1, "%s\n\n", m_Title.c_str());
+			UTIL_Format(buffer, sizeof(buffer)-1, "%s\n\n", m_Title.c_str());
 	}
 	
 	m_Text.append(buffer);
@@ -446,22 +446,22 @@ const char *Menu::GetTextString(int player, page_t page, int &keys)
 
 		if (pItem->isBlank)
 		{
-			_snprintf(buffer, sizeof(buffer)-1, "%s\n", pItem->name.c_str());
+			UTIL_Format(buffer, sizeof(buffer)-1, "%s\n", pItem->name.c_str());
 		}
 		else if (enabled)
 		{
 			if (m_AutoColors) 
 			{
-				_snprintf(buffer, sizeof(buffer)-1, "%s%d.\\w %s\n", m_ItemColor.c_str(),option_display, pItem->name.c_str());
+				UTIL_Format(buffer, sizeof(buffer)-1, "%s%d.\\w %s\n", m_ItemColor.c_str(),option_display, pItem->name.c_str());
 			} else {
-				_snprintf(buffer, sizeof(buffer)-1, "%d. %s\n", option_display, pItem->name.c_str());
+				UTIL_Format(buffer, sizeof(buffer)-1, "%d. %s\n", option_display, pItem->name.c_str());
 			}
 		} else {
 			if (m_AutoColors)
 			{
-				_snprintf(buffer, sizeof(buffer)-1, "\\d%d. %s\n\\w", option_display, pItem->name.c_str());
+				UTIL_Format(buffer, sizeof(buffer)-1, "\\d%d. %s\n\\w", option_display, pItem->name.c_str());
 			} else {
-				_snprintf(buffer, sizeof(buffer)-1, "#. %s\n", pItem->name.c_str());
+				UTIL_Format(buffer, sizeof(buffer)-1, "#. %s\n", pItem->name.c_str());
 			}
 		}
 		slots++;
@@ -503,14 +503,14 @@ const char *Menu::GetTextString(int player, page_t page, int &keys)
 				keys |= (1<<option++);
 				if (m_AutoColors)
 				{
-					_snprintf(buffer, 
+					UTIL_Format(buffer, 
 						sizeof(buffer)-1, 
 						"%s%d. \\w%s\n", 
 						m_ItemColor.c_str(), 
 						option == 10 ? 0 : option, 
 						m_OptNames[abs(MENU_BACK)].c_str());
 				} else {
-					_snprintf(buffer, 
+					UTIL_Format(buffer, 
 						sizeof(buffer)-1, 
 						"%d. %s\n", 
 						option == 10 ? 0 : option, 
@@ -520,13 +520,13 @@ const char *Menu::GetTextString(int player, page_t page, int &keys)
 				option++;
 				if (m_AutoColors)
 				{
-					_snprintf(buffer,
+					UTIL_Format(buffer,
 						sizeof(buffer)-1,
 						"\\d%d. %s\n\\w",
 						option == 10 ? 0 : option,
 						m_OptNames[abs(MENU_BACK)].c_str());
 				} else {
-					_snprintf(buffer, sizeof(buffer)-1, "#. %s\n", m_OptNames[abs(MENU_BACK)].c_str());
+					UTIL_Format(buffer, sizeof(buffer)-1, "#. %s\n", m_OptNames[abs(MENU_BACK)].c_str());
 				}
 			}
 			m_Text.append(buffer);
@@ -536,14 +536,14 @@ const char *Menu::GetTextString(int player, page_t page, int &keys)
 				keys |= (1<<option++);
 				if (m_AutoColors)
 				{
-					_snprintf(buffer, 
+					UTIL_Format(buffer, 
 						sizeof(buffer)-1, 
 						"%s%d. \\w%s\n", 
 						m_ItemColor.c_str(), 
 						option == 10 ? 0 : option, 
 						m_OptNames[abs(MENU_MORE)].c_str());
 				} else {
-					_snprintf(buffer, 
+					UTIL_Format(buffer, 
 						sizeof(buffer)-1, 
 						"%d. %s\n", 
 						option == 10 ? 0 : option, 
@@ -553,13 +553,13 @@ const char *Menu::GetTextString(int player, page_t page, int &keys)
 				option++;
 				if (m_AutoColors)
 				{
-					_snprintf(buffer,
+					UTIL_Format(buffer,
 						sizeof(buffer)-1,
 						"\\d%d. %s\n\\w",
 						option == 10 ? 0 : option,
 						m_OptNames[abs(MENU_MORE)].c_str());
 				} else {
-					_snprintf(buffer, sizeof(buffer)-1, "#. %s\n", m_OptNames[abs(MENU_MORE)].c_str());
+					UTIL_Format(buffer, sizeof(buffer)-1, "#. %s\n", m_OptNames[abs(MENU_MORE)].c_str());
 				}
 			}
 			m_Text.append(buffer);
@@ -578,14 +578,14 @@ const char *Menu::GetTextString(int player, page_t page, int &keys)
 		keys |= (1<<option++);
 		if (m_AutoColors)
 		{
-			_snprintf(buffer, 
+			UTIL_Format(buffer, 
 				sizeof(buffer)-1, 
 				"%s%d. \\w%s\n", 
 				m_ItemColor.c_str(), 
 				option == 10 ? 0 : option, 
 				m_OptNames[abs(MENU_EXIT)].c_str());
 		} else {
-			_snprintf(buffer, 
+			UTIL_Format(buffer, 
 				sizeof(buffer)-1, 
 				"%d. %s\n", 
 				option == 10 ? 0 : option, 

--- a/amxmodx/util.cpp
+++ b/amxmodx/util.cpp
@@ -350,8 +350,8 @@ void UTIL_FakeClientCommand(edict_t *pEdict, const char *cmd, const char *arg1, 
 		g_fakecmd.argv[1] = arg1;
 		g_fakecmd.argv[2] = arg2;
 		// build argument line
-		snprintf(g_fakecmd.args, 255, "%s %s", arg1, arg2);
-		// if snprintf reached 255 chars limit, this will make sure there will be no access violation
+		UTIL_Format(g_fakecmd.args, 255, "%s %s", arg1, arg2);
+		// if UTIL_Format reached 255 chars limit, this will make sure there will be no access violation
 		g_fakecmd.args[255] = 0;
 	}
 	else if (arg1)
@@ -360,8 +360,8 @@ void UTIL_FakeClientCommand(edict_t *pEdict, const char *cmd, const char *arg1, 
 		// store argument
 		g_fakecmd.argv[1] = arg1;
 		// build argument line
-		snprintf(g_fakecmd.args, 255, "%s", arg1);
-		// if snprintf reached 255 chars limit, this will make sure there will be no access violation
+		UTIL_Format(g_fakecmd.args, 255, "%s", arg1);
+		// if UTIL_Format reached 255 chars limit, this will make sure there will be no access violation
 		g_fakecmd.args[255] = 0;
 	}
 	else


### PR DESCRIPTION
There are some differences in what `snprintf` does on Windows/MSVC versus Linux.
On Windows, `snprintf` does not always null terminate.

This patch replaces all calls with `UTIL_Replace` for the sake of safety..
