### PR TITLE
Cstrike: Fix crash at server start

### DIFF
--- a/dlls/cstrike/cstrike/amxx_api.cpp
+++ b/dlls/cstrike/cstrike/amxx_api.cpp
@@ -61,9 +61,6 @@ void OnAmxxAttach()
 	{
 		MF_Log("UTIL_FindEntByString is not available - native cs_find_ent_by_class() has been disabled");
 	}
-
-	// Search pev offset automatically.
-	G_OffsetHandler = new OffsetHandler;
 }
 
 void OnPluginsLoaded()
@@ -81,6 +78,12 @@ void OnPluginsLoaded()
 	// And enable/disable detours when necessary.
 	ToggleDetour_ClientCommands(ForwardInternalCommand != -1 || ForwardOnBuy != -1 || ForwardOnBuy != -1);
 	ToggleDetour_BuyCommands(ForwardOnBuy != -1);
+
+	// Search pev offset automatically.
+	if (!G_OffsetHandler)
+	{
+		G_OffsetHandler = new OffsetHandler;
+	}
 }
 
 void OnAmxxDetach()


### PR DESCRIPTION
Related to #189.

@stambeto2006 reported a crash at server start.
Searching `pev` offset (which calls `INDEXENT(0)`) on AMXX attach seemed to be too soon depending server.

Patch moves code on plugins loaded.