### PR TITLE
Fix fgets native not setting always the plugin buffer

### DIFF
--- a/amxmodx/file.cpp
+++ b/amxmodx/file.cpp
@@ -622,10 +622,7 @@ static cell AMX_NATIVE_CALL amx_fgets(AMX *amx, cell *params)
 	static char buffer[4096];
 	buffer[0] = '\0';
 
-	if (!fp->ReadLine(buffer, sizeof(buffer) - 1))
-	{
-		return 0;
-	}
+	fp->ReadLine(buffer, sizeof(buffer) - 1);
 
 	return set_amxstring_utf8(amx, params[2], buffer, strlen(buffer), params[3] + 1); // + EOS
 }


### PR DESCRIPTION
Just a silly issue where a buffer from a plugin should be always set. It results that if you parse an empty line after a valid one, the plugin variable would contain previous value.

Related #217