### PR TITLE
Fix SQL Modules Threading

### DIFF
--- a/dlls/mysqlx/AMBuilder
+++ b/dlls/mysqlx/AMBuilder
@@ -27,7 +27,7 @@ if AMXX.mysql_path:
     binary.compiler.linkflags += [
       os.path.join(AMXX.mysql_path, 'lib', 'opt', 'mysqlclient.lib'),
       os.path.join(AMXX.mysql_path, 'lib', 'opt', 'zlib.lib'),
-      'wsock32.lib'
+      'ws2_32.lib'
     ]
 
   binary.sources = [

--- a/dlls/mysqlx/msvc12/mysqlx.vcxproj
+++ b/dlls/mysqlx/msvc12/mysqlx.vcxproj
@@ -66,8 +66,8 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>wsock32.lib;..\..\..\..\mysql-5.0\lib\opt\mysqlclient.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <IgnoreSpecificDefaultLibraries>LIBCMT;LIBCMT;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
+      <AdditionalDependencies>ws2_32.lib;..\..\..\..\mysql-5.0\lib\opt\mysqlclient.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <IgnoreSpecificDefaultLibraries>LIBCMT;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>$(OutDir)mysql2.pdb</ProgramDatabaseFile>
       <SubSystem>Windows</SubSystem>
@@ -88,7 +88,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>wsock32.lib;..\..\..\..\mysql-5.0\lib\opt\mysqlclient.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;..\..\..\..\mysql-5.0\lib\opt\mysqlclient.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>

--- a/dlls/mysqlx/mysql/MysqlHeaders.h
+++ b/dlls/mysqlx/mysql/MysqlHeaders.h
@@ -30,7 +30,7 @@
 
 #include <ISQLDriver.h>
 #if defined WIN32 || defined _WIN32
-#include <winsock.h>
+#include <WinSock2.h>
 #endif
 typedef unsigned long ulong;
 #include <mysql.h>

--- a/dlls/mysqlx/thread/ThreadWorker.h
+++ b/dlls/mysqlx/thread/ThreadWorker.h
@@ -12,7 +12,7 @@
 
 #include "BaseWorker.h"
 
-#define DEFAULT_THINK_TIME_MS	200
+#define DEFAULT_THINK_TIME_MS	25
 
 class ThreadWorker : public BaseWorker, public IThread
 {

--- a/dlls/mysqlx/threading.cpp
+++ b/dlls/mysqlx/threading.cpp
@@ -29,6 +29,8 @@ void ShutdownThreading()
 {
 	if (g_pWorker)
 	{
+		// Flush all the remaining job fast!
+		g_pWorker->SetMaxThreadsPerFrame(8192);
 		g_pWorker->Stop(true);
 		delete g_pWorker;
 		g_pWorker = NULL;
@@ -316,7 +318,7 @@ void OnPluginsLoaded()
 		g_QueueLock = g_Threader.MakeMutex();
 	}
 
-	g_pWorker = new ThreadWorker(&g_Threader, 250);
+	g_pWorker = new ThreadWorker(&g_Threader, DEFAULT_THINK_TIME_MS);
 	if (!g_pWorker->Start())
 	{
 		delete g_pWorker;
@@ -333,7 +335,7 @@ void StartFrame()
 {
 	if (g_pWorker && (g_lasttime < gpGlobals->time))
 	{
-        g_lasttime = gpGlobals->time + 0.05f;
+		g_lasttime = gpGlobals->time + 0.025f;
 		g_QueueLock->Lock();
 		size_t remaining = g_ThreadQueue.size();
 		if (remaining)
@@ -364,6 +366,8 @@ void OnPluginsUnloading()
 		return;
 	}
 
+	// Flush all the remaining job fast!
+	g_pWorker->SetMaxThreadsPerFrame(8192);
 	g_pWorker->Stop(false);
 	delete g_pWorker;
 	g_pWorker = NULL;

--- a/dlls/sqlite/thread/ThreadWorker.h
+++ b/dlls/sqlite/thread/ThreadWorker.h
@@ -12,7 +12,7 @@
 
 #include "BaseWorker.h"
 
-#define DEFAULT_THINK_TIME_MS	500
+#define DEFAULT_THINK_TIME_MS	25
 
 class ThreadWorker : public BaseWorker, public IThread
 {

--- a/dlls/sqlite/threading.cpp
+++ b/dlls/sqlite/threading.cpp
@@ -28,6 +28,8 @@ void ShutdownThreading()
 {
 	if (g_pWorker)
 	{
+		// Flush all the remaining job fast!
+		g_pWorker->SetMaxThreadsPerFrame(8192);
 		g_pWorker->Stop(true);
 		delete g_pWorker;
 		g_pWorker = NULL;
@@ -293,7 +295,7 @@ void OnPluginsLoaded()
 		g_QueueLock = g_Threader.MakeMutex();
 	}
 
-	g_pWorker = new ThreadWorker(&g_Threader, 250);
+	g_pWorker = new ThreadWorker(&g_Threader, DEFAULT_THINK_TIME_MS);
 	if (!g_pWorker->Start())
 	{
 		delete g_pWorker;
@@ -310,7 +312,7 @@ void StartFrame()
 {
 	if (g_pWorker && (g_lasttime < gpGlobals->time))
 	{
-        g_lasttime = gpGlobals->time + 0.05f;
+		g_lasttime = gpGlobals->time + 0.025f;
 		g_QueueLock->Lock();
 		size_t remaining = g_ThreadQueue.size();
 		if (remaining)
@@ -341,6 +343,8 @@ void OnPluginsUnloading()
 		return;
 	}
 
+	// Flush all the remaining job fast!
+	g_pWorker->SetMaxThreadsPerFrame(8192);
 	g_pWorker->Stop(false);
 	delete g_pWorker;
 	g_pWorker = NULL;


### PR DESCRIPTION
Fix SQL modules threading because of the problem(s) listed below.

* The game server is having problems when too many threaded queries are started and the connection between the game server and the MySQL remote server is lost. Problems consist in 'queueTime' (Float) higher than 5.0 seconds, up to ...

* The server is having problems when map changes (during OnPluginsUnloading() AMX Mod X Core Forward) if the connection is lost or too many threaded queries are started. It just freezes to execute all the remaining threaded queries, and some OS such Linux are killing processes that are frozen for 5-10-15 seconds, unfortunately.

What can I say about my changes?

* Changing the SleepTime (milliseconds) from 250...500 to 25, because SourceMod uses the same (they even use 20 milliseconds).
* Reducing the interval of SQL Threaded Queries check in StartFrame() Meta Mod Forward.
* Making sure so the BaseThreader executes much more threads when OnAmxxDetach and OnPluginsUnloading AMX Mod X Core Forwards are reached so everything is getting flushed amazingly fast when the map ends.
* Also, making sure that everything is going to be executed, even with Internet connection or without.
* Changed WinSock to WinSock2 in MySQL module.

Did I test that?

You can see a SQL Stress Test plug-in I made for myself, I will not include that as a "Test Suite" because it's too abusive.
http://pastebin.com/UZmVhpQA

You can see that even spamming, everything is going to be executed safe.
