### PR TITLE
Improve handling of KeyValueData

### DIFF
--- a/modules/fakemeta/dllfunc.cpp
+++ b/modules/fakemeta/dllfunc.cpp
@@ -72,12 +72,14 @@ static cell AMX_NATIVE_CALL dllfunc(AMX *amx,cell *params)
 			index=cRet[0];
 			CHECK_ENTITY(index);
 			cRet = MF_GetAmxAddr(amx, params[3]);
-			KVD_Wrapper *kvdw;
+
+			KeyValueData *kvd;
 			if (*cRet == 0)
-				kvdw = &g_kvd_glb;
+				kvd = &(g_kvd_glb.kvd);
 			else
-				kvdw = reinterpret_cast<KVD_Wrapper *>(*cRet);
-			gpGamedllFuncs->dllapi_table->pfnKeyValue(INDEXENT2(index), kvdw->kvd);
+				kvd = reinterpret_cast<KeyValueData *>(*cRet);
+
+			gpGamedllFuncs->dllapi_table->pfnKeyValue(INDEXENT2(index), kvd);
 			return 1;
 		}
 

--- a/modules/fakemeta/fakemeta_amxx.cpp
+++ b/modules/fakemeta/fakemeta_amxx.cpp
@@ -29,13 +29,16 @@ void OnAmxxAttach()
 	MF_AddNatives(glb_natives);
 	MF_AddNatives(ext2_natives);
 	MF_AddNatives(misc_natives);
-	g_kvd_2.szClassName = "";
-	g_kvd_2.szKeyName = "";
-	g_kvd_2.szValue = "";
-	g_kvd_glb.kvd = &g_kvd_2;
+	g_kvd_glb.kvd.szClassName = const_cast<char *>(g_kvd_glb.cls.chars());
+	g_kvd_glb.kvd.szKeyName = const_cast<char *>(g_kvd_glb.key.chars());
+	g_kvd_glb.kvd.szValue = const_cast<char *>(g_kvd_glb.val.chars());
+	g_kvd_glb.kvd.fHandled = 0;
 }
 
 extern CStack<TraceResult *> g_FreeTRs;
+extern ke::Vector<KVD_Wrapper *> g_KVDWs;
+extern ke::Vector<KVD_Wrapper *> g_FreeKVDWs;
+
 void OnAmxxDetach()
 {
 	while (!g_FreeTRs.empty())
@@ -43,6 +46,12 @@ void OnAmxxDetach()
 		delete g_FreeTRs.front();
 		g_FreeTRs.pop();
 	}
+
+	while (!g_KVDWs.empty())
+		delete g_KVDWs.popCopy();
+
+	while (!g_FreeKVDWs.empty())
+		delete g_FreeKVDWs.popCopy();
 }
 
 int GetHullBounds(int hullnumber, float *mins, float *maxs);

--- a/modules/fakemeta/fm_tr.h
+++ b/modules/fakemeta/fm_tr.h
@@ -20,7 +20,6 @@ extern TraceResult *gfm_tr;
 
 //these also don't fit in here but gaben does not care.  GABEN DOES NOT CARE!!!
 extern TraceResult g_tr_2;
-extern KeyValueData g_kvd_2;
 extern clientdata_t g_cd_glb;
 extern clientdata_t *g_cd_hook;
 extern entity_state_t g_es_glb;
@@ -30,14 +29,13 @@ extern usercmd_t *g_uc_hook;
 
 struct KVD_Wrapper
 {
-	KeyValueData *kvd;
+	KeyValueData kvd;
 	ke::AString cls;
 	ke::AString key;
 	ke::AString val;
 };
 
 extern KVD_Wrapper g_kvd_glb;
-extern KVD_Wrapper g_kvd_hook;
 
 enum
 {

--- a/modules/fakemeta/forward.cpp
+++ b/modules/fakemeta/forward.cpp
@@ -262,15 +262,13 @@ typedef struct KeyValueData_s
 */
 void KeyValue(edict_t* entity, KeyValueData* data)
 {
-	g_kvd_hook.kvd = data;
-	FM_ENG_HANDLE(FM_KeyValue, (Engine[FM_KeyValue].at(i), (cell)ENTINDEX(entity), (cell)(&g_kvd_hook)));
+	FM_ENG_HANDLE(FM_KeyValue, (Engine[FM_KeyValue].at(i), (cell)ENTINDEX(entity), (cell)(data)));
 	RETURN_META(mswi(lastFmRes));
 }
 
 void KeyValue_post(edict_t* entity, KeyValueData* data)
 {
-	g_kvd_hook.kvd = data;
-	FM_ENG_HANDLE_POST(FM_KeyValue, (EnginePost[FM_KeyValue].at(i), (cell)ENTINDEX(entity), (cell)(&g_kvd_hook)));
+	FM_ENG_HANDLE_POST(FM_KeyValue, (EnginePost[FM_KeyValue].at(i), (cell)ENTINDEX(entity), (cell)(data)));
 	RETURN_META(MRES_IGNORED);
 }
 

--- a/plugins/include/fakemeta.inc
+++ b/plugins/include/fakemeta.inc
@@ -473,6 +473,9 @@ native get_kvd(kvd_handle, KeyValueData:member, any:...);
 // keyvalues structure rather than changing the internal engine strings.
 native set_kvd(kvd_handle, KeyValueData:member, any:...);
 
+native create_kvd();
+native free_kvd(kvd_handle);
+
 // These functions are used with the clientdata data structure (FM_UpdateClientData)
 // Get: 0 extra params - Return integer; 1 extra param - by ref float or vector; 2 extra params - string and length
 // Set: Use anything

--- a/plugins/include/fakemeta.inc
+++ b/plugins/include/fakemeta.inc
@@ -473,7 +473,22 @@ native get_kvd(kvd_handle, KeyValueData:member, any:...);
 // keyvalues structure rather than changing the internal engine strings.
 native set_kvd(kvd_handle, KeyValueData:member, any:...);
 
+/**
+ * Creates a KeyValueData handle.
+ *
+ * @note Handles should be freed using free_kvd().
+ *
+ * @return		New KeyValueData handle
+ */
 native create_kvd();
+
+/**
+ * Frees a KeyValueData handle.
+ *
+ * @param kvd_handle	KeyValueData handle
+ *
+ * @noreturn
+ */
 native free_kvd(kvd_handle);
 
 // These functions are used with the clientdata data structure (FM_UpdateClientData)

--- a/plugins/include/ham_const.inc
+++ b/plugins/include/ham_const.inc
@@ -70,7 +70,7 @@ enum Ham
 	/**
 	 * Description:		Typically this is similar to an engine keyvalue call.
 	 *					Use the kvd natives from fakemeta to handle the kvd_handle passed.
-	 *					NOTE: Do not pass handle 0 to this! Use get_kvd_handle(0) from fakemeta instead!
+	 *					NOTE: Do not pass handle 0 to this! Use create_kvd() from fakemeta instead!
 	 * Forward params:	function(this, kvd_handle);
 	 * Return type:		None.
 	 * Execute params:	ExecuteHam(Ham_Keyvalue, this, kvd_handle);


### PR DESCRIPTION
Despite Hamsandwich documentation pointing to FM natives for handling KVD, FM was actually incompatible to the raw pointers Ham works with. This is due to the `KVD_Wrapper` helper structure in FM, the basic compatibility fix is making `&kvdw == &kvdw.kvd`, so the wrapper can be pushed into Ham without issue.

`create_kvd()` and `free_kvd()` allow creation of new KVD structures that can be used with Ham. These can and should also be used in FM to replace the global `0` KVD that has multiple problems and can unfortunately not be fixed up properly.

Documentation will be done properly when I touch fakemeta.inc in the next doc update.