### PR TITLE
meta_api.cpp: modify csstats_rank value to match amxx.cfg default value

### DIFF
--- a/dlls/cstrike/csx/meta_api.cpp
+++ b/dlls/cstrike/csx/meta_api.cpp
@@ -64,7 +64,7 @@ int g_CurrentMsg;
 
 cvar_t init_csstats_maxsize ={"csstats_maxsize","3500", 0 , 3500.0 };
 cvar_t init_csstats_reset ={"csstats_reset","0"};
-cvar_t init_csstats_rank ={"csstats_rank","0"};
+cvar_t init_csstats_rank ={"csstats_rank","1"};
 cvar_t *csstats_maxsize;
 cvar_t *csstats_reset;
 cvar_t *csstats_rank;


### PR DESCRIPTION
modify csstats_rank value to match amxx.cfg default value aka save by steamID and not by nick.

"if someone forgot to overwrite all their files when they installed the CStrike Addon, it will default to saving by Nick"