### PR TITLE
Revert "Done" text due to AMXX-Studio compatibility.

### DIFF
--- a/compiler/amxxpc/amxxpc.cpp
+++ b/compiler/amxxpc/amxxpc.cpp
@@ -185,7 +185,12 @@ int main(int argc, char **argv)
 	fclose(fp);
 
 	unlink(file);
-
+	
+	/*
+	Without "Done" message "Compile and start Half-Life"
+	and "Compile and upload" buttons in AMXX-Studio doesn't work.
+	*/
+	pc_printf("Done.\n");
 #if !defined EMSCRIPTEN
 	dlclose(lib);
 #endif


### PR DESCRIPTION
Without "Done" message "Compile and start Half-Life" and "Compile and upload" buttons in AMXX-Studio doesn't work. 
