### PR TITLE
Fix missing libm linkage under linux (math functions like floor, etc.)

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -230,7 +230,7 @@ class AMXXConfig(object):
     # Platform-specifics
     if builder.target_platform == 'linux':
       cfg.defines += ['_LINUX', 'POSIX', 'LINUX']
-      cfg.postlink += ['-ldl']
+      cfg.postlink += ['-ldl', '-lm']
       if cxx.name == 'gcc':
         cfg.postlink += ['-static-libgcc']
       elif cxx.name == 'clang':


### PR DESCRIPTION
Some people seem to have some trouble under linux to load AMXX and get such error `undefined symbol: floorf`. The use of some math functions like `floor` adds a dependency of `libm` which seems to be absent in AMBuild script. 

On side not, `-lm` linkage is present in `MakeFile`! 



