### PR TITLE
Fix returning strings from variadic functions.

### DIFF
--- a/compiler/libpc300/sc.h
+++ b/compiler/libpc300/sc.h
@@ -598,6 +598,8 @@ SC_FUNC void addr2cell(void);
 SC_FUNC void char2addr(void);
 SC_FUNC void charalign(void);
 SC_FUNC void addconst(cell value);
+SC_FUNC void move_alt(void);
+SC_FUNC void load_hidden_arg();
 
 /*  Code generation functions for arithmetic operators.
  *

--- a/compiler/libpc300/sc1.c
+++ b/compiler/libpc300/sc1.c
@@ -5230,6 +5230,18 @@ static symbol *fetchlab(char *name)
   return sym;
 }
 
+static int is_variadic(symbol *sym)
+{
+  assert(sym->ident==iFUNCTN);
+  arginfo *arg = sym->dim.arglist;
+  while (arg->ident) {
+    if (arg->ident == iVARARGS)
+      return TRUE;
+    arg++;
+  }
+  return FALSE;
+}
+
 /*  doreturn
  *
  *  Global references: rettype  (altered)
@@ -5329,7 +5341,11 @@ static void doreturn(void)
        * it stays on the heap for the moment, and it is removed -usually- at
        * the end of the expression/statement, see expression() in SC3.C)
        */
-      address(sub,sALT);                /* ALT = destination */
+      if (is_variadic(curfunc)) {
+        load_hidden_arg();
+      } else {
+        address(sub,sALT);           /* ALT = destination */
+      }
       arraysize=calc_arraysize(dim,numdim,0);
       memcopy(arraysize*sizeof(cell));  /* source already in PRI */
       /* moveto1(); is not necessary, callfunction() does a popreg() */


### PR DESCRIPTION
Similar to the SM fix @ https://github.com/alliedmodders/sourcemod/pull/123. Most of the patch is just adding helpers to generate the assembly text. One difference is that AMX Mod X counts arguments in bytes, whereas SourceMod counts in cells (that is, it does not have the `params[0] / sizeof(cell)` pattern). So instead of `idxaddr` to add the base and count, it just uses `add`.
