### PR TITLE
Fix compiler crash due to missing recursion message warning (bug 6251)

### DIFF
--- a/compiler/libpc300/sc1.c
+++ b/compiler/libpc300/sc1.c
@@ -4271,7 +4271,7 @@ static long max_stacksize_recurse(symbol **sourcesym,symbol *sym,long basesize,i
             funcdisplayname(symname,sym->name);
             errorset(sSETFILE,sym->fnumber);
             errorset(sSETLINE,sym->lnumber);
-            error(237,symname);         /* recursive function */
+            error(234,symname);         /* recursive function */
           } /* if */
           *recursion=1;
           goto break_recursion;         /* recursion was detected, quit loop */

--- a/compiler/libpc300/sc5-in.scp
+++ b/compiler/libpc300/sc5-in.scp
@@ -291,6 +291,7 @@ static char *warnmsg[] = {
 /*231*/  "state specification on forward declaration is ignored\n",
 /*232*/  "output file is written, but with compact encoding disabled\n"
 /*233*/  "symbol \"%s\" is marked as deprecated: %s\n",
+/*234*/  "recursive function \"%s\"\n",
 #else
   "\345 \274tr\240\226\233\277 %\206\273\337c\367\305",
   "\222\323i\231\300\344\224t/\314cr\375\364",


### PR DESCRIPTION
Related to https://github.com/alliedmodders/amxmodx/commit/e46785a4344fa5f29dc7c43a5b8cbb2de60f3d68.
