### PR TITLE
Fix crash under linux in Hamsandwich module (bug 6323)

### DIFF
--- a/modules/hamsandwich/forward.h
+++ b/modules/hamsandwich/forward.h
@@ -16,6 +16,8 @@
 #ifndef FORWARD_H
 #define FORWARD_H
 
+#include <am-refcounting.h>
+
 enum fwdstate
 {
 	FSTATE_INVALID = 0,
@@ -25,7 +27,7 @@ enum fwdstate
 	FSTATE_DESTROY
 };
 
-class Forward
+class Forward :public ke::Refcounted<Forward>
 {
 public:
 	int      id;    // id of the forward

--- a/modules/hamsandwich/hook.h
+++ b/modules/hamsandwich/hook.h
@@ -89,12 +89,12 @@ public:
 
 		for (size_t i = 0; i < pre.length(); ++i)
 		{
-			delete pre.at(i);
+			pre.at(i)->Release();
 		}
 
 		for (size_t i = 0; i < post.length(); ++i)
 		{
-			delete post.at(i);
+			post.at(i)->Release();
 		}
 
 		pre.clear();

--- a/modules/hamsandwich/hook_native.cpp
+++ b/modules/hamsandwich/hook_native.cpp
@@ -583,6 +583,7 @@ static cell AMX_NATIVE_CALL RegisterHam(AMX *amx, cell *params)
 	}
 
 	Forward *pfwd = new Forward(fwd);
+	pfwd->AddRef();
 
 	// We've passed all tests...
 	if (strcmp(classname, "player") == 0 && enableSpecialBot)
@@ -676,6 +677,9 @@ static cell AMX_NATIVE_CALL RegisterHamFromEntity(AMX *amx, cell *params)
 
 	// We've passed all tests...
 
+	Forward *pfwd = new Forward(fwd);
+	pfwd->AddRef();
+
 	int **ivtable=(int **)vtable;
 
 	void *vfunction=(void *)ivtable[hooklist[func].vtid];
@@ -687,7 +691,6 @@ static cell AMX_NATIVE_CALL RegisterHamFromEntity(AMX *amx, cell *params)
 		if (hooks[func].at(i)->tramp == vfunction)
 		{
 			// Yes, this function is hooked
-			Forward *pfwd=new Forward(fwd);
 			if (post)
 			{
 				hooks[func].at(i)->post.append(pfwd);
@@ -710,7 +713,6 @@ static cell AMX_NATIVE_CALL RegisterHamFromEntity(AMX *amx, cell *params)
 	Hook *hook = new Hook(vtable, hooklist[func].vtid, hooklist[func].targetfunc, hooklist[func].isvoid, hooklist[func].needsretbuf, hooklist[func].paramcount, classname);
 	hooks[func].append(hook);
 
-	Forward *pfwd=new Forward(fwd);
 	if (post)
 	{
 		hook->post.append(pfwd);

--- a/modules/hamsandwich/hook_specialbot.cpp
+++ b/modules/hamsandwich/hook_specialbot.cpp
@@ -84,6 +84,8 @@ void CHamSpecialBotHandler::RegisterHamSpecialBot(AMX *amx, int &func, const cha
 
 void CHamSpecialBotHandler::RegisterChecked(AMX *amx, int &func, const char *function, int &post, Forward *pfwd)
 {
+	pfwd->AddRef();
+
 	void **vtable = m_specialbot_vtable;
 	int **ivtable=(int **)vtable;
 


### PR DESCRIPTION
Silly bug where a same pointer was saved 2 times in a list, resulting segfault on cleanup.
Bug appears only now because libc has been updated recently and the magic has disappeared.
Thanks to The Genius (a.k.a Nextra) for his help to narrow down the issue.

Related to #153