### PR TITLE
Datapack update

### DIFF
--- a/amxmodx/CDataPack.h
+++ b/amxmodx/CDataPack.h
@@ -108,6 +108,11 @@ public:
 	 */
 	void *ReadMemory(size_t *size) const;
 
+	bool CanReadCell() const;
+	bool CanReadFloat() const;
+	bool CanReadString(size_t *len) const;
+	bool CanReadMemory(size_t *size) const;
+
 public:
 	/**
 	 * @brief Resets the used size of the stream back to zero.

--- a/amxmodx/CDataPack.h
+++ b/amxmodx/CDataPack.h
@@ -8,7 +8,7 @@
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License, version 3.0, as published by the
  * Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
@@ -79,7 +79,7 @@ public:
 	/**
 	 * @brief Returns whether or not a specified number of bytes from the current stream
 	 *  position to the end can be read.
-	 * 
+	 *
 	 * @param bytes		Number of bytes to simulate reading.
 	 * @return			True if can be read, false otherwise.
 	 */
@@ -160,6 +160,13 @@ private:
 	mutable char *m_curptr;
 	size_t m_capacity;
 	size_t m_size;
+
+	enum DataPackType {
+		Raw,
+		Cell,
+		Float,
+		String,
+	};
 };
 
 class CDataPackHandles

--- a/amxmodx/datapacks.cpp
+++ b/amxmodx/datapacks.cpp
@@ -94,9 +94,9 @@ static cell AMX_NATIVE_CALL ReadPackCell(AMX* amx, cell* params)
 		return 0;
 	}
 
-	if (!d->IsReadable(sizeof(char) + sizeof(size_t) + sizeof(cell)))
+	if (!d->CanReadCell())
 	{
-		LogError(amx, AMX_ERR_NATIVE, "DataPack operation is out of bounds.");
+		LogError(amx, AMX_ERR_NATIVE, "Datapack operation is invalid.");
 		return 0;
 	}
 
@@ -113,9 +113,9 @@ static cell AMX_NATIVE_CALL ReadPackFloat(AMX* amx, cell* params)
 		return 0;
 	}
 
-	if (!d->IsReadable(sizeof(char) + sizeof(size_t) + sizeof(float)))
+	if (!d->CanReadFloat())
 	{
-		LogError(amx, AMX_ERR_NATIVE, "DataPack operation is out of bounds.");
+		LogError(amx, AMX_ERR_NATIVE, "Datapack operation is invalid.");
 		return 0;
 	}
 
@@ -134,13 +134,14 @@ static cell AMX_NATIVE_CALL ReadPackString(AMX* amx, cell* params)
 		return 0;
 	}
 
-	const char *str;
-	size_t len;
-	if (!(str = d->ReadString(&len)))
+	if (!d->CanReadString(NULL))
 	{
-		LogError(amx, AMX_ERR_NATIVE, "DataPack operation is out of bounds.");
+		LogError(amx, AMX_ERR_NATIVE, "Datapack operation is invalid.");
 		return 0;
 	}
+
+	size_t len;
+	const char *str = d->ReadString(&len);
 
 	return set_amxstring_utf8(amx, params[2], str, len, params[3] + 1); // + EOS
 }

--- a/amxmodx/datapacks.cpp
+++ b/amxmodx/datapacks.cpp
@@ -197,6 +197,19 @@ static cell AMX_NATIVE_CALL SetPackPosition(AMX* amx, cell* params)
 	return 1;
 }
 
+static cell AMX_NATIVE_CALL IsPackEnded(AMX* amx, cell* params)
+{
+	CDataPack *d = g_DataPackHandles.lookup(params[1]);
+
+	if (d == NULL)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Invalid datapack handle provided (%d)", params[1]);
+		return 0;
+	}
+
+	return d->IsReadable(1) ? false : true;
+}
+
 static cell AMX_NATIVE_CALL DestroyDataPack(AMX* amx, cell* params)
 {
 	cell *ptr = get_amxaddr(amx, params[1]);
@@ -230,6 +243,7 @@ AMX_NATIVE_INFO g_DatapackNatives[] =
 	{ "ResetPack",					ResetPack },
 	{ "GetPackPosition",			GetPackPosition },
 	{ "SetPackPosition",			SetPackPosition },
+	{ "IsPackEnded",				IsPackEnded },
 	{ "DestroyDataPack",			DestroyDataPack },
 	{NULL,							NULL}
 };

--- a/amxmodx/datapacks.cpp
+++ b/amxmodx/datapacks.cpp
@@ -94,7 +94,7 @@ static cell AMX_NATIVE_CALL ReadPackCell(AMX* amx, cell* params)
 		return 0;
 	}
 
-	if (!d->IsReadable(sizeof(size_t) + sizeof(cell)))
+	if (!d->IsReadable(sizeof(char) + sizeof(size_t) + sizeof(cell)))
 	{
 		LogError(amx, AMX_ERR_NATIVE, "DataPack operation is out of bounds.");
 		return 0;
@@ -113,7 +113,7 @@ static cell AMX_NATIVE_CALL ReadPackFloat(AMX* amx, cell* params)
 		return 0;
 	}
 
-	if (!d->IsReadable(sizeof(size_t) + sizeof(float)))
+	if (!d->IsReadable(sizeof(char) + sizeof(size_t) + sizeof(float)))
 	{
 		LogError(amx, AMX_ERR_NATIVE, "DataPack operation is out of bounds.");
 		return 0;

--- a/amxmodx/datapacks.cpp
+++ b/amxmodx/datapacks.cpp
@@ -197,19 +197,6 @@ static cell AMX_NATIVE_CALL SetPackPosition(AMX* amx, cell* params)
 	return 1;
 }
 
-static cell AMX_NATIVE_CALL IsPackReadable(AMX* amx, cell* params)
-{
-	CDataPack *d = g_DataPackHandles.lookup(params[1]);
-
-	if (d == NULL)
-	{
-		LogError(amx, AMX_ERR_NATIVE, "Invalid datapack handle provided (%d)", params[1]);
-		return 0;
-	}
-
-	return d->IsReadable(params[2]) ? 1 : 0;
-}
-
 static cell AMX_NATIVE_CALL DestroyDataPack(AMX* amx, cell* params)
 {
 	cell *ptr = get_amxaddr(amx, params[1]);
@@ -243,7 +230,6 @@ AMX_NATIVE_INFO g_DatapackNatives[] =
 	{ "ResetPack",					ResetPack },
 	{ "GetPackPosition",			GetPackPosition },
 	{ "SetPackPosition",			SetPackPosition },
-	{ "IsPackReadable",				IsPackReadable },
 	{ "DestroyDataPack",			DestroyDataPack },
 	{NULL,							NULL}
 };

--- a/plugins/include/datapack.inc
+++ b/plugins/include/datapack.inc
@@ -142,6 +142,17 @@ native GetPackPosition(DataPack:pack);
 native SetPackPosition(DataPack:pack, position);
 
 /**
+ * Returns if the datapack has reached its end and no more data can be read.
+ *
+ * @param pack      Datapack handle
+ *
+ * @return          True if datapack has reached the end, false otherwise
+ * @error           If an invalid handle is provided, or the new position is
+ *                  out of datapack bounds, an error will be thrown.
+ */
+ native bool:IsPackEnded(DataPack:pack);
+
+/**
  * Destroys the datapack and frees its memory.
  *
  * @param pack      Datapack handle


### PR DESCRIPTION
- Adds type safety, brought over from SourceMod
- Removes `IsPackReadable` because it is terrible (comment in commit)
- Adds `CanReadX` functions ~~and natives~~ to determine readability, as a replacement to `IsPackReadable`
- Updates test plugin