### PR TITLE
Rename change_level to engine_changelevel

### DIFF
--- a/amxmodx/amxmodx.cpp
+++ b/amxmodx/amxmodx.cpp
@@ -2578,7 +2578,7 @@ static cell AMX_NATIVE_CALL change_task(AMX *amx, cell *params)
 	return g_tasksMngr.changeTasks(params[1], params[3] ? 0 : amx, flNewTime);
 }
 
-static cell AMX_NATIVE_CALL change_level(AMX *amx, cell *params)
+static cell AMX_NATIVE_CALL engine_changelevel(AMX *amx, cell *params)
 {
 	int length;
 	const char* new_map = get_amxstring(amx, params[1], 0, length);
@@ -4854,7 +4854,7 @@ AMX_NATIVE_INFO amxmodx_Natives[] =
 	{"callfunc_push_str",		callfunc_push_str},
 	{"callfunc_push_array",		callfunc_push_array},
 	{"change_task",				change_task},
-	{"change_level",			change_level},
+	{"engine_changelevel",		engine_changelevel},
 	{"client_cmd",				client_cmd},
 	{"client_print",			client_print},
 	{"client_print_color",		client_print_color},

--- a/plugins/admincmd.sma
+++ b/plugins/admincmd.sma
@@ -633,7 +633,7 @@ public cmdSlap(id, level, cid)
 
 public chMap(map[])
 {
-	change_level(map);
+	engine_changelevel(map);
 }
 
 public cmdMap(id, level, cid)

--- a/plugins/include/amxmodx.inc
+++ b/plugins/include/amxmodx.inc
@@ -63,7 +63,7 @@ forward plugin_unpause();
  *       server command "changelevel" which is used by many plugins will not
  *       trigger this forward. Unfortunately this means that in practice this
  *       forward is very unreliable, and will not be called in many situations.
- * @note AMXX 1.8.3 has added the change_level() function which will utilize
+ * @note AMXX 1.8.3 has added the engine_changelevel() function which will utilize
  *       the correct engine function to change the map and therefore trigger
  *       this forward.
  *
@@ -262,7 +262,7 @@ native precache_generic(const szFile[]);
  *
  * @noreturn
  */
-native change_level(const map[]);
+native engine_changelevel(const map[]);
 
 /**
  * Sets info on the client.

--- a/plugins/mapsmenu.sma
+++ b/plugins/mapsmenu.sma
@@ -300,7 +300,9 @@ public cmdMapsMenu(id, level, cid)
 }
 
 public delayedChange(mapname[])
-	change_level(mapname)
+{
+	engine_changelevel(mapname)
+}
 
 public actionVoteMapMenu(id, key)
 {

--- a/plugins/nextmap.sma
+++ b/plugins/nextmap.sma
@@ -97,7 +97,7 @@ public delayedChange(param[])
 	if (g_mp_chattime) {
 		set_pcvar_float(g_mp_chattime, get_pcvar_float(g_mp_chattime) - 2.0)
 	}
-	change_level(param)
+	engine_changelevel(param)
 }
 
 public changeMap()


### PR DESCRIPTION
Because name was kind of too generic and some existing plugins would seem to use that name for private functions, making compiler whining.

While we can, and since it has been implemented recently, let's rename it with less generic name.