### PR TITLE
Fix issue where at mapchange a cvar current value is overwritten by defined bounds where it should not

### DIFF
--- a/amxmodx/CvarManager.h
+++ b/amxmodx/CvarManager.h
@@ -78,17 +78,12 @@ struct CvarBind
 
 struct CvarBound
 {
-	CvarBound(bool hasMin_, float minVal_, bool hasMax_, float maxVal_, int minPluginId_, int maxPluginId_)
-		:
-		hasMin(hasMin_), minVal(minVal_),
-		hasMax(hasMax_), maxVal(maxVal_),
-		minPluginId(minPluginId_), 
-		maxPluginId(maxPluginId_) {};
-
 	CvarBound()
 		:
 		hasMin(false), minVal(0), 
-		hasMax(false), maxVal(0) {};
+		hasMax(false), maxVal(0),
+		minPluginId(-1),
+		maxPluginId(-1) {};
 
 	bool    hasMin;
 	float   minVal;
@@ -103,13 +98,10 @@ typedef ke::Vector<CvarBind*> CvarsBind;
 
 struct CvarInfo : public ke::InlineListNode<CvarInfo>
 {
-	CvarInfo(const char* name_, const char* helpText, 
-			 bool hasMin_, float min_, bool hasMax_, float max_, 
-			 const char* plugin_, int pluginId_)
+	CvarInfo(const char* name_, const char* helpText, const char* plugin_, int pluginId_)
 		:
 		name(name_), description(helpText),	
-		plugin(plugin_), pluginId(pluginId_),
-		bound(hasMin_, min_, hasMax_, max_, pluginId_, pluginId_) {};
+		plugin(plugin_), pluginId(pluginId_), bound() {};
 
 	CvarInfo(const char* name_)
 		:
@@ -150,19 +142,15 @@ class CvarManager
 
 		void      CreateCvarHook();
 
-		CvarInfo* CreateCvar(const char* name, const char* value, const char* plugin, int pluginId, 
-							 int flags = 0, const char* helpText = "",
-							 bool hasMin = false, float min = 0, 
-							 bool hasMax = false, float max = 0);
-
+		CvarInfo* CreateCvar(const char* name, const char* value, const char* plugin, int pluginId, int flags = 0, const char* helpText = "");
 		CvarInfo* FindCvar(const char* name);
 		CvarInfo* FindCvar(size_t index);
 		bool      CacheLookup(const char* name, CvarInfo** info);
 
 		AutoForward*  HookCvarChange(cvar_t* var, AMX* amx, cell param, const char** callback);
 		bool          BindCvar(CvarInfo* info, CvarBind::CvarType type, AMX* amx, cell varofs, size_t varlen = 0);
-		bool          SetCvarMin(CvarInfo* info, bool set, float value, int pluginId);
-		bool          SetCvarMax(CvarInfo* info, bool set, float value, int pluginId);
+		void          SetCvarMin(CvarInfo* info, bool set, float value, int pluginId);
+		void          SetCvarMax(CvarInfo* info, bool set, float value, int pluginId);
 
 		size_t    GetRegCvarsCount();
 

--- a/amxmodx/cvars.cpp
+++ b/amxmodx/cvars.cpp
@@ -40,17 +40,19 @@ static cell AMX_NATIVE_CALL create_cvar(AMX *amx, cell *params)
 		float minVal = amx_ctof(params[6]);
 		float maxVal = amx_ctof(params[8]);
 
-		if (!g_CvarManager.SetCvarMin(info, hasMin, minVal, plugin->getId()))
+		if (hasMax && minVal > maxVal)
 		{
 			LogError(amx, AMX_ERR_NATIVE, "The minimum value can not be above the maximum value");
 			return 0;
 		}
-
-		if (!g_CvarManager.SetCvarMax(info, hasMax, maxVal, plugin->getId()))
+		else if (hasMin && maxVal < minVal)
 		{
 			LogError(amx, AMX_ERR_NATIVE, "The maximum value can not be below the minimum value");
 			return 0;
 		}
+
+		g_CvarManager.SetCvarMin(info, hasMin, minVal, plugin->getId());
+		g_CvarManager.SetCvarMax(info, hasMax, maxVal, plugin->getId());
 
 		return reinterpret_cast<cell>(info->var);
 	}
@@ -498,20 +500,24 @@ static cell AMX_NATIVE_CALL set_pcvar_bounds(AMX *amx, cell *params)
 	{
 		case CvarBound_Lower:
 		{
-			if (!g_CvarManager.SetCvarMin(info, set, value, pluginId))
+			if (set && info->bound.hasMax && value > info->bound.maxVal)
 			{
 				LogError(amx, AMX_ERR_NATIVE, "The minimum value can not be above the maximum value");
 				return 0;
 			}
+
+			g_CvarManager.SetCvarMin(info, set, value, pluginId);
 			break;
 		}
 		case CvarBound_Upper:
 		{
-			if (!g_CvarManager.SetCvarMax(info, set, value, pluginId))
+			if (set && info->bound.hasMin && value < info->bound.minVal)
 			{
 				LogError(amx, AMX_ERR_NATIVE, "The maximum value can not be below the minimum value");
 				return 0;
 			}
+
+			g_CvarManager.SetCvarMax(info, set, value, pluginId);
 			break;
 		}
 		default:


### PR DESCRIPTION
Reported on the [forum](https://forums.alliedmods.net/showpost.php?p=2263610&postcount=8), related to #185.

If a cvar has bounds defined in `create_cvar`, at map change, even though current value is not out of bounds, cvar was set again with the defined bounds, resulting overwriting the current value.

This is happening because:
* Saved bounds values are reset at map change to reflect any changes in plugin and `SetCvarMin/Max` was relying on these values.
* No checks are done to verify if a value is already in the expected bounds.

Patch refactors a bit some code:
* Since bounds are set after cvar creation, no need to pass such datas `CreateCvar`
* The invalid bounds check is done now in native directly before calling `SetCvarMin/Max`
* A check has been added in `SetCvarMin/Max` to not set cvar if value is already in range.