### PR TITLE
Allow find_ent_by_owner native to work in client_disconnect forward

### DIFF
--- a/dlls/engine/entity.cpp
+++ b/dlls/engine/entity.cpp
@@ -1477,7 +1477,7 @@ static cell AMX_NATIVE_CALL find_ent_by_owner(AMX *amx, cell *params)  // native
 	int iEnt = params[1];
 	int oEnt = params[3];
 	// Check index to start searching at, 0 must be possible for iEnt.
-	CHECK_ENTITY(oEnt);
+	CHECK_ENTITY_SIMPLE(oEnt);
 
 	edict_t *pEnt = INDEXENT2(iEnt);
 	edict_t *entOwner = INDEXENT2(oEnt);


### PR DESCRIPTION
Reported by beneado at https://forums.alliedmods.net/showthread.php?t=246902.

This allows `find_ent_by_owner` native to work in `client_disconnect` forward as at this point player is not yet fully disconnected and player's edict is still valid. Also, the fakemeta version is working fine.

Difference between `CHECK_ENTITY` and `CHECK_ENTITY_SIMPLE` is the first checks entity is in-game (from AMXX point of view, and edict validity is still checked). AMXX keeps the current player's edict until a new player is connecting.

This should be safe change.

@Nextra 
