### PR TITLE
Change AMX Mod X Lang Files Hash Method

### DIFF
--- a/amxmodx/CLang.cpp
+++ b/amxmodx/CLang.cpp
@@ -318,15 +318,15 @@ void reparse_color(String* def)
 // -- BAILOPAN
 int CLangMngr::MergeDefinitionFile(const char *file)
 {
-	const char* md5buffer = hashFile(file, Hash_Md5);
-	if (!md5buffer)
+	const char* hashBuffer = hashFile(file, Hash_Crc32);
+	if (!hashBuffer)
 	{
-		CVector<md5Pair *>::iterator iter;
+		CVector<CRC32Pair *>::iterator iter;
 		for (iter = FileList.begin(); iter != FileList.end(); ++iter)
 		{
 			if ((*iter)->file.compare(file) == 0)
 			{
-				char buf[33] = {0};
+				char buf[8 /* CRC32 Length */ + 1] = { 0 };
 				(*iter)->val.assign(buf);
 				break;
 			}	
@@ -337,16 +337,16 @@ int CLangMngr::MergeDefinitionFile(const char *file)
 	
 	bool foundFlag = false;
 	
-	CVector<md5Pair *>::iterator iter;
+	CVector<CRC32Pair *>::iterator iter;
 	for (iter = FileList.begin(); iter != FileList.end(); ++iter)
 	{
 		if ((*iter)->file.compare(file) == 0)
 		{
-			if ((*iter)->val.compare(md5buffer) == 0)
+			if ((*iter)->val.compare(hashBuffer) == 0)
 			{
 				return -1;
 			} else {
-				(*iter)->val.assign(md5buffer);
+				(*iter)->val.assign(hashBuffer);
 				break;
 			}
 			foundFlag = true;
@@ -355,9 +355,9 @@ int CLangMngr::MergeDefinitionFile(const char *file)
 
 	if (!foundFlag)
 	{
-		md5Pair *p = new md5Pair;
+		CRC32Pair *p = new CRC32Pair;
 		p->file.assign(file);
-		p->val.assign(md5buffer);
+		p->val.assign(hashBuffer);
 		FileList.push_back(p);
 	}
 

--- a/amxmodx/CLang.h
+++ b/amxmodx/CLang.h
@@ -11,6 +11,7 @@
 #define _INCLUDE_CLANG_H
 
 #include "sh_tinyhash.h"
+#include "sm_stringhashmap.h"
 
 #define LANG_SERVER 0
 #define LANG_PLAYER -1
@@ -118,7 +119,7 @@ private:
 	
 	LangVec m_Languages;
 
-	CVector<CRC32Pair *> FileList;
+	StringHashMap<time_t> FileList;
 	CVector<String *> KeyList;
 	THash<String, keytbl_val> KeyTable;
 

--- a/amxmodx/CLang.h
+++ b/amxmodx/CLang.h
@@ -18,7 +18,7 @@
 #define ERR_BADKEY	1	// Lang key not found
 #define ERR_BADLANG 2	// Invalid lang
 
-struct md5Pair
+struct CRC32Pair
 {
 	String file;
 	String val;
@@ -118,7 +118,7 @@ private:
 	
 	LangVec m_Languages;
 
-	CVector<md5Pair *> FileList;
+	CVector<CRC32Pair *> FileList;
 	CVector<String *> KeyList;
 	THash<String, keytbl_val> KeyTable;
 

--- a/dlls/mysqlx/threading.cpp
+++ b/dlls/mysqlx/threading.cpp
@@ -333,7 +333,7 @@ void StartFrame()
 {
 	if (g_pWorker && (g_lasttime < gpGlobals->time))
 	{
-        g_lasttime = gpGlobals->time + 0.05f;
+		g_lasttime = gpGlobals->time + 0.05f;
 		g_QueueLock->Lock();
 		size_t remaining = g_ThreadQueue.size();
 		if (remaining)

--- a/dlls/sqlite/threading.cpp
+++ b/dlls/sqlite/threading.cpp
@@ -310,7 +310,7 @@ void StartFrame()
 {
 	if (g_pWorker && (g_lasttime < gpGlobals->time))
 	{
-        g_lasttime = gpGlobals->time + 0.05f;
+		g_lasttime = gpGlobals->time + 0.05f;
 		g_QueueLock->Lock();
 		size_t remaining = g_ThreadQueue.size();
 		if (remaining)


### PR DESCRIPTION
Change AMX Mod X Language Files hashing method from MD5 to CRC32 because it is 2x or even 3x faster and more reliable for that type of hash. Not for security, but for comparing files' content difference.