### PR TITLE
Change MAX_PLAYERS value to 32

### DIFF
--- a/plugins/admin.sma
+++ b/plugins/admin.sma
@@ -32,7 +32,7 @@ new PLUGINNAME[] = "AMX Mod X"
 #define ADMIN_IPADDR	(1<<3)
 #define ADMIN_NAME		(1<<4)
 
-new bool:g_CaseSensitiveName[MAX_PLAYERS];
+new bool:g_CaseSensitiveName[MAX_PLAYERS + 1];
 
 // pcvars
 new amx_mode;
@@ -145,7 +145,7 @@ public addadminfn(id, level, cid)
 			player = cmd_target(id, arg, CMDTARGET_ALLOW_SELF | CMDTARGET_NO_BOTS)
 		} else {
 			new _steamid[44]
-			static _players[32], _num, _pv
+			static _players[MAX_PLAYERS], _num, _pv
 			get_players(_players, _num)
 			for (new _i=0; _i<_num; _i++)
 			{
@@ -583,7 +583,7 @@ public cmdReload(id, level, cid)
 	}
 #endif
 
-	new players[32], num, pv
+	new players[MAX_PLAYERS], num, pv
 	new name[MAX_NAME_LENGTH]
 	get_players(players, num)
 	for (new i=0; i<num; i++)
@@ -752,7 +752,7 @@ accessUser(id, name[] = "")
 {
 	remove_user_flags(id)
 	
-	new userip[32], userauthid[32], password[32], passfield[32], username[32]
+	new userip[32], userauthid[32], password[32], passfield[32], username[MAX_NAME_LENGTH]
 	
 	get_user_ip(id, userip, charsmax(userip), 1)
 	get_user_authid(id, userauthid, charsmax(userauthid))

--- a/plugins/adminchat.sma
+++ b/plugins/adminchat.sma
@@ -26,8 +26,8 @@ new amx_show_activity;
 new amx_flood_time;
 new g_AdminChatFlag = ADMIN_CHAT;
 
-new Float:g_Flooding[MAX_PLAYERS] = {0.0, ...}
-new g_Flood[MAX_PLAYERS] = {0, ...}
+new Float:g_Flooding[MAX_PLAYERS + 1] = {0.0, ...}
+new g_Flood[MAX_PLAYERS + 1] = {0, ...}
 
 public plugin_init()
 {
@@ -139,7 +139,7 @@ public cmdSayChat(id, level)
 	{
 		case 3, 4:
 		{
-			new players[32], plrsnum, pl
+			new players[MAX_PLAYERS], plrsnum, pl
 			get_players(players, plrsnum, "ch")
 			for(new j; j<plrsnum; j++)
 			{
@@ -205,7 +205,7 @@ public cmdSayAdmin(id)
 	}
 
 	new message[192], name[MAX_NAME_LENGTH], authid[32], userid
-	new players[32], inum, pl
+	new players[MAX_PLAYERS], inum, pl
 	
 	read_args(message, charsmax(message))
 	remove_quotes(message)
@@ -246,7 +246,7 @@ public cmdChat(id, level, cid)
 	if (!message[0])
 		return PLUGIN_HANDLED
 	
-	new name[MAX_NAME_LENGTH], players[32], inum, authid[32], userid, pl
+	new name[MAX_NAME_LENGTH], players[MAX_PLAYERS], inum, authid[32], userid, pl
 	
 	get_user_authid(id, authid, charsmax(authid))
 	get_user_name(id, name, charsmax(name))
@@ -386,7 +386,7 @@ public cmdTsay(id, level, cid)
 	{
 		case 3, 4:
 		{
-			new players[32], plrsnum, pl
+			new players[MAX_PLAYERS], plrsnum, pl
 			get_players(players, plrsnum, "ch")
 			for(new i; i<plrsnum; i++)
 			{

--- a/plugins/admincmd.sma
+++ b/plugins/admincmd.sma
@@ -340,7 +340,7 @@ public cmdAddBan(id, level, cid)
 		else
 		{
 			new Auth[32];
-			new Name[32];
+			new Name[MAX_NAME_LENGTH];
 			new dummy[1];
 			new Access;
 			for (new i = 0; i < g_Size; i++)
@@ -449,7 +449,7 @@ public cmdBan(id, level, cid)
 
 	new msg[256];
 	new len;
-	new players[32], pnum, plr
+	new players[MAX_PLAYERS], pnum, plr
 	get_players(players, pnum, "ch")
 	for (new i; i<pnum; i++)
 	{
@@ -536,7 +536,7 @@ public cmdBanIP(id, level, cid)
 
 	new msg[256];
 	new len;
-	new players[32], pnum, plr
+	new players[MAX_PLAYERS], pnum, plr
 	get_players(players, pnum, "ch")
 	for (new i; i<pnum; i++)
 	{
@@ -776,7 +776,7 @@ public cmdCvar(id, level, cid)
 	// Display the message to all clients
 
 	new cvar_val[64];
-	new players[32], pnum, plr
+	new players[MAX_PLAYERS], pnum, plr
 	get_players(players, pnum, "ch")
 	for (new i; i<pnum; i++)
 	{
@@ -900,7 +900,7 @@ public cmdXvar(id, level, cid)
 	log_amx("Cmd: ^"%s<%d><%s><>^" set xvar (name ^"%s^") (value ^"%s^")", name, get_user_userid(id), authid, arg1, arg2);
 	
 	// Display the message to all clients
-	new players[32], pnum, plr;
+	new players[MAX_PLAYERS], pnum, plr;
 	get_players(players, pnum, "ch");
 	for (new i; i<pnum; i++)
 	{
@@ -1105,7 +1105,7 @@ public cmdPause(id, level, cid)
 
 	// Display the message to all clients
 
-	new players[32], pnum
+	new players[MAX_PLAYERS], pnum
 	get_players(players, pnum, "ch")
 	for (new i; i<pnum; i++)
 	{
@@ -1164,7 +1164,7 @@ public cmdWho(id, level, cid)
 	if (!cmd_access(id, level, cid, 1))
 		return PLUGIN_HANDLED
 
-	new players[32], inum, cl_on_server[64], authid[32], name[MAX_NAME_LENGTH], flags, sflags[32], plr
+	new players[MAX_PLAYERS], inum, cl_on_server[64], authid[32], name[MAX_NAME_LENGTH], flags, sflags[32], plr
 	new lImm[16], lRes[16], lAccess[16], lYes[16], lNo[16]
 	
 	formatex(lImm, charsmax(lImm), "%L", id, "IMMU")

--- a/plugins/adminvote.sma
+++ b/plugins/adminvote.sma
@@ -129,7 +129,7 @@ public checkVotes()
 	new votesNum = g_voteCount[0] + g_voteCount[1] + g_voteCount[2] + g_voteCount[3]
 	new iRatio = votesNum ? floatround(g_voteRatio * float(votesNum), floatround_ceil) : 1
 	new iResult = g_voteCount[best]
-	new players[32], pnum, i
+	new players[MAX_PLAYERS], pnum, i
 	
 	get_players(players, pnum, "c")
 	
@@ -449,7 +449,7 @@ public cmdVoteKickBan(id, level, cid)
 	
 	if (voteban && is_user_bot(player))
 	{
-		new imname[32]
+		new imname[MAX_NAME_LENGTH]
 		
 		get_user_name(player, imname, charsmax(imname))
 		console_print(id, "%L", id, "ACTION_PERFORMED", imname)

--- a/plugins/antiflood.sma
+++ b/plugins/antiflood.sma
@@ -13,8 +13,8 @@
 
 #include <amxmodx>
 
-new Float:g_Flooding[MAX_PLAYERS] = {0.0, ...}
-new g_Flood[MAX_PLAYERS] = {0, ...}
+new Float:g_Flooding[MAX_PLAYERS + 1] = {0.0, ...}
+new g_Flood[MAX_PLAYERS + 1] = {0, ...}
 
 new amx_flood_time;
 

--- a/plugins/cmdmenu.sma
+++ b/plugins/cmdmenu.sma
@@ -65,10 +65,10 @@ new g_cvarCmd[MAX_CVARS*5][32]
 new g_cvarCmdNum
 new g_cvarNum
 
-new g_menuPosition[MAX_PLAYERS]
-new g_menuSelect[MAX_PLAYERS][MAX_CMDS]
-new g_menuSelectNum[MAX_PLAYERS]
-new g_menuLayer[MAX_PLAYERS]
+new g_menuPosition[MAX_PLAYERS + 1]
+new g_menuSelect[MAX_PLAYERS + 1][MAX_CMDS]
+new g_menuSelectNum[MAX_PLAYERS + 1]
+new g_menuLayer[MAX_PLAYERS + 1]
 
 new g_coloredMenus
 

--- a/plugins/cstrike/miscstats.sma
+++ b/plugins/cstrike/miscstats.sma
@@ -57,8 +57,8 @@ public GrenadeSuicideSound
 const SOUNDFILE_PATH_MAXLEN = 64
 const SOUND_SHORTPATH_MAXLEN = SOUNDFILE_PATH_MAXLEN - 10 // 64 (sound/ [ 54 ] .wav) critical value for fast dl
 
-new g_streakKills[MAX_PLAYERS][2]
-new g_multiKills[MAX_PLAYERS][2]
+new g_streakKills[MAX_PLAYERS + 1][2]
+new g_multiKills[MAX_PLAYERS + 1][2]
 new g_C4Timer
 new g_Defusing
 new g_Planter 
@@ -67,7 +67,7 @@ new g_LastAnnounce
 new g_roundCount
 new Float:g_doubleKill
 new g_doubleKillId
-new g_friend[MAX_PLAYERS]
+new g_friend[MAX_PLAYERS + 1]
 new g_firstBlood
 new g_center1_sync
 new g_announce_sync
@@ -84,8 +84,8 @@ const TASK_DELAYED_NEW_ROUND = 98038
 const TEAM_T = 1
 const TEAM_CT = 2
 
-new g_connected[MAX_PLAYERS]
-new g_msounds[MAX_PLAYERS]
+new g_connected[MAX_PLAYERS + 1]
+new g_msounds[MAX_PLAYERS + 1]
 new const _msound[] = "_msound"
 
 new g_MultiKillMsg[7][] =
@@ -548,7 +548,7 @@ public client_death(killer, victim, wpnindex, hitplace, TK)
 	{
 		if( TEAM_T <= team <= TEAM_CT )
 		{
-			new ppl[32], pplnum, epplnum, a
+			new ppl[MAX_PLAYERS], pplnum, epplnum, a
 			get_players(ppl, epplnum, "ae", team == TEAM_T ? "CT" : "TERRORIST")
 			get_players(ppl, pplnum, "ae", team == TEAM_T ? "TERRORIST" : "CT")
 			if( victim_alive )
@@ -592,7 +592,7 @@ public client_death(killer, victim, wpnindex, hitplace, TK)
 
 	if (LastMan || LastManSound)
 	{
-		new cts[32], ts[32], ctsnum, tsnum, b
+		new cts[MAX_PLAYERS], ts[MAX_PLAYERS], ctsnum, tsnum, b
 		get_players(cts, ctsnum, "ae", "CT")
 		get_players(ts, tsnum, "ae", "TERRORIST")
 		
@@ -744,7 +744,7 @@ public client_death(killer, victim, wpnindex, hitplace, TK)
 	{
 		if (HeadShotKill && wpnindex)
 		{
-			new killer_name[MAX_NAME_LENGTH], victim_name[MAX_NAME_LENGTH], weapon_name[32], message[256], players[32], pnum, plr
+			new killer_name[MAX_NAME_LENGTH], victim_name[MAX_NAME_LENGTH], weapon_name[32], message[256], players[MAX_PLAYERS], pnum, plr
 			
 			xmod_get_wpnname(wpnindex, weapon_name, charsmax(weapon_name))
 			get_user_name(killer, killer_name, charsmax(killer_name))
@@ -866,7 +866,7 @@ public LogEvent_Round_Start()
 {
 	if (KillingStreak)
 	{
-		new appl[32], ppl, i
+		new appl[MAX_PLAYERS], ppl, i
 		get_players(appl, ppl, "ac")
 		
 		for (new a = 0; a < ppl; ++a)
@@ -1088,7 +1088,7 @@ play_sound(id, sound[])
 	}
 	else
 	{
-		new players[32], pnum, id
+		new players[MAX_PLAYERS], pnum, id
 		get_players(players, pnum, "ch")
 
 		for(--pnum; pnum>=0; pnum--)

--- a/plugins/cstrike/restmenu.sma
+++ b/plugins/cstrike/restmenu.sma
@@ -19,14 +19,14 @@
 
 #define MAXMENUPOS 34
 
-new g_Position[MAX_PLAYERS]
+new g_Position[MAX_PLAYERS + 1]
 new g_Modified
 new g_blockPos[112]
 new g_saveFile[64]
 new g_Restricted[] = "* This item is restricted *"
 new g_szWeapRestr[27] = "00000000000000000000000000"
 new g_szEquipAmmoRestr[10] = "000000000"
-new g_InBuyMenu[MAX_PLAYERS]
+new g_InBuyMenu[MAX_PLAYERS + 1]
 new g_RegisteredMenus[10]
 
 new g_menuStrings[6][] =
@@ -283,8 +283,8 @@ new g_Aliases2[MAXMENUPOS][] =
 }
 
 #define AUTOBUYLENGTH 511
-new g_Autobuy[MAX_PLAYERS][AUTOBUYLENGTH + 1]
-//new g_Rebuy[MAX_PLAYERS][AUTOBUYLENGTH + 1]
+new g_Autobuy[MAX_PLAYERS + 1][AUTOBUYLENGTH + 1]
+//new g_Rebuy[MAX_PLAYERS + 1][AUTOBUYLENGTH + 1]
 
 bool:IsOurMenuID(id)
 {

--- a/plugins/cstrike/stats_logging.sma
+++ b/plugins/cstrike/stats_logging.sma
@@ -14,9 +14,9 @@
 #include <amxmodx>
 #include <csx>
 
-new g_pingSum[MAX_PLAYERS]
-new g_pingCount[MAX_PLAYERS]
-new g_inGame[MAX_PLAYERS]
+new g_pingSum[MAX_PLAYERS + 1]
+new g_pingCount[MAX_PLAYERS + 1]
+new g_inGame[MAX_PLAYERS + 1]
 
 public plugin_init()
 {

--- a/plugins/cstrike/statsx.sma
+++ b/plugins/cstrike/statsx.sma
@@ -107,56 +107,56 @@ new BODY_PART[8][] =
 #define KILLED_TEAM             3   // Killer's team
 #define KILLED_KILLER_STATSFIX  4   // Fix to register the last hit/kill
 
-new g_izKilled[MAX_PLAYERS][5]
+new g_izKilled[MAX_PLAYERS + 1][5]
 
 // Menu variables and configuration
 #define MAX_PPL_MENU_ACTIONS    2   // Number of player menu actions
 #define PPL_MENU_OPTIONS        7   // Number of player options per displayed menu
 
-new g_iPluginMode                                   = 0
+new g_iPluginMode                                       = 0
 
-new g_izUserMenuPosition[MAX_PLAYERS]               = {0, ...}
-new g_izUserMenuAction[MAX_PLAYERS]                 = {0, ...}
-new g_izUserMenuPlayers[MAX_PLAYERS][32]
+new g_izUserMenuPosition[MAX_PLAYERS + 1]               = {0, ...}
+new g_izUserMenuAction[MAX_PLAYERS + 1]                 = {0, ...}
+new g_izUserMenuPlayers[MAX_PLAYERS + 1][32]
 
-new g_izSpecMode[MAX_PLAYERS]                       = {0, ...}
+new g_izSpecMode[MAX_PLAYERS + 1]                       = {0, ...}
 
-new g_izShowStatsFlags[MAX_PLAYERS]                 = {0, ...}
-new g_izStatsSwitch[MAX_PLAYERS]                    = {0, ...}
-new Float:g_fzShowUserStatsTime[MAX_PLAYERS]        = {0.0, ...}
-new Float:g_fShowStatsTime                          = 0.0
-new Float:g_fFreezeTime                             = 0.0
-new Float:g_fFreezeLimitTime                        = 0.0
-new Float:g_fHUDDuration                            = 0.0
+new g_izShowStatsFlags[MAX_PLAYERS + 1]                 = {0, ...}
+new g_izStatsSwitch[MAX_PLAYERS + 1]                    = {0, ...}
+new Float:g_fzShowUserStatsTime[MAX_PLAYERS + 1]        = {0.0, ...}
+new Float:g_fShowStatsTime                              = 0.0
+new Float:g_fFreezeTime                                 = 0.0
+new Float:g_fFreezeLimitTime                            = 0.0
+new Float:g_fHUDDuration                                = 0.0
 
-new g_iRoundEndTriggered                            = 0
-new g_iRoundEndProcessed                            = 0
+new g_iRoundEndTriggered                                = 0
+new g_iRoundEndProcessed                                = 0
 
-new g_pFreezeTime                                   = 0
-new g_pRoundTime                                    = 0
-new g_pHudDuration                                  = 0
-new g_pHudFreezeLimit                               = 0
+new g_pFreezeTime                                       = 0
+new g_pRoundTime                                        = 0
+new g_pHudDuration                                      = 0
+new g_pHudFreezeLimit                                   = 0
 
-new Float:g_fStartGame                              = 0.0
-new g_izTeamScore[MAX_TEAMS]                        = {0, ...}
-new g_izTeamEventScore[MAX_TEAMS]                   = {0, ...}
+new Float:g_fStartGame                                  = 0.0
+new g_izTeamScore[MAX_TEAMS]                            = {0, ...}
+new g_izTeamEventScore[MAX_TEAMS]                       = {0, ...}
 new g_izTeamRndStats[MAX_TEAMS][8]
 new g_izTeamGameStats[MAX_TEAMS][8]
-new g_izUserUserID[MAX_PLAYERS]                     = {0, ...}
-new g_izUserAttackerDistance[MAX_PLAYERS]           = {0, ...}
-new g_izUserVictimDistance[MAX_PLAYERS][MAX_PLAYERS]
-new g_izUserRndName[MAX_PLAYERS][MAX_NAME_LENGTH]
-new g_izUserRndStats[MAX_PLAYERS][8]
-new g_izUserGameStats[MAX_PLAYERS][8]
+new g_izUserUserID[MAX_PLAYERS + 1]                     = {0, ...}
+new g_izUserAttackerDistance[MAX_PLAYERS + 1]           = {0, ...}
+new g_izUserVictimDistance[MAX_PLAYERS + 1][MAX_PLAYERS + 1]
+new g_izUserRndName[MAX_PLAYERS + 1][MAX_NAME_LENGTH]
+new g_izUserRndStats[MAX_PLAYERS + 1][8]
+new g_izUserGameStats[MAX_PLAYERS + 1][8]
 
 // Common buffer to improve performance, as Small always zero-initializes all vars
-new g_sBuffer[MAX_BUFFER_LENGTH + 1]                = ""
-new g_sScore[MAX_TEXT_LENGTH + 1]                   = ""
-new g_sAwardAndScore[MAX_BUFFER_LENGTH + 1]         = ""
+new g_sBuffer[MAX_BUFFER_LENGTH + 1]                    = ""
+new g_sScore[MAX_TEXT_LENGTH + 1]                       = ""
+new g_sAwardAndScore[MAX_BUFFER_LENGTH + 1]             = ""
 
-new t_sText[MAX_TEXT_LENGTH + 1]                    = ""
-new t_sName[MAX_NAME_LENGTH + 1]                    = ""
-new t_sWpn[MAX_WEAPON_LENGTH + 1]                   = ""
+new t_sText[MAX_TEXT_LENGTH + 1]                        = ""
+new t_sName[MAX_NAME_LENGTH + 1]                        = ""
+new t_sWpn[MAX_WEAPON_LENGTH + 1]                       = ""
 
 new g_HudSync_EndRound
 new g_HudSync_SpecInfo
@@ -1547,7 +1547,7 @@ endround_stats()
 	if (g_iRoundEndProcessed || !g_iRoundEndTriggered)
 		return
 
-	new iaPlayers[32], iPlayer, iPlayers, id
+	new iaPlayers[MAX_PLAYERS], iPlayer, iPlayers, id
 
 	get_players(iaPlayers, iPlayers)
 
@@ -1599,7 +1599,7 @@ public eventIntermission()
 
 public end_game_stats()
 {
-	new iaPlayers[32], iPlayer, iPlayers, id
+	new iaPlayers[MAX_PLAYERS], iPlayer, iPlayers, id
 
 	if (EndPlayer)
 	{

--- a/plugins/cstrike/statsx.sma
+++ b/plugins/cstrike/statsx.sma
@@ -117,7 +117,7 @@ new g_iPluginMode                                       = 0
 
 new g_izUserMenuPosition[MAX_PLAYERS + 1]               = {0, ...}
 new g_izUserMenuAction[MAX_PLAYERS + 1]                 = {0, ...}
-new g_izUserMenuPlayers[MAX_PLAYERS + 1][32]
+new g_izUserMenuPlayers[MAX_PLAYERS + 1][MAX_PLAYERS]
 
 new g_izSpecMode[MAX_PLAYERS + 1]                       = {0, ...}
 

--- a/plugins/dod/plmenu.sma
+++ b/plugins/dod/plmenu.sma
@@ -15,14 +15,14 @@
 #include <amxmisc>
 #include <dodx>
 
-new g_menuPosition[MAX_PLAYERS]
-new g_menuPlayers[MAX_PLAYERS][32]
-new g_menuPlayersNum[MAX_PLAYERS]
-new g_menuOption[MAX_PLAYERS]
-new g_menuSettings[MAX_PLAYERS]
+new g_menuPosition[MAX_PLAYERS + 1]
+new g_menuPlayers[MAX_PLAYERS + 1][32]
+new g_menuPlayersNum[MAX_PLAYERS + 1]
+new g_menuOption[MAX_PLAYERS + 1]
+new g_menuSettings[MAX_PLAYERS + 1]
 
-new g_menuSelect[MAX_PLAYERS][64]
-new g_menuSelectNum[MAX_PLAYERS]
+new g_menuSelect[MAX_PLAYERS + 1][64]
+new g_menuSelectNum[MAX_PLAYERS + 1]
 
 #define MAX_CLCMDS 24
 

--- a/plugins/dod/plmenu.sma
+++ b/plugins/dod/plmenu.sma
@@ -16,7 +16,7 @@
 #include <dodx>
 
 new g_menuPosition[MAX_PLAYERS + 1]
-new g_menuPlayers[MAX_PLAYERS + 1][32]
+new g_menuPlayers[MAX_PLAYERS + 1][MAX_PLAYERS]
 new g_menuPlayersNum[MAX_PLAYERS + 1]
 new g_menuOption[MAX_PLAYERS + 1]
 new g_menuSettings[MAX_PLAYERS + 1]

--- a/plugins/dod/stats.sma
+++ b/plugins/dod/stats.sma
@@ -75,7 +75,7 @@ new g_RoundScore[2]
 
 new g_userPosition[MAX_PLAYERS + 1]
 new g_userState[MAX_PLAYERS + 1]
-new g_userPlayers[MAX_PLAYERS + 1][32]
+new g_userPlayers[MAX_PLAYERS + 1][MAX_PLAYERS]
 new g_Buffer[2048]
 
 new g_Killers[MAX_PLAYERS + 1][3]

--- a/plugins/dod/stats.sma
+++ b/plugins/dod/stats.sma
@@ -66,20 +66,20 @@ public EnemyGreKillSound
 public LeadSounds
 public MortarKill
 
-new g_streakKills[MAX_PLAYERS][2]
-new g_multiKills[MAX_PLAYERS][2]
+new g_streakKills[MAX_PLAYERS + 1][2]
+new g_multiKills[MAX_PLAYERS + 1][2]
 new Float:g_prevKill
 new g_prevKillerId
 new g_KillCount;
 new g_RoundScore[2]
 
-new g_userPosition[MAX_PLAYERS]
-new g_userState[MAX_PLAYERS]
-new g_userPlayers[MAX_PLAYERS][32]
+new g_userPosition[MAX_PLAYERS + 1]
+new g_userState[MAX_PLAYERS + 1]
+new g_userPlayers[MAX_PLAYERS + 1][32]
 new g_Buffer[2048]
 
-new g_Killers[MAX_PLAYERS][3]
-new Float:g_DeathStats[MAX_PLAYERS]
+new g_Killers[MAX_PLAYERS + 1][3]
+new Float:g_DeathStats[MAX_PLAYERS + 1]
 
 new g_damage_sync
 new g_center1_sync
@@ -259,14 +259,14 @@ public cmdFF(id){
 public endGameStats(){
   new i
   if ( EndPlayer ){
-    new players[32], inum
+    new players[MAX_PLAYERS], inum
     get_players(players,inum)
     for(i = 0; i < inum; ++i){
         displayStats_steam(players[i],players[i])
     }
   } 
   else if ( EndTop15 ){
-    new players[32], inum
+    new players[MAX_PLAYERS], inum
     get_players(players,inum)
 
     new g_Top[16], top = get_cvar_num("dodstats_topvalue") 
@@ -479,7 +479,7 @@ public round_end(){
 
   if ( !EndRoundStats ) return PLUGIN_CONTINUE
 
-  new g_Buffer2[1024], len, players[32], pnum, stats[9],bodyhits[8]
+  new g_Buffer2[1024], len, players[MAX_PLAYERS], pnum, stats[9],bodyhits[8]
   get_players( players , pnum ) 
 
 
@@ -719,7 +719,7 @@ public client_death(killer,victim,wpnindex,hitplace,TK)
 
   if ( headshot && (HeadShotKill || HeadShotKillSound) && !xmod_is_melee_wpn(wpnindex) ){
     if ( HeadShotKill ){
-      new weapon[32], message[256], players[32], pnum
+      new weapon[32], message[256], players[MAX_PLAYERS], pnum
       xmod_get_wpnname(wpnindex,weapon,charsmax(weapon)) 
 
       get_players(players,pnum,"c")
@@ -817,7 +817,7 @@ public checkKills(param[]){
 new LeaderScore 
 new NumOfLeaders 
 new LeaderID 
-new PScore[MAX_PLAYERS] 
+new PScore[MAX_PLAYERS + 1] 
 
 public client_disconnect(id) { 
   if ( !LeadSounds || isDSMActive() ) return PLUGIN_CONTINUE
@@ -826,7 +826,7 @@ public client_disconnect(id) {
     PScore[id] = 0 
     if ( NumOfLeaders == 0 ){ 
       LeaderScore = 0 
-      for ( new i=1; i<MAX_PLAYERS; i++ ) 
+      for ( new i=1; i<=MAX_PLAYERS; i++ ) 
         if ( PScore[i] > LeaderScore ){ 
 
 
@@ -853,7 +853,7 @@ public client_disconnect(id) {
         client_cmd( LeaderID,"spk misc/takenlead" ) 
       } 
       else { 
-        for ( new i=1; i<MAX_PLAYERS; i++ ) 
+        for ( new i=1; i<=MAX_PLAYERS; i++ ) 
         if ( PScore[i] == LeaderScore ) client_cmd( i,"spk misc/takenlead" ) 
       } 
   } 
@@ -878,13 +878,13 @@ public get_score(){
       } 
       else if ( NumOfLeaders > 1 ){ 
 
-        for ( new i=1; i<MAX_PLAYERS; i++ ) 
+        for ( new i=1; i<=MAX_PLAYERS; i++ ) 
           if ( PScore[i] == LeaderScore  && i != PlayerID ) 
             client_cmd( i,"spk misc/lostlead" ) 
         client_cmd( PlayerID,"spk misc/takenlead" ) 
       } 
       else if ( NumOfLeaders == 0 ){ // start 
-        for ( new i=1; i<MAX_PLAYERS; i++ ) 
+        for ( new i=1; i<=MAX_PLAYERS; i++ ) 
           if ( i != PlayerID && is_user_connected(i) ) client_cmd( i,"spk misc/lostlead" ) 
         client_cmd( PlayerID,"spk misc/takenlead" ) 
       } 

--- a/plugins/dod/stats_logging.sma
+++ b/plugins/dod/stats_logging.sma
@@ -15,8 +15,8 @@
 #include <amxmodx>
 #include <dodx>
 
-new g_pingSum[MAX_PLAYERS]
-new g_pingCount[MAX_PLAYERS]
+new g_pingSum[MAX_PLAYERS + 1]
+new g_pingCount[MAX_PLAYERS + 1]
 
 public plugin_init()
   register_plugin("Stats Logging",AMXX_VERSION_STR,"AMXX Dev Team")

--- a/plugins/include/amxconst.inc
+++ b/plugins/include/amxconst.inc
@@ -37,7 +37,7 @@
  *        all possible server situations. MaxClients changes based on the
  *        server the plugin is deployed on..
  */
-#define MAX_PLAYERS 33 /* Maximum number of players AMX Mod X supports */
+#define MAX_PLAYERS 32 /* Maximum number of players AMX Mod X supports */
 
 public stock const MaxClients; /* Maximum number of players the server supports */
 

--- a/plugins/include/amxmodx.inc
+++ b/plugins/include/amxmodx.inc
@@ -1221,7 +1221,7 @@ native get_playersnum(flag=0);
  *
  * @noreturn
  */
-native get_players(players[32], &num, const flags[]="", const team[]="");
+native get_players(players[MAX_PLAYERS], &num, const flags[]="", const team[]="");
 
 /**
  * Retrieves argument of client command.

--- a/plugins/mapsmenu.sma
+++ b/plugins/mapsmenu.sma
@@ -16,12 +16,12 @@
 
 new Array:g_mapName;
 new g_mapNums
-new g_menuPosition[MAX_PLAYERS]
+new g_menuPosition[MAX_PLAYERS + 1]
 
 new g_voteCount[5]
 
-new g_voteSelected[MAX_PLAYERS][4]
-new g_voteSelectedNum[MAX_PLAYERS]
+new g_voteSelected[MAX_PLAYERS + 1][4]
+new g_voteSelectedNum[MAX_PLAYERS + 1]
 
 new g_coloredMenus
 
@@ -97,7 +97,7 @@ public actionResult(id, key)
 public checkVotes(id)
 {
 	id -= 34567
-	new num, ppl[32], a = 0
+	new num, ppl[MAX_PLAYERS], a = 0
 	
 	get_players(ppl, num, "c")
 	if (num == 0) num = 1
@@ -334,7 +334,7 @@ public actionVoteMapMenu(id, key)
 			set_task(vote_time, "checkVotes", 34567 + id)
 
 			new menuBody[512]
-			new players[32]
+			new players[MAX_PLAYERS]
 			new pnum, keys, len
 
 			get_players(players, pnum)

--- a/plugins/menufront.sma
+++ b/plugins/menufront.sma
@@ -20,7 +20,7 @@
 #define MENUITEMSPERPAGE	8
 //#define MENUS_NUMBER 16
 
-new g_menuPosition[MAX_PLAYERS]
+new g_menuPosition[MAX_PLAYERS + 1]
 new g_menusNumber = 0
 new g_menuBody[MAXMENUS][STRINGSIZE]
 new bool:g_menuBodyPhrase[MAXMENUS]
@@ -30,7 +30,7 @@ new g_menuPlugin[MAXMENUS][STRINGSIZE]
 
 new g_coloredMenus
 
-new g_clientMenuPosition[MAX_PLAYERS]
+new g_clientMenuPosition[MAX_PLAYERS + 1]
 new g_clientMenusNumber = 0
 new g_clientMenuBody[MAXMENUS][STRINGSIZE]
 new bool:g_clientMenuBodyPhrase[MAXMENUS]

--- a/plugins/multilingual.sma
+++ b/plugins/multilingual.sma
@@ -14,7 +14,7 @@
 #include <amxmodx>
 #include <amxmisc>
 
-new g_menuLang[MAX_PLAYERS]
+new g_menuLang[MAX_PLAYERS + 1]
 new g_langNum
 new g_coloredMenus
 

--- a/plugins/ns/idlekicker.sma
+++ b/plugins/ns/idlekicker.sma
@@ -19,10 +19,10 @@
 #define CHECK_FREQ		5			// This is also the warning message frequency.
 #define CLASS_GESTATE	9
 
-new g_oldangles[MAX_PLAYERS][3]
-new g_idletime[MAX_PLAYERS]
-new bool:g_spawned[MAX_PLAYERS] = {true, ...}
-new g_class[MAX_PLAYERS]	// stored info from the "ScoreInfo" message
+new g_oldangles[MAX_PLAYERS + 1][3]
+new g_idletime[MAX_PLAYERS + 1]
+new bool:g_spawned[MAX_PLAYERS + 1] = {true, ...}
+new g_class[MAX_PLAYERS + 1]	// stored info from the "ScoreInfo" message
 
 new mp_tournamentmode;
 new amx_idle_time;
@@ -129,17 +129,9 @@ public delayedSpawn(sid[]) {
 
 public msgScoreInfo() {
   new id=read_data(1);
-  if (id>32||id<1) {
-    // just incase..
-    return;
-  }
   g_class[id]=read_data(5);
 }
 public msgScoreInfo32() {
   new id=read_data(1);
-  if (id>32||id<1) {
-    // just incase..
-    return;
-  }
   g_class[id]=read_data(6);
 }

--- a/plugins/ns/nextmap.sma
+++ b/plugins/ns/nextmap.sma
@@ -115,7 +115,7 @@ public getNextValidMap(szNextMap[]) {
 		while(looped < 2) {
 			new minPlayers = g_mapCycle[g_nextPos][MIN]
 			new maxPlayers = g_mapCycle[g_nextPos][MAX]
-			if (maxPlayers == 0) maxPlayers = 32
+			if (maxPlayers == 0) maxPlayers = MAX_PLAYERS
 			if (minPlayers <= g_numPlayers <= maxPlayers) break
 			if (minPlayers <= curNumPlayers <= maxPlayers) {
 				g_numPlayers = curNumPlayers
@@ -215,9 +215,9 @@ readMapCycle() {
 			new szKey1[11], szKey2[11], szValue1[3], szValue2[3]
 			parse(szMapPlayerNum, szKey1, charsmax(szKey1), szValue1, charsmax(szValue1), szKey2, charsmax(szKey2), szValue2, charsmax(szValue2))
 			if (equal(szKey1, "minplayers"))
-				g_mapCycle[g_numMaps][MIN] = clamp(str_to_num(szValue1), 0, 32)
+				g_mapCycle[g_numMaps][MIN] = clamp(str_to_num(szValue1), 0, MAX_PLAYERS)
 			if (equal(szKey2, "maxplayers"))
-				g_mapCycle[g_numMaps][MAX] = clamp(str_to_num(szValue2), 0, 32)
+				g_mapCycle[g_numMaps][MAX] = clamp(str_to_num(szValue2), 0, MAX_PLAYERS)
 
 			if (++g_numMaps == MAX_MAPS) break
 		}

--- a/plugins/ns/nscommands.sma
+++ b/plugins/ns/nscommands.sma
@@ -50,9 +50,8 @@ enum {
   TEAM_SPECTATOR
 };
 
-
-new g_Class[MAX_PLAYERS]; // stored info from the "ScoreInfo" message
-new g_Team[MAX_PLAYERS];
+new g_Class[MAX_PLAYERS + 1] = {0, ...}; // stored info from the "ScoreInfo" message
+new g_Team[MAX_PLAYERS + 1] = {1, ...};
 
 new g_ScoreInfo_Class;
 new g_ScoreInfo_Team;
@@ -80,14 +79,6 @@ public plugin_init() {
   register_concmd("amx_random","cmdRandom",ADMIN_LEVEL_H,"<name or #userid> - omit to do all in rr");
   register_concmd("amx_readyroom","cmdReadyRoom",ADMIN_LEVEL_H,"<name or #userid> - omit to do everybody");
 
-  // clear class info..
-  new i=0;
-  while (i<MAX_PLAYERS) {
-    g_Class[i]=0;
-    g_Team[i]=-1;
-    i++;
-  }
-  
   if (cvar_exists("sv_structurelimit"))
   {
     // ns 3.2 beta
@@ -106,10 +97,6 @@ public plugin_init() {
 }
 public msgScoreInfo() {
   new id=read_data(1);
-  if (id>32||id<1) {
-    // just incase..
-    return;
-  }
   g_Class[id]=read_data(g_ScoreInfo_Class);
   g_Team[id]=read_data(g_ScoreInfo_Team);
 }
@@ -123,7 +110,7 @@ public client_connect(id) {
 }
 stock UTIL_FindCommander() {
   new i=1;
-  while (i<MAX_PLAYERS) {
+  while (i<=MAX_PLAYERS) {
     if (g_Class[i]==PLAYERCLASS_COMMANDER) // this player is comm..
       return i;
     i++;

--- a/plugins/ns/plmenu.sma
+++ b/plugins/ns/plmenu.sma
@@ -16,7 +16,7 @@
 #include <ns>
 
 new g_menuPosition[MAX_PLAYERS + 1]
-new g_menuPlayers[MAX_PLAYERS + 1][32]
+new g_menuPlayers[MAX_PLAYERS + 1][MAX_PLAYERS]
 new g_menuPlayersNum[MAX_PLAYERS + 1]
 new g_menuOption[MAX_PLAYERS + 1]
 new g_menuSettings[MAX_PLAYERS + 1]

--- a/plugins/ns/plmenu.sma
+++ b/plugins/ns/plmenu.sma
@@ -15,14 +15,14 @@
 #include <amxmisc>
 #include <ns>
 
-new g_menuPosition[MAX_PLAYERS]
-new g_menuPlayers[MAX_PLAYERS][32]
-new g_menuPlayersNum[MAX_PLAYERS]
-new g_menuOption[MAX_PLAYERS]
-new g_menuSettings[MAX_PLAYERS]
+new g_menuPosition[MAX_PLAYERS + 1]
+new g_menuPlayers[MAX_PLAYERS + 1][32]
+new g_menuPlayersNum[MAX_PLAYERS + 1]
+new g_menuOption[MAX_PLAYERS + 1]
+new g_menuSettings[MAX_PLAYERS + 1]
 
-new g_menuSelect[MAX_PLAYERS][64]
-new g_menuSelectNum[MAX_PLAYERS]
+new g_menuSelect[MAX_PLAYERS + 1][64]
+new g_menuSelectNum[MAX_PLAYERS + 1]
 
 #define MAX_CLCMDS 24
 

--- a/plugins/ns/unstuck.sma
+++ b/plugins/ns/unstuck.sma
@@ -18,7 +18,7 @@
 #define MAX_ATTEMPTS		128			// How many times to search in an area for a free space
 #define BLOCKED_MASKS		MASK_PLAYER_STUNNED | MASK_ENSNARED | MASK_ALIEN_EMBRYO
 
-new Float:g_lastcmdtime[MAX_PLAYERS]
+new Float:g_lastcmdtime[MAX_PLAYERS + 1]
 
 new amx_unstuck_frequency;
 

--- a/plugins/pausecfg.sma
+++ b/plugins/pausecfg.sma
@@ -21,7 +21,7 @@
 
 #define MAX_SYSTEM 32
  
-new g_menuPos[MAX_PLAYERS]
+new g_menuPos[MAX_PLAYERS + 1]
 new g_fileToSave[64]
 new g_coloredMenus
 new g_Modified

--- a/plugins/plmenu.sma
+++ b/plugins/plmenu.sma
@@ -19,14 +19,14 @@
 #include <cstrike>
 #include <fakemeta>
 
-new g_menuPosition[MAX_PLAYERS];
-new g_menuPlayers[MAX_PLAYERS][32];
-new g_menuPlayersNum[MAX_PLAYERS];
-new g_menuOption[MAX_PLAYERS];
-new g_menuSettings[MAX_PLAYERS];
+new g_menuPosition[MAX_PLAYERS + 1];
+new g_menuPlayers[MAX_PLAYERS + 1][32];
+new g_menuPlayersNum[MAX_PLAYERS + 1];
+new g_menuOption[MAX_PLAYERS + 1];
+new g_menuSettings[MAX_PLAYERS + 1];
 
-new g_menuSelect[MAX_PLAYERS][64];
-new g_menuSelectNum[MAX_PLAYERS];
+new g_menuSelect[MAX_PLAYERS + 1][64];
+new g_menuSelectNum[MAX_PLAYERS + 1];
 
 #define MAX_CLCMDS 24
 
@@ -58,7 +58,7 @@ new g_CSTeamiNumbers[3] = {
 	3
 };
 
-new g_CSPlayerCanSwitchFromSpec[MAX_PLAYERS];
+new g_CSPlayerCanSwitchFromSpec[MAX_PLAYERS + 1];
 new g_transferingAdmin;
 
 new allow_spectators, mp_limitteams;
@@ -66,7 +66,7 @@ new allow_spectators, mp_limitteams;
 new p_amx_tempban_maxtime;
 new Trie:g_tempBans;
 
-new g_silent[MAX_PLAYERS];
+new g_silent[MAX_PLAYERS + 1];
 
 public plugin_natives()
 {

--- a/plugins/plmenu.sma
+++ b/plugins/plmenu.sma
@@ -20,7 +20,7 @@
 #include <fakemeta>
 
 new g_menuPosition[MAX_PLAYERS + 1];
-new g_menuPlayers[MAX_PLAYERS + 1][32];
+new g_menuPlayers[MAX_PLAYERS + 1][MAX_PLAYERS];
 new g_menuPlayersNum[MAX_PLAYERS + 1];
 new g_menuOption[MAX_PLAYERS + 1];
 new g_menuSettings[MAX_PLAYERS + 1];

--- a/plugins/pluginmenu.sma
+++ b/plugins/pluginmenu.sma
@@ -20,25 +20,25 @@ new DisabledCallback;
 new EnabledCallback;
 
 // pcvar that the client is currently modifying
-new CurrentCvar[MAX_PLAYERS];
+new CurrentCvar[MAX_PLAYERS + 1];
 
 // Name of the cvar being modified
-new CurrentCvarName[MAX_PLAYERS][32];
+new CurrentCvarName[MAX_PLAYERS + 1][32];
 
 // Plugin ID that the client is modifying
-new CurrentPlid[MAX_PLAYERS];
+new CurrentPlid[MAX_PLAYERS + 1];
 
 // Page that the client is currently on
-new CurrentPage[MAX_PLAYERS];
+new CurrentPage[MAX_PLAYERS + 1];
 
 // Menu function ID that the client is in
-new CurrentMenuFunction[MAX_PLAYERS] = { -1,... };
+new CurrentMenuFunction[MAX_PLAYERS + 1] = { -1,... };
 
-new CurrentCommand[MAX_PLAYERS][32];
+new CurrentCommand[MAX_PLAYERS + 1][32];
 new cvarmenu_cmdid;
 new cmdmenu_cmdid;
 
-new ExplicitPlugin[MAX_PLAYERS];
+new ExplicitPlugin[MAX_PLAYERS + 1];
 
 public plugin_init()
 {

--- a/plugins/statscfg.sma
+++ b/plugins/statscfg.sma
@@ -20,7 +20,7 @@ new g_menuData[MAX_MENU_DATA][32]
 new g_menuDataVar[MAX_MENU_DATA][32]
 new g_menuDataId[MAX_MENU_DATA]
 new g_menuDataNum
-new g_menuPosition[MAX_PLAYERS]
+new g_menuPosition[MAX_PLAYERS + 1]
 new g_fileToSave[64]
 new bool:g_modified
 new g_coloredMenus

--- a/plugins/telemenu.sma
+++ b/plugins/telemenu.sma
@@ -16,7 +16,7 @@
 #include <fakemeta>
 
 new g_menuPosition[MAX_PLAYERS + 1]
-new g_menuPlayers[MAX_PLAYERS + 1][32]
+new g_menuPlayers[MAX_PLAYERS + 1][MAX_PLAYERS]
 new g_menuPlayersNum[MAX_PLAYERS + 1]
 new g_menuOption[MAX_PLAYERS + 1] = {-1, ...}
 new Float:g_menuOrigin[MAX_PLAYERS + 1][3]

--- a/plugins/telemenu.sma
+++ b/plugins/telemenu.sma
@@ -15,12 +15,12 @@
 #include <amxmisc>
 #include <fakemeta>
 
-new g_menuPosition[MAX_PLAYERS]
-new g_menuPlayers[MAX_PLAYERS][32]
-new g_menuPlayersNum[MAX_PLAYERS]
-new g_menuOption[MAX_PLAYERS] = {-1, ...}
-new Float:g_menuOrigin[MAX_PLAYERS][3]
-new Float:g_menuVAngle[MAX_PLAYERS][3]
+new g_menuPosition[MAX_PLAYERS + 1]
+new g_menuPlayers[MAX_PLAYERS + 1][32]
+new g_menuPlayersNum[MAX_PLAYERS + 1]
+new g_menuOption[MAX_PLAYERS + 1] = {-1, ...}
+new Float:g_menuOrigin[MAX_PLAYERS + 1][3]
+new Float:g_menuVAngle[MAX_PLAYERS + 1][3]
 new g_coloredMenus
 
 new g_bDuckingStateSaved

--- a/plugins/tfc/plmenu.sma
+++ b/plugins/tfc/plmenu.sma
@@ -16,7 +16,7 @@
 #include <tfcx>
 
 new g_menuPosition[MAX_PLAYERS + 1]
-new g_menuPlayers[MAX_PLAYERS + 1][32]
+new g_menuPlayers[MAX_PLAYERS + 1][MAX_PLAYERS]
 new g_menuPlayersNum[MAX_PLAYERS + 1]
 new g_menuOption[MAX_PLAYERS + 1]
 new g_menuSettings[MAX_PLAYERS + 1]

--- a/plugins/tfc/plmenu.sma
+++ b/plugins/tfc/plmenu.sma
@@ -15,14 +15,14 @@
 #include <amxmisc>
 #include <tfcx>
 
-new g_menuPosition[MAX_PLAYERS]
-new g_menuPlayers[MAX_PLAYERS][32]
-new g_menuPlayersNum[MAX_PLAYERS]
-new g_menuOption[MAX_PLAYERS]
-new g_menuSettings[MAX_PLAYERS]
+new g_menuPosition[MAX_PLAYERS + 1]
+new g_menuPlayers[MAX_PLAYERS + 1][32]
+new g_menuPlayersNum[MAX_PLAYERS + 1]
+new g_menuOption[MAX_PLAYERS + 1]
+new g_menuSettings[MAX_PLAYERS + 1]
 
-new g_menuSelect[MAX_PLAYERS][64]
-new g_menuSelectNum[MAX_PLAYERS]
+new g_menuSelect[MAX_PLAYERS + 1][64]
+new g_menuSelectNum[MAX_PLAYERS + 1]
 
 #define MAX_CLCMDS 24
 

--- a/plugins/tfc/stats.sma
+++ b/plugins/tfc/stats.sma
@@ -55,20 +55,20 @@ public DoubleKill
 public DoubleKillSound
 public BulletDamage
 
-new g_streakKills[MAX_PLAYERS][2]
-new g_multiKills[MAX_PLAYERS][2]
+new g_streakKills[MAX_PLAYERS + 1][2]
+new g_multiKills[MAX_PLAYERS + 1][2]
 new Float:g_prevKill
 new g_prevKillerId
 new g_KillCount;
 
-new g_userPosition[MAX_PLAYERS]
-new g_userState[MAX_PLAYERS]
-new g_userPlayers[MAX_PLAYERS][32]
+new g_userPosition[MAX_PLAYERS + 1]
+new g_userState[MAX_PLAYERS + 1]
+new g_userPlayers[MAX_PLAYERS + 1][32]
 new g_Buffer[2048]
 
 
-new g_Killers[MAX_PLAYERS][4]
-new Float:g_DeathStats[MAX_PLAYERS]
+new g_Killers[MAX_PLAYERS + 1][4]
+new Float:g_DeathStats[MAX_PLAYERS + 1]
 
 new g_center1_sync
 new g_center2_sync
@@ -286,14 +286,14 @@ getTop15(){
 
 public endGameStats(){
   if ( EndPlayer ){
-    new players[32], inum
+    new players[MAX_PLAYERS], inum
     get_players(players,inum)
     for(new i = 0; i < inum; ++i){
       displayStats(players[i],players[i])
     }
   } 
   else if ( EndTop15 ){
-    new players[32], inum
+    new players[MAX_PLAYERS], inum
     get_players(players,inum)
     getTop15()
     for(new i = 0; i < inum; ++i)

--- a/plugins/tfc/stats.sma
+++ b/plugins/tfc/stats.sma
@@ -63,7 +63,7 @@ new g_KillCount;
 
 new g_userPosition[MAX_PLAYERS + 1]
 new g_userState[MAX_PLAYERS + 1]
-new g_userPlayers[MAX_PLAYERS + 1][32]
+new g_userPlayers[MAX_PLAYERS + 1][MAX_PLAYERS]
 new g_Buffer[2048]
 
 

--- a/plugins/tfc/stats_logging.sma
+++ b/plugins/tfc/stats_logging.sma
@@ -14,8 +14,8 @@
 #include <amxmodx>
 #include <tfcx>
 
-new g_pingSum[MAX_PLAYERS]
-new g_pingCount[MAX_PLAYERS]
+new g_pingSum[MAX_PLAYERS + 1]
+new g_pingCount[MAX_PLAYERS + 1]
 
 public plugin_init()
   register_plugin("TFC Stats Logging",AMXX_VERSION_STR,"AMXX Dev Team")

--- a/plugins/timeleft.sma
+++ b/plugins/timeleft.sma
@@ -245,7 +245,7 @@ public timeRemain(param[])
 			
 			if (flags & TD_BOTTOM_WHITE_TEXT)
 			{
-				new players[32], pnum, plr
+				new players[MAX_PLAYERS], pnum, plr
 				
 				get_players(players, pnum, "c")
 

--- a/plugins/ts/stats.sma
+++ b/plugins/ts/stats.sma
@@ -57,12 +57,12 @@ public BulletDamage
 public TAInfo
 public FragInfo 
 
-new g_userPosition[MAX_PLAYERS]
-new g_userState[MAX_PLAYERS]
-new g_userPlayers[MAX_PLAYERS][32]
+new g_userPosition[MAX_PLAYERS + 1]
+new g_userState[MAX_PLAYERS + 1]
+new g_userPlayers[MAX_PLAYERS + 1][32]
 new g_Buffer[2048]
-new g_Killers[MAX_PLAYERS][3] 
-new Float:g_DeathStats[MAX_PLAYERS]
+new g_Killers[MAX_PLAYERS + 1][3] 
+new Float:g_DeathStats[MAX_PLAYERS + 1]
 
 new g_center1_sync
 new g_damage_sync
@@ -231,13 +231,13 @@ getTop15(){
 
 public endGameStats(){
   if ( EndPlayer ){
-    new players[32], inum
+    new players[MAX_PLAYERS], inum
     get_players(players,inum)
     for(new i = 0; i < inum; ++i)
       displayStats(players[i],players[i])
   } 
   else if ( EndTop15 ) {
-    new players[32], inum
+    new players[MAX_PLAYERS], inum
     get_players(players,inum)
     getTop15()
     for(new i = 0; i < inum; ++i)

--- a/plugins/ts/stats.sma
+++ b/plugins/ts/stats.sma
@@ -59,7 +59,7 @@ public FragInfo
 
 new g_userPosition[MAX_PLAYERS + 1]
 new g_userState[MAX_PLAYERS + 1]
-new g_userPlayers[MAX_PLAYERS + 1][32]
+new g_userPlayers[MAX_PLAYERS + 1][MAX_PLAYERS]
 new g_Buffer[2048]
 new g_Killers[MAX_PLAYERS + 1][3] 
 new Float:g_DeathStats[MAX_PLAYERS + 1]

--- a/plugins/ts/stats_logging.sma
+++ b/plugins/ts/stats_logging.sma
@@ -16,8 +16,8 @@
 #include <tsx>
 #include <tsfun>
 
-new g_pingSum[MAX_PLAYERS]
-new g_pingCount[MAX_PLAYERS]
+new g_pingSum[MAX_PLAYERS + 1]
+new g_pingCount[MAX_PLAYERS + 1]
 
 public plugin_init()
   register_plugin("Stats Logging",AMXX_VERSION_STR,"AMXX Dev Team")


### PR DESCRIPTION
It would seem that value set to `33` appears to be uncomfortable for people. 

Usually this define is always declared with `32` in plugins, because it's the technical limit, and a new player's array with `MAX_PLAYERS + 1`. There is nothing wrong doing `+ 1` and it explicits why we do that. Also, `32` can be used on others places, making the change a bit unwelcomed..

Let's revert to `32` which makes more sense in HL1/AMXX context.