### PR TITLE
Fix checking cvar's bounds

### DIFF
--- a/amxmodx/cvars.cpp
+++ b/amxmodx/cvars.cpp
@@ -39,16 +39,19 @@ static cell AMX_NATIVE_CALL create_cvar(AMX *amx, cell *params)
 		bool hasMax  = params[7] != 0;
 		float minVal = amx_ctof(params[6]);
 		float maxVal = amx_ctof(params[8]);
-
-		if (hasMax && minVal > maxVal)
+		
+		if (hasMin && hasMax)
 		{
-			LogError(amx, AMX_ERR_NATIVE, "The minimum value can not be above the maximum value");
-			return 0;
-		}
-		else if (hasMin && maxVal < minVal)
-		{
-			LogError(amx, AMX_ERR_NATIVE, "The maximum value can not be below the minimum value");
-			return 0;
+			if (minVal > maxVal)
+			{
+				LogError(amx, AMX_ERR_NATIVE, "The minimum value can not be above the maximum value");
+				return 0;
+			}
+			else if (maxVal < minVal)
+			{
+				LogError(amx, AMX_ERR_NATIVE, "The maximum value can not be below the minimum value");
+				return 0;
+			}
 		}
 
 		g_CvarManager.SetCvarMin(info, hasMin, minVal, plugin->getId());


### PR DESCRIPTION
It looks like the current code that checks bounds for a cvar will fail in two cases. 

**1st case**
If we define min value that is higher than max value and max value is set to false,
```
create_cvar("cvar_name", "5", FCVAR_NONE, "desc", true, 1.0, false);
```
it will print -> *The maximum value can not be below the minimum value*

**2nd case**
If we define max value that is lower than min value and min value is set to false,
```
create_cvar("cvar_name", "5", FCVAR_NONE, "desc", false, 0.0, true, -1.0);
```
it will print -> *The minimum value can not be above the maximum value*

**Solution**
I think first we should check them if they are defined (both are set to true), then we can compare them. (Like I did in the this PR)