### PR TITLE
Remove use of UTIL_StringToLowwer

### DIFF
--- a/dlls/cstrike/cstrike/CstrikeHacks.cpp
+++ b/dlls/cstrike/cstrike/CstrikeHacks.cpp
@@ -90,9 +90,6 @@ DETOUR_DECL_STATIC1(C_ClientCommand, void, edict_t*, pEdict) // void ClientComma
 	// to be used in OnBuy* forwards.
 	if ((ForwardOnBuyAttempt != -1 || ForwardOnBuy != -1) && command && *command)
 	{
-		// Just for safety.
-		command = UTIL_StringToLower((char *)command);
-
 		int itemId = 0;
 		
 		// Handling buy via menu.

--- a/dlls/cstrike/cstrike/CstrikeUtils.cpp
+++ b/dlls/cstrike/cstrike/CstrikeUtils.cpp
@@ -121,13 +121,3 @@ bool UTIL_CheckForPublic(const char *publicname)
 	return false; 
 }
 
-char *UTIL_StringToLower(char *str)
-{
-	char *p;
-	for (p = str; *p != '\0'; ++p)
-	{
-		*p = tolower(*p);
-	}
-
-	return str;
-}


### PR DESCRIPTION

Well, It's kind of stupid code. Someone reported me a crash on it.

`UTIL_StringToLowwer` doesn't duplicate string, and doesn't check letter before calling `tolower`, this could lead to issues.
Altering the original string is a bad idea, and lowering string letters here is anyway kind of pointless as `menuselect` is usually sent by the game (and game itself does case sensitive checks)

Let's :fire: this shit. 