### PR TITLE
Fix ArrayDestroy/DestroyStack erroring on invalid handle

### DIFF
--- a/amxmodx/datastructs.cpp
+++ b/amxmodx/datastructs.cpp
@@ -661,6 +661,12 @@ static cell AMX_NATIVE_CALL ArrayDeleteItem(AMX* amx, cell* params)
 static cell AMX_NATIVE_CALL ArrayDestroy(AMX* amx, cell* params)
 {
 	cell* handle = get_amxaddr(amx, params[1]);
+
+	if (*handle == 0)
+	{
+		return 0;
+	}
+
 	CellArray* vec = HandleToVector(amx, *handle);
 
 	if (vec == NULL)

--- a/amxmodx/stackstructs.cpp
+++ b/amxmodx/stackstructs.cpp
@@ -241,6 +241,12 @@ static cell AMX_NATIVE_CALL IsStackEmpty(AMX* amx, cell* params)
 static cell AMX_NATIVE_CALL DestroyStack(AMX* amx, cell* params)
 {
 	cell *handle = get_amxaddr(amx, params[1]);
+
+	if (*handle == 0)
+	{
+		return 0;
+	}
+
 	CellArray *vec = HandleToVector(amx, *handle);
 
 	if (vec == NULL)


### PR DESCRIPTION
Allow passing 0/Invalid_* to ArrayDestroy and DestroyStack because it makes sense (and in the case of ArrayDestroy is also legacy behavior, so a must). Updated documentation lands with #208