### PR TITLE
Set length to 0 on failed lookup in lookupString()

### DIFF
--- a/dlls/geoip/Makefile
+++ b/dlls/geoip/Makefile
@@ -15,7 +15,7 @@ PUBLIC_ROOT = ../../public
 
 PROJECT = geoip
 
-OBJECTS = amxxmodule.cpp GeoIP2/maxminddb.cpp geoip_main.cpp geoip_natives.cpp geoip_util.cpp
+OBJECTS = amxxmodule.cpp GeoIP2/maxminddb.c geoip_main.cpp geoip_natives.cpp geoip_util.cpp
 
 ##############################################
 ### CONFIGURE ANY OTHER FLAGS/OPTIONS HERE ###

--- a/dlls/geoip/geoip_util.cpp
+++ b/dlls/geoip/geoip_util.cpp
@@ -166,6 +166,9 @@ const char *lookupString(const char *ip, const char **path, int *length)
 
 	if (!lookupByIp(ip, path, &result))
 	{
+		if (length)
+			*length = 0;
+
 		return NULL;
 	}
 

--- a/dlls/geoip/msvc12/geoip.vcxproj
+++ b/dlls/geoip/msvc12/geoip.vcxproj
@@ -98,7 +98,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\GeoIP2\maxminddb.cpp" />
+    <ClCompile Include="..\GeoIP2\maxminddb.c" />
     <ClCompile Include="..\geoip_main.cpp" />
     <ClCompile Include="..\geoip_natives.cpp" />
     <ClCompile Include="..\geoip_util.cpp" />

--- a/dlls/geoip/msvc12/geoip.vcxproj.filters
+++ b/dlls/geoip/msvc12/geoip.vcxproj.filters
@@ -23,7 +23,7 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\GeoIP2\maxminddb.cpp">
+    <ClCompile Include="..\GeoIP2\maxminddb.c">
       <Filter>GeoIP2</Filter>
     </ClCompile>
     <ClCompile Include="..\geoip_util.cpp">


### PR DESCRIPTION
In (const char *) lookupString() :
For (const char *) NULL result :

Length must be ZERO, if involved.

Also, renamed "maxminddb.cpp" to "maxminddb.c" inside Project's CFGs.