### PR TITLE
Added note for SQL_SetCharset native

### DIFF
--- a/plugins/include/sqlx.inc
+++ b/plugins/include/sqlx.inc
@@ -72,6 +72,8 @@ native Handle:SQL_Connect(Handle:cn_tuple, &errcode, error[], maxlength);
  * 
  * Example: "utf8", "latin1"
  *
+ * @note Only available in 1.8.3 and above.
+ *
  * @param h					Database or connection tuple Handle.
  * @param charset			The character set string to change to.
  * @return					True, if character set was changed, false otherwise.


### PR DESCRIPTION
I just used SQL_SetCharset in my plugin and its doesnt work on AMXX < 1.8.3. Please, add this note to native.