### PR TITLE
Fix a typo in the documentation.

### DIFF
--- a/plugins/include/amxmodx.inc
+++ b/plugins/include/amxmodx.inc
@@ -2582,7 +2582,7 @@ forward plugin_natives();
 /**
  * Registers a native.
  *
- * @note Stlye 0 natives call the handler in the following manner:
+ * @note Style 0 natives call the handler in the following manner:
  *
  * public native_handler(plugin_id, argc)
  *


### PR DESCRIPTION
Just fixed a little typo in the documentation.
