### PR TITLE
Fix potential formatting issue with nvault_[p]set

### DIFF
--- a/dlls/nvault/amxxapi.cpp
+++ b/dlls/nvault/amxxapi.cpp
@@ -172,8 +172,8 @@ static cell nvault_set(AMX *amx, cell *params)
 	}
 	NVault *pVault = g_Vaults.at(id);
 	int len;
-	char *key = MF_GetAmxString(amx, params[2], 0, &len);
-	char *val = MF_FormatAmxString(amx, params, 3, &len);
+	const char *key = MF_GetAmxString(amx, params[2], 0, &len);
+	const char *val = MF_GetAmxString(amx, params[3], 1, &len);
 
 	pVault->SetValue(key, val);
 
@@ -190,8 +190,8 @@ static cell nvault_pset(AMX *amx, cell *params)
 	}
 	NVault *pVault = g_Vaults.at(id);
 	int len;
-	char *key = MF_GetAmxString(amx, params[2], 0, &len);
-	char *val = MF_FormatAmxString(amx, params, 3, &len);
+	const char *key = MF_GetAmxString(amx, params[2], 0, &len);
+	const char *val = MF_GetAmxString(amx, params[3], 1, &len);
 
 	pVault->SetValue(key, val, 0);
 


### PR DESCRIPTION
Reported by Bugsy.

```PAWN
native nvault_set(vault, const key[], const value[]);
native nvault_pset(vault, const key[], const value[]);
```
`value` parameter can't be formatted.

If passed data was coincidentally containing adjacent bytes which would be similar to "%s", "%d", etc., native would think data needs to be formatted and will result a *String formatted incorrectly* error.

It would seem that originally `value` was formattable but it has been changed right after and code has not been updated to reflect the change. 