### PR TITLE
plmenu: Fix another alive spectator bug

### DIFF
--- a/plugins/plmenu.sma
+++ b/plugins/plmenu.sma
@@ -712,9 +712,9 @@ public actionTeamMenu(id, key)
 				return PLUGIN_HANDLED
 			}
 
-			if ( g_fakemeta )
+			if( g_fakemeta )
 			{
-				if ( get_pdata_int(player, m_iMenu) == Menu_ChooseAppearance )
+				if( get_pdata_int(player, m_iMenu) == Menu_ChooseAppearance )
 				{
 					new name[MAX_NAME_LENGTH]
 					get_user_name(player, name, charsmax(name))
@@ -739,6 +739,11 @@ public actionTeamMenu(id, key)
 			log_amx("Cmd: ^"%s<%d><%s><>^" transfer ^"%s<%d><%s><>^" (team ^"%s^")", name, get_user_userid(id), authid, name2, get_user_userid(player), authid2, g_CSTeamNames[destTeamSlot])
 
 			show_activity_key("ADMIN_TRANSF_1", "ADMIN_TRANSF_2", name, name2, g_CSTeamNames[destTeamSlot]);
+			
+			if( !g_fakemeta && destTeamSlot == 2 )
+			{
+				engclient_cmd(player, "joinclass", "6")
+			}
 
 			if ( g_CSPlayerCanSwitchFromSpec[player] && g_cstrike && (CS_TEAM_T <= cs_get_user_team(player) <= CS_TEAM_CT))
 			{

--- a/plugins/plmenu.sma
+++ b/plugins/plmenu.sma
@@ -712,6 +712,18 @@ public actionTeamMenu(id, key)
 				return PLUGIN_HANDLED
 			}
 
+			if ( g_fakemeta )
+			{
+				if ( get_pdata_int(player, m_iMenu) == Menu_ChooseAppearance )
+				{
+					new name[MAX_NAME_LENGTH]
+					get_user_name(player, name, charsmax(name))
+					client_print(id, print_chat, "%L", id, "CANT_PERF_PLAYER", name)
+					displayTeamMenu(id, g_menuPosition[id])
+					return PLUGIN_HANDLED
+				}
+			}
+
 			g_transferingAdmin = id
 
 			new authid[32], authid2[32], name[MAX_NAME_LENGTH], name2[MAX_NAME_LENGTH]
@@ -727,22 +739,6 @@ public actionTeamMenu(id, key)
 			log_amx("Cmd: ^"%s<%d><%s><>^" transfer ^"%s<%d><%s><>^" (team ^"%s^")", name, get_user_userid(id), authid, name2, get_user_userid(player), authid2, g_CSTeamNames[destTeamSlot])
 
 			show_activity_key("ADMIN_TRANSF_1", "ADMIN_TRANSF_2", name, name2, g_CSTeamNames[destTeamSlot]);
-			
-			if( destTeamSlot == 2 )
-			{
-				if ( g_fakemeta )
-				{
-					if( get_pdata_int(player, m_iMenu) == Menu_ChooseAppearance )
-					{
-						// works for both vgui and old style menus, and send menuselect could close other menus (and since get_user_menu fails to return VGUI and old style classes menus...)
-						engclient_cmd(player, "joinclass", "6");
-					}
-				}
-				else // force
-				{
-					engclient_cmd(player, "joinclass", "6");
-				}
-			}
 
 			if ( g_CSPlayerCanSwitchFromSpec[player] && g_cstrike && (CS_TEAM_T <= cs_get_user_team(player) <= CS_TEAM_CT))
 			{


### PR DESCRIPTION
Switch a newly connected user to spectator who selected his team but not his class can create an alive spectator if done during the first seconds of the round.

Solution : block the team transfer for any people stuck in this menu.
Well it's the worst case and probably the only possible one to completely fix this issue.
