### PR TITLE
Use server language as fallback if client's "lang" key is not defined.

### DIFF
--- a/amxmodx/format.cpp
+++ b/amxmodx/format.cpp
@@ -79,8 +79,12 @@ const char *translate(AMX *amx, cell amxaddr, const char *key)
 		get_amxstring_r(amx, amxaddr, name, 3);
 		pLangName = name;
 	}
+
 	if (!pLangName || !isalpha(pLangName[0]))
-		pLangName = "en";
+	{
+		pLangName = amxmodx_language->string;
+	}
+
 	//next parameter!
 	def = g_langMngr.GetDef(pLangName, key, status);
 			

--- a/plugins/multilingual.sma
+++ b/plugins/multilingual.sma
@@ -20,6 +20,7 @@ new g_coloredMenus
 
 new g_cvarDisplayClientMessage;
 new g_cvarClientLanguages;
+new g_cvarServerLanguage;
 
 public plugin_init()
 {
@@ -30,6 +31,8 @@ public plugin_init()
 	
 	g_cvarClientLanguages = register_cvar("amx_client_languages", "1")
 	g_cvarDisplayClientMessage = register_cvar("amx_language_display_msg", "1")
+	g_cvarServerLanguage = get_cvar_pointer("amx_language");
+	
 	register_clcmd("amx_langmenu", "cmdLangMenu", ADMIN_ALL)
 	register_menu("Language Menu", 1023, "actionMenu")
 	
@@ -65,6 +68,12 @@ public cmdLangMenu(id, level, cid)
 	
 	new buffer[3]
 	get_user_info(id, "lang", buffer, charsmax(buffer))
+	
+	if (buffer[0] == EOS) // if "lang" is not defined, by default it will use server language.
+	{
+		get_pcvar_string(g_cvarServerLanguage, buffer, charsmax(buffer));
+	}
+	
 	g_menuLang[id] = get_lang_id(buffer)
 	
 	showMenu(id)


### PR DESCRIPTION
Fix a bug where if a client's `lang` info couldn't be retrieved (`config.cfg` in read-only mode, or such key doesn't exist), the expected behavior is the fallback should be the server language defined with `amx_language` cvar ; not `"en"`.

Change should be safe as, if for some reason `amx_language` is empty, it will use `en` at the very end.
