### PR TITLE
Geoip: Fix possible crash

### DIFF
--- a/dlls/geoip/geoip_util.cpp
+++ b/dlls/geoip/geoip_util.cpp
@@ -73,10 +73,10 @@ bool lookupByIp(const char *ip, const char **path, MMDB_entry_data_s *result)
 		// Dirty fall back to default language ("en") in case provided user's language is not localized.
 
 		// Searh "names" position.
-		while (strcmp(path[i++], "names"));  
+		while (path[i] && strcmp(path[i++], "names"));
 
 		// No localized entry or we use already default language.
-		if (!*path[i] || !strcmp(path[i], "en")) 
+		if (!path[i] || !strcmp(path[i], "en")) 
 		{
 			return false;
 		}


### PR DESCRIPTION
Just a dumb typo. `path` is a list of strings and last entry is guaranteed to be NULL and forgot to check that as it's possible `names` to not be in the current list, thus resulting a crash if it reads further.

Just for information: related to https://github.com/alliedmodders/amxmodx/pull/99 