### PR TITLE
>> FIXED lookupString() LENGTH ISSUE

### DIFF
--- a/dlls/geoip/geoip_util.cpp
+++ b/dlls/geoip/geoip_util.cpp
@@ -166,6 +166,9 @@ const char *lookupString(const char *ip, const char **path, int *length)
 
 	if (!lookupByIp(ip, path, &result))
 	{
+		if (length)
+			*length = 0;
+
 		return NULL;
 	}
 


### PR DESCRIPTION
In (const char *) lookupString() :
For (const char *) NULL result :
- Length must be ZERO, if defined.