### PR TITLE
Add %l format specifier and SetTranslationTarget() native (bug 6331)

### DIFF
--- a/amxmodx/amxmodx.cpp
+++ b/amxmodx/amxmodx.cpp
@@ -4431,6 +4431,14 @@ static cell AMX_NATIVE_CALL LookupLangKey(AMX *amx, cell *params)
 	return 1;
 };
 
+// SetGlobalTransTarget(client)
+static cell AMX_NATIVE_CALL SetGlobalTransTarget(AMX *amx, cell *params)
+{
+	g_langMngr.SetDefLang(params[1]);
+
+	return 1;
+};
+
 // has_map_ent_class(const classname[])
 static cell AMX_NATIVE_CALL has_map_ent_class(AMX *amx, cell *params)
 {
@@ -4629,6 +4637,7 @@ AMX_NATIVE_INFO amxmodx_Natives[] =
 	{"GetLangTransKey",			GetLangTransKey},
 	{"LibraryExists",			LibraryExists},
 	{"LookupLangKey",			LookupLangKey},
+	{"SetGlobalTransTarget",	SetGlobalTransTarget},
 	{"PrepareArray",			PrepareArray},
 	{"ShowSyncHudMsg",			ShowSyncHudMsg},
 	{"is_rukia_a_hag",			is_rukia_a_hag},

--- a/amxmodx/format.cpp
+++ b/amxmodx/format.cpp
@@ -650,16 +650,26 @@ reswitch:
 			arg++;
 			break;
 		case 'L':
+		case 'l':
 			{
-				CHECK_ARGS(1);
-				cell addr = params[arg++];
+				cell target;
+				if (ch == 'L')
+				{
+					CHECK_ARGS(1);
+					target = params[arg++];
+				}
+				else
+				{
+					CHECK_ARGS(0);
+					target = g_langMngr.GetDefLang();
+				}
 				int len;
 				const char *key = get_amxstring(amx, params[arg++], 3, len);
-				const char *def = translate(amx, addr, key);
+				const char *def = translate(amx, target, key);
 				if (!def)
 				{
 					static char buf[255];
-					UTIL_Format(buf, sizeof(buf)-1, "ML_NOTFOUND: %s", key);
+					UTIL_Format(buf, sizeof(buf) - 1, "ML_NOTFOUND: %s", key);
 					def = buf;
 				}
 				size_t written = atcprintf(buf_p, llen, def, amx, params, &arg);

--- a/plugins/include/lang.inc
+++ b/plugins/include/lang.inc
@@ -60,3 +60,16 @@ native AddTranslation(const lang[3], TransKey:key, const phrase[]);
  *       or LANG_SERVER
  */
 native LookupLangKey(Output[], OutputSize, const Key[], &id);
+
+/**
+ * Sets the global language target.  
+ *
+ * @note This is useful for creating functions
+ *       that will be compatible with the %l format specifier.  Note that invalid
+ *       indexes can be specified but the error will occur during translation,
+ *       not during this function call.
+ *
+ * @param client    Client index or LANG_SERVER
+ * @noreturn
+ */
+native SetGlobalTransTarget(client);


### PR DESCRIPTION
This adds a new `%l` format specifier which allows you to specify a client's index just once.
E.g. : 
`client_print(index, print_chat, "%L", index, "EGG"`
 is now 
`client_print(index, print_chat, "%l", "EGG"`

This new format will use the current index set internally with `SetDefLang`.

To complement this, a new native to define the current index has been added: `SetTranslationTarget`.
This is useful to be used before with natives which are not "players directed", like a bunch of `format[ex]` or custom function with `v[d]format`.

I wanted to fix base plugins, but I figured out that considering plugins need to be rewritten anyway, then changes will happen at this point.

