### PR TITLE
Fix missing SQL_SetCharset native in SQLite

### DIFF
--- a/modules/sqlite/basic_sql.cpp
+++ b/modules/sqlite/basic_sql.cpp
@@ -595,6 +595,12 @@ static cell AMX_NATIVE_CALL SQL_QuoteStringFmt(AMX *amx, cell *params)
 	}
 }
 
+static cell AMX_NATIVE_CALL SQL_SetCharset(AMX *amx, cell *params)
+{
+	/* SQLite supports only UTF-8/16 */
+	return 0;
+}
+
 AMX_NATIVE_INFO g_BaseSqlNatives[] = 
 {
 	{"SQL_MakeDbTuple",		SQL_MakeDbTuple},
@@ -620,6 +626,7 @@ AMX_NATIVE_INFO g_BaseSqlNatives[] =
 	{"SQL_QuoteString",		SQL_QuoteString},
 	{"SQL_QuoteStringFmt",	SQL_QuoteStringFmt},
 	{"SQL_NextResultSet",	SQL_NextResultSet},
+	{"SQL_SetCharset",      SQL_SetCharset},
 
 	{NULL,					NULL},
 };

--- a/modules/sqlite/msvc12/sqlite.vcxproj.filters
+++ b/modules/sqlite/msvc12/sqlite.vcxproj.filters
@@ -80,7 +80,7 @@
     <ClCompile Include="..\..\..\public\sdk\amxxmodule.cpp">
       <Filter>Module SDK\SDK Base</Filter>
     </ClCompile>
-    <ClCompile Include="..\sqlite-source\sqlite3.c">
+    <ClCompile Include="..\..\..\third_party\sqlite\sqlite3.c">
       <Filter>SQLite Source</Filter>
     </ClCompile>
   </ItemGroup>
@@ -136,7 +136,7 @@
     <ClInclude Include="..\moduleconfig.h">
       <Filter>Module SDK</Filter>
     </ClInclude>
-    <ClInclude Include="..\sqlite-source\sqlite3.h">
+    <ClInclude Include="..\..\..\third_party\sqlite\sqlite3.h">
       <Filter>SQLite Source</Filter>
     </ClInclude>
   </ItemGroup>

--- a/plugins/include/sqlx.inc
+++ b/plugins/include/sqlx.inc
@@ -67,7 +67,8 @@ native Handle:SQL_Connect(Handle:cn_tuple, &errcode, error[], maxlength);
  * 
  * If a connection tuple is supplied, this should be called before SQL_Connect or SQL_ThreadQuery.
  * Also note the change will remain until you call this function with another value.
- * 
+ * This native does nothing in SQLite. 
+ *
  * Example: "utf8", "latin1"
  *
  * @param h					Database or connection tuple Handle.


### PR DESCRIPTION
Even though SQLite doesn't need this, It's motivated by the following:
* For consistency, considering SQLite and MySQL use the same API, it should be there
* For usability, when your plugin deals with both driver dynamically, you would want to have the same code for both (meaning not checking driver name to use native)