### PR TITLE
Add gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Tell GitHub that these files are SourcePawn
+*.inc text linguist-language=sourcepawn
+*.sma text linguist-language=sourcepawn
+
+# Custom for Visual Studio
+*.cs diff=csharp
+
+# Sources
+*.C text
+*.cc text
+*.cxx text
+*.cpp text
+*.c++ text
+*.hpp text
+*.h text
+*.h++ text
+*.hh text
+
+# Compiled Object files
+*.o binary
+*.obj binary


### PR DESCRIPTION
This is supposed to normalize line endings (I didn't do it myself because the diff is huge, and I'd rather have this PR be clean). This also tells GitHub that sma and inc files are supposed to be SourcePawn. Sadly it won't affect syntax highlighting because GitHub doesn't support that, but it will affect language stats in repository.

I've also created a PR in GitHub's linguist to detect *.sma files as SourcePawn for syntax highlighting purposes: https://github.com/github/linguist/pull/2218