### PR TITLE
Remove copyright years from Makefiles.

### DIFF
--- a/amxmodx/Makefile
+++ b/amxmodx/Makefile
@@ -1,4 +1,4 @@
-# (C)2004-2015 AMX Mod X Development Team
+# (C) AMX Mod X Development Team
 # Makefile written by David "BAILOPAN" Anderson
 
 ###########################################

--- a/compiler/amxxpc/Makefile
+++ b/compiler/amxxpc/Makefile
@@ -1,4 +1,4 @@
-# (C)2004-2015 AMX Mod X Development Team
+# (C) AMX Mod X Development Team
 # Makefile written by David "BAILOPAN" Anderson
 
 #####################################

--- a/compiler/amxxpc/amxxpc.cpp
+++ b/compiler/amxxpc/amxxpc.cpp
@@ -84,7 +84,7 @@ int main(int argc, char **argv)
 
 	pc_printf("AMX Mod X Compiler %s\n", AMXX_VERSION);
 	pc_printf("Copyright (c) 1997-2006 ITB CompuPhase\n");
-        pc_printf("Copyright (c) 2004-2013 AMX Mod X Team\n\n");
+        pc_printf("Copyright (c) 2004-2015 AMX Mod X Team\n\n");
 	
 	if (argc < 2)
 	{

--- a/compiler/libpc300/Makefile
+++ b/compiler/libpc300/Makefile
@@ -1,4 +1,4 @@
-# (C)2004-2015 AMX Mod X Development Team
+# (C) AMX Mod X Development Team
 # Makefile written by David "BAILOPAN" Anderson
 
 #####################################

--- a/modules/cstrike/cstrike/Makefile
+++ b/modules/cstrike/cstrike/Makefile
@@ -1,4 +1,4 @@
-# (C)2004-2015 AMX Mod X Development Team
+# (C) AMX Mod X Development Team
 # Makefile written by David "BAILOPAN" Anderson
 
 ###########################################

--- a/modules/cstrike/csx/Makefile
+++ b/modules/cstrike/csx/Makefile
@@ -1,4 +1,4 @@
-# (C)2004-2015 AMX Mod X Development Team
+# (C) AMX Mod X Development Team
 # Makefile written by David "BAILOPAN" Anderson
 
 ###########################################

--- a/modules/dod/dodfun/Makefile
+++ b/modules/dod/dodfun/Makefile
@@ -1,4 +1,4 @@
-# (C)2004-2015 AMX Mod X Development Team
+# (C) AMX Mod X Development Team
 # Makefile written by David "BAILOPAN" Anderson
 
 ###########################################

--- a/modules/dod/dodx/Makefile
+++ b/modules/dod/dodx/Makefile
@@ -1,4 +1,4 @@
-# (C)2004-2015 AMX Mod X Development Team
+# (C) AMX Mod X Development Team
 # Makefile written by David "BAILOPAN" Anderson
 
 ###########################################

--- a/modules/engine/Makefile
+++ b/modules/engine/Makefile
@@ -1,4 +1,4 @@
-# (C)2004-2015 AMX Mod X Development Team
+# (C) AMX Mod X Development Team
 # Makefile written by David "BAILOPAN" Anderson
 
 ###########################################

--- a/modules/fakemeta/Makefile
+++ b/modules/fakemeta/Makefile
@@ -1,4 +1,4 @@
-# (C)2004-2015 AMX Mod X Development Team
+# (C) AMX Mod X Development Team
 # Makefile written by David "BAILOPAN" Anderson
 
 ###########################################

--- a/modules/fun/Makefile
+++ b/modules/fun/Makefile
@@ -1,4 +1,4 @@
-# (C)2004-2015 AMX Mod X Development Team
+# (C) AMX Mod X Development Team
 # Makefile written by David "BAILOPAN" Anderson
 
 ###########################################

--- a/modules/geoip/Makefile
+++ b/modules/geoip/Makefile
@@ -1,4 +1,4 @@
-# (C)2004-2015 AMX Mod X Development Team
+# (C) AMX Mod X Development Team
 # Makefile written by David "BAILOPAN" Anderson
 
 ###########################################

--- a/modules/hamsandwich/Makefile
+++ b/modules/hamsandwich/Makefile
@@ -1,4 +1,4 @@
-# (C)2004-2015 AMX Mod X Development Team
+# (C) AMX Mod X Development Team
 # Makefile written by David "BAILOPAN" Anderson
 
 ###########################################

--- a/modules/mysqlx/Makefile
+++ b/modules/mysqlx/Makefile
@@ -1,4 +1,4 @@
-# (C)2004-2015 AMX Mod X Development Team
+# (C) AMX Mod X Development Team
 # Makefile written by David "BAILOPAN" Anderson
 
 ###########################################

--- a/modules/ns/Makefile
+++ b/modules/ns/Makefile
@@ -1,4 +1,4 @@
-# (C)2004-2015 AMX Mod X Development Team
+# (C) AMX Mod X Development Team
 # Makefile written by David "BAILOPAN" Anderson
 
 ###########################################

--- a/modules/nvault/Makefile
+++ b/modules/nvault/Makefile
@@ -1,4 +1,4 @@
-# (C)2004-2015 AMX Mod X Development Team
+# (C) AMX Mod X Development Team
 # Makefile written by David "BAILOPAN" Anderson
 
 ###########################################

--- a/modules/regex/Makefile
+++ b/modules/regex/Makefile
@@ -1,4 +1,4 @@
-# (C)2004-2015 AMX Mod X Development Team
+# (C) AMX Mod X Development Team
 # Makefile written by David "BAILOPAN" Anderson
 
 ###########################################

--- a/modules/sockets/Makefile
+++ b/modules/sockets/Makefile
@@ -1,4 +1,4 @@
-# (C)2004-2015 AMX Mod X Development Team
+# (C) AMX Mod X Development Team
 # Makefile written by David "BAILOPAN" Anderson
 
 ###########################################

--- a/modules/sqlite/Makefile
+++ b/modules/sqlite/Makefile
@@ -1,4 +1,4 @@
-# (C)2004-2015 AMX Mod X Development Team
+# (C) AMX Mod X Development Team
 # Makefile written by David "BAILOPAN" Anderson
 
 ###########################################

--- a/modules/tfcx/Makefile
+++ b/modules/tfcx/Makefile
@@ -1,4 +1,4 @@
-# (C)2004-2015 AMX Mod X Development Team
+# (C) AMX Mod X Development Team
 # Makefile written by David "BAILOPAN" Anderson
 
 ###########################################

--- a/modules/ts/tsfun/Makefile
+++ b/modules/ts/tsfun/Makefile
@@ -1,4 +1,4 @@
-# (C)2004-2015 AMX Mod X Development Team
+# (C) AMX Mod X Development Team
 # Makefile written by David "BAILOPAN" Anderson
 
 ###########################################

--- a/modules/ts/tsx/Makefile
+++ b/modules/ts/tsx/Makefile
@@ -1,4 +1,4 @@
-# (C)2004-2015 AMX Mod X Development Team
+# (C) AMX Mod X Development Team
 # Makefile written by David "BAILOPAN" Anderson
 
 ###########################################


### PR DESCRIPTION
I did that what suggest xPaw in my previous PR to remove copyright years from makefiles because as he said most amxx's files don't contain them and these years won't need to be updated in the future anymore.