### PR TITLE
Improve more sizeof return on array without specifiying the dimensions

### DIFF
--- a/compiler/libpc300/sc1.c
+++ b/compiler/libpc300/sc1.c
@@ -2264,18 +2264,18 @@ static void initials(int ident,int tag,cell *size,int dim[],int numdim,
          * the same value; if so, we can store this
          */
         constvalue *ld=lastdim.next;
-        int d,match;
-        for (d=0; d<dim[numdim-2]; d++) {
-          assert(ld!=NULL);
-          assert(strtol(ld->name,NULL,16)==d);
-          if (d==0)
-            match=ld->value;
-          else if (match!=ld->value)
-            break;
+        int match;
+        assert(ld!=NULL);
+        assert(strtol(ld->name,NULL,16)==0);
+        match=ld->value;
+        while (ld->next) {
           ld=ld->next;
-        } /* for */
-        if (d==dim[numdim-2])
-          dim[numdim-1]=match;
+          if (match!=ld->value) { 
+            match=0; 
+            break; 
+          }
+        }
+        dim[numdim-1]=match;
       } /* if */
       /* after all arrays have been initalized, we know the (major) dimensions
        * of the array and we can properly adjust the indirection vectors


### PR DESCRIPTION
This improves this fix: https://github.com/alliedmodders/amxmodx/commit/c4b233d094c5a6d6ada868448327fd6400088d0c

Unless I"ve missed something, Pawn author forgot to support array with 3+ dimensions. 

The original fix basically checks each item length of last dimension, and if all are the same, it defines a length for this dimension.
This works well with for example `new my_array[][] = { {1,0}, {2,1}, {3,1} }` ; and `sizeof my_array[]` will return 2.

This doesn't work well with 3D arrays like: `new const my_array[][][] = 
        {
            { "aa", "aa", "aa", "aa" },
            { "lol", "rofl", "lmao", "roflmao" }
        };`
In this case, original fix will process only `{ "aa", "aa", "aa", "aa" }` and since all those items have the same length, the last dimension will have now a fixed length whereas we expect variable lengths. Result: retrieving such items`{ "lol", "rofl", "lmao", "roflmao" }` will give truncated string.

This is kind of nasty because for example this `new const my_array[][][] = 
        {
            { "dvander", "is", "an", "egg" },
            { "lol", "rofl", "lmao", "roflmao" }
        };` will work properly since the first slot items have different length.

Solution is to loop over the table, checking all items, and if one's length differs, we don't set size (meaning variable length expected).

Note: SourceMod has the same issue.
