### PR TITLE
Add NULL_VECTOR and expose null functions to AMXX API

### DIFF
--- a/amxmodx/CPlugin.cpp
+++ b/amxmodx/CPlugin.cpp
@@ -157,6 +157,11 @@ int CPluginMngr::loadPluginsFromFile(const char* filename, bool warn)
 			{
 				plugin->m_pNullStringOfs = get_amxaddr(plugin->getAMX(), addr);
 			}
+
+			if (amx_FindPubVar(plugin->getAMX(), "NULL_VECTOR", &addr) != AMX_ERR_NOTFOUND)
+			{
+				plugin->m_pNullVectorOfs = get_amxaddr(plugin->getAMX(), addr);
+			}
 		}
 	}
 
@@ -261,7 +266,7 @@ const char* CPluginMngr::CPlugin::getStatus() const
 	return "error";
 }
 
-CPluginMngr::CPlugin::CPlugin(int i, const char* p, const char* n, char* e, int d) : name(n), title(n), m_pNullStringOfs(nullptr)
+CPluginMngr::CPlugin::CPlugin(int i, const char* p, const char* n, char* e, int d) : name(n), title(n), m_pNullStringOfs(nullptr), m_pNullVectorOfs(nullptr)
 {
 	const char* unk = "unknown";
 	

--- a/amxmodx/CPlugin.h
+++ b/amxmodx/CPlugin.h
@@ -62,6 +62,7 @@ public:
 		
 		bool m_Debug;
 		cell* m_pNullStringOfs;
+		cell* m_pNullVectorOfs;
 	public:
 		inline const char* getName() { return name.c_str();}
 		inline const char* getVersion() { return version.c_str();}
@@ -92,6 +93,7 @@ public:
 		const char* getStatus() const;
 		inline bool isDebug() const { return m_Debug; }
 		inline cell* getNullStringOfs() const { return m_pNullStringOfs; }
+		inline cell* getNullVectorOfs() const { return m_pNullVectorOfs; }
 	}; 
 	
 private:	

--- a/amxmodx/amxmodx.cpp
+++ b/amxmodx/amxmodx.cpp
@@ -29,7 +29,7 @@ static cell AMX_NATIVE_CALL get_xvar_id(AMX *amx, cell *params)
 	char* sName = get_amxstring(amx, params[1], 0, len);
 	cell ptr;
 
-	if (!strcmp(sName, "MaxClients") || !strcmp(sName, "NULL_STRING"))
+	if (!strcmp(sName, "MaxClients") || !strcmp(sName, "NULL_STRING") || !strcmp(sName, "NULL_VECTOR"))
 	{
 		return -1;
 	}

--- a/amxmodx/amxmodx.h
+++ b/amxmodx/amxmodx.h
@@ -276,7 +276,8 @@ char* format_amxstring(AMX *amx, cell *params, int parm, int& len);
 AMX* get_amxscript(int, void**, const char**);
 const char* get_amxscriptname(AMX* amx);
 char* get_amxstring(AMX *amx, cell amx_addr, int id, int& len);
-char *get_amxstring_null(AMX *amx, cell amx_addr, int id, int& len);
+char* get_amxstring_null(AMX *amx, cell amx_addr, int id, int& len);
+cell* get_amxvector_null(AMX *amx, cell amx_addr);
 extern "C" size_t get_amxstring_r(AMX *amx, cell amx_addr, char *destination, int maxlen);
 
 int amxstring_len(cell* cstr);

--- a/amxmodx/modules.cpp
+++ b/amxmodx/modules.cpp
@@ -1239,6 +1239,17 @@ extern "C" char *MNF_GetAmxString(AMX *amx, cell amx_addr, int bufferId, int *pL
 	return retVal;
 }
 
+extern "C" char *MNF_GetAmxStringNull(AMX *amx, cell amx_addr, int bufferId, int *pLen)
+{
+	int len;
+	char *retVal = get_amxstring_null(amx, amx_addr, bufferId, len);
+
+	if (pLen && retVal)
+		*pLen = len;
+
+	return retVal;
+}
+
 int MNF_GetAmxStringLen(const cell *ptr)
 {
 	register int c = 0;
@@ -1827,10 +1838,12 @@ void Module_CacheFunctions()
 	REGISTER_FUNC("SetAmxStringUTF8Char", set_amxstring_utf8_char)
 	REGISTER_FUNC("SetAmxStringUTF8Cell", set_amxstring_utf8_cell)
 	REGISTER_FUNC("GetAmxString", MNF_GetAmxString)
+	REGISTER_FUNC("GetAmxStringNull", MNF_GetAmxStringNull)
 	REGISTER_FUNC("GetAmxStringLen", MNF_GetAmxStringLen)
 	REGISTER_FUNC("FormatAmxString", MNF_FormatAmxString)
 	REGISTER_FUNC("CopyAmxMemory", MNF_CopyAmxMemory)
 	REGISTER_FUNC("GetAmxAddr", get_amxaddr)
+	REGISTER_FUNC("GetAmxVectorNull", get_amxvector_null)
 	REGISTER_FUNC("AmxReregister", amx_Reregister);
 
 	// other amx stuff

--- a/amxmodx/string.cpp
+++ b/amxmodx/string.cpp
@@ -186,6 +186,17 @@ char *get_amxstring_null(AMX *amx, cell amx_addr, int id, int& len)
 	return get_amxstring(amx, amx_addr, id, len);
 }
 
+cell *get_amxvector_null(AMX *amx, cell amx_addr)
+{
+	cell *addr = get_amxaddr(amx, amx_addr);
+	if (addr == g_plugins.findPluginFast(amx)->getNullVectorOfs())
+	{
+		return nullptr;
+	}
+
+	return addr;
+}
+
 void copy_amxmemory(cell* dest, cell* src, int len)
 {
 	while (len--)

--- a/plugins/include/amxconst.inc
+++ b/plugins/include/amxconst.inc
@@ -50,6 +50,11 @@ public stock const MaxClients;
 public stock const NULL_STRING[1];
 
 /**
+ * Pass this into certain functions to act as a C++ NULL
+ */
+public stock const Float:NULL_VECTOR[3];
+
+/**
  * The maximum buffer size required to store a clients name.
  */
 #define MAX_NAME_LENGTH 32

--- a/public/sdk/amxxmodule.cpp
+++ b/public/sdk/amxxmodule.cpp
@@ -2421,6 +2421,7 @@ PFN_ADD_NEW_NATIVES			g_fn_AddNewNatives;
 PFN_BUILD_PATHNAME			g_fn_BuildPathname;
 PFN_BUILD_PATHNAME_R		g_fn_BuildPathnameR;
 PFN_GET_AMXADDR				g_fn_GetAmxAddr;
+PFN_GET_AMXVECTOR_NULL		g_fn_GetAmxVectorNull;
 PFN_PRINT_SRVCONSOLE		g_fn_PrintSrvConsole;
 PFN_GET_MODNAME				g_fn_GetModname;
 PFN_GET_AMXSCRIPTNAME		g_fn_GetAmxScriptName;
@@ -2431,6 +2432,7 @@ PFN_SET_AMXSTRING			g_fn_SetAmxString;
 PFN_SET_AMXSTRING_UTF8_CHAR	g_fn_SetAmxStringUTF8Char;
 PFN_SET_AMXSTRING_UTF8_CELL	g_fn_SetAmxStringUTF8Cell;
 PFN_GET_AMXSTRING			g_fn_GetAmxString;
+PFN_GET_AMXSTRING_NULL		g_fn_GetAmxStringNull;
 PFN_GET_AMXSTRINGLEN		g_fn_GetAmxStringLen;
 PFN_FORMAT_AMXSTRING		g_fn_FormatAmxString;
 PFN_COPY_AMXMEMORY			g_fn_CopyAmxMemory;
@@ -2572,10 +2574,12 @@ C_DLLEXPORT int AMXX_Attach(PFN_REQ_FNPTR reqFnptrFunc)
 	REQFUNC("SetAmxStringUTF8Char", g_fn_SetAmxStringUTF8Char, PFN_SET_AMXSTRING_UTF8_CHAR);
 	REQFUNC("SetAmxStringUTF8Cell", g_fn_SetAmxStringUTF8Cell, PFN_SET_AMXSTRING_UTF8_CELL);
 	REQFUNC("GetAmxString", g_fn_GetAmxString, PFN_GET_AMXSTRING);
+	REQFUNC("GetAmxStringNull", g_fn_GetAmxStringNull, PFN_GET_AMXSTRING_NULL);
 	REQFUNC("GetAmxStringLen", g_fn_GetAmxStringLen, PFN_GET_AMXSTRINGLEN);
 	REQFUNC("FormatAmxString", g_fn_FormatAmxString, PFN_FORMAT_AMXSTRING);
 	REQFUNC("CopyAmxMemory", g_fn_CopyAmxMemory, PFN_COPY_AMXMEMORY);
 	REQFUNC("GetAmxAddr", g_fn_GetAmxAddr, PFN_GET_AMXADDR);
+	REQFUNC("GetAmxVectorNull", g_fn_GetAmxVectorNull, PFN_GET_AMXVECTOR_NULL);
 
 	REQFUNC("amx_Exec", g_fn_AmxExec, PFN_AMX_EXEC);
 	REQFUNC("amx_Execv", g_fn_AmxExecv, PFN_AMX_EXECV);
@@ -2717,6 +2721,7 @@ void ValidateMacros_DontCallThis_Smiley()
 	MF_BuildPathnameR(NULL, 0, "%d", 0);
 	MF_FormatAmxString(NULL, 0, 0, NULL);
 	MF_GetAmxAddr(NULL, 0);
+	MF_GetAmxVectorNull(NULL, 0);
 	MF_PrintSrvConsole("str", "str", 0);
 	MF_GetModname();
 	MF_GetScriptName(0);
@@ -2726,7 +2731,8 @@ void ValidateMacros_DontCallThis_Smiley()
 	MF_SetAmxString(NULL, 0, "str", 0);
 	MF_SetAmxStringUTF8Char(NULL, 0, "str", 0, 0);
 	MF_SetAmxStringUTF8Cell(NULL, 0, str, 0, 0);
-	MF_GetAmxString(NULL, 0, 0, 0);
+	MF_GetAmxString(NULL, 0, 0, NULL);
+	MF_GetAmxStringNull(NULL, 0, 0, NULL);
 	MF_GetAmxStringLen(NULL);
 	MF_CopyAmxMemory(NULL, NULL, 0);
 	MF_Log("str", "str", 0);

--- a/public/sdk/amxxmodule.h
+++ b/public/sdk/amxxmodule.h
@@ -2130,6 +2130,7 @@ typedef int				(*PFN_ADD_NEW_NATIVES)			(const AMX_NATIVE_INFO * /*list*/);
 typedef char *			(*PFN_BUILD_PATHNAME)			(const char * /*format*/, ...);
 typedef char *			(*PFN_BUILD_PATHNAME_R)			(char * /*buffer*/, size_t /* maxlen */, const char * /* format */, ...);
 typedef cell *			(*PFN_GET_AMXADDR)				(AMX * /*amx*/, cell /*offset*/);
+typedef cell *			(*PFN_GET_AMXVECTOR_NULL)		(AMX * /*amx*/, cell /*offset*/);
 typedef void			(*PFN_PRINT_SRVCONSOLE)			(const char * /*format*/, ...);
 typedef const char *	(*PFN_GET_MODNAME)				(void);
 typedef const char *	(*PFN_GET_AMXSCRIPTNAME)		(int /*id*/);
@@ -2140,6 +2141,7 @@ typedef int				(*PFN_SET_AMXSTRING)			(AMX * /*amx*/, cell /*amx_addr*/, const c
 typedef int				(*PFN_SET_AMXSTRING_UTF8_CHAR)	(AMX *amx, cell amx_addr, const char *source, size_t sourcelen, size_t maxlen);
 typedef int				(*PFN_SET_AMXSTRING_UTF8_CELL)	(AMX *amx, cell amx_addr, const cell *source, size_t sourcelen, size_t maxlen);
 typedef char *			(*PFN_GET_AMXSTRING)			(AMX * /*amx*/, cell /*amx_addr*/, int /*bufferId*/, int * /*pLen*/);
+typedef char *			(*PFN_GET_AMXSTRING_NULL)		(AMX * /*amx*/, cell /*amx_addr*/, int /*bufferId*/, int * /*pLen*/);
 typedef int				(*PFN_GET_AMXSTRINGLEN)			(const cell *ptr);
 typedef char *			(*PFN_FORMAT_AMXSTRING)			(AMX * /*amx*/, cell * /*params*/, int /*startParam*/, int * /*pLen*/);
 typedef void			(*PFN_COPY_AMXMEMORY)			(cell * /*dest*/, const cell * /*src*/, int /*len*/);
@@ -2221,6 +2223,7 @@ extern PFN_ADD_NEW_NATIVES			g_fn_AddNewNatives;
 extern PFN_BUILD_PATHNAME			g_fn_BuildPathname;
 extern PFN_BUILD_PATHNAME_R			g_fn_BuildPathnameR;
 extern PFN_GET_AMXADDR				g_fn_GetAmxAddr;
+extern PFN_GET_AMXVECTOR_NULL		g_fn_GetAmxVectorNull;
 extern PFN_PRINT_SRVCONSOLE			g_fn_PrintSrvConsole;
 extern PFN_GET_MODNAME				g_fn_GetModname;
 extern PFN_GET_AMXSCRIPTNAME		g_fn_GetAmxScriptName;
@@ -2231,6 +2234,7 @@ extern PFN_SET_AMXSTRING			g_fn_SetAmxString;
 extern PFN_SET_AMXSTRING_UTF8_CHAR	g_fn_SetAmxStringUTF8Char;
 extern PFN_SET_AMXSTRING_UTF8_CELL	g_fn_SetAmxStringUTF8Cell;
 extern PFN_GET_AMXSTRING			g_fn_GetAmxString;
+extern PFN_GET_AMXSTRING_NULL		g_fn_GetAmxStringNull;
 extern PFN_GET_AMXSTRINGLEN			g_fn_GetAmxStringLen;
 extern PFN_FORMAT_AMXSTRING			g_fn_FormatAmxString;
 extern PFN_COPY_AMXMEMORY			g_fn_CopyAmxMemory;
@@ -2302,6 +2306,7 @@ int				MF_AddNewNatives			(const AMX_NATIVE_INFO *list) { }
 char *			MF_BuildPathname			(const char * format, ...) { }
 char *			MF_BuildPathnameR			(char *buffer, size_t maxlen, const char *fmt, ...) { }
 cell *			MF_GetAmxAddr				(AMX * amx, cell offset) { }
+cell *			MF_GetAmxVectorNull			(AMX * amx, cell offset) { }
 void			MF_PrintSrvConsole			(char * format, ...) { }
 const char *	MF_GetModname				(void) { }
 const char *	MF_GetScriptName			(int id) { }
@@ -2312,6 +2317,7 @@ int				MF_SetAmxString				(AMX * amx, cell amx_addr, const char *  source , int 
 int				MF_SetAmxStringUTF8Char		(AMX *amx, cell amx_addr, const char *source, size_t sourcelen, size_t maxlen) { }
 int				MF_SetAmxStringUTF8Cell		(AMX *amx, cell amx_addr, const cell *source, size_t sourcelen, size_t maxlen) { }
 char *			MF_GetAmxString				(AMX * amx, cell amx_addr, int bufferId, int * pLen) { }
+char *			MF_GetAmxStringNull			(AMX * amx, cell amx_addr, int bufferId, int * pLen) { }
 int				MF_GetAmxStringLen			(const cell *ptr) { }
 char *			MF_FormatAmxString			(AMX * amx, cell * params, int startParam, int * pLen) { }
 void			MF_CopyAmxMemory			(cell * dest, const cell * src, int len) { }
@@ -2376,6 +2382,7 @@ void *			MF_MessageBlock				(int mode, int msg, int *opt) { }
 #define MF_BuildPathnameR g_fn_BuildPathnameR
 #define MF_FormatAmxString g_fn_FormatAmxString
 #define MF_GetAmxAddr g_fn_GetAmxAddr
+#define MF_GetAmxVectorNull g_fn_GetAmxVectorNull
 #define MF_PrintSrvConsole g_fn_PrintSrvConsole
 #define MF_GetModname g_fn_GetModname
 #define MF_GetScriptName g_fn_GetAmxScriptName
@@ -2386,6 +2393,7 @@ void *			MF_MessageBlock				(int mode, int msg, int *opt) { }
 #define MF_SetAmxStringUTF8Char g_fn_SetAmxStringUTF8Char
 #define MF_SetAmxStringUTF8Cell g_fn_SetAmxStringUTF8Cell
 #define MF_GetAmxString g_fn_GetAmxString
+#define MF_GetAmxStringNull g_fn_GetAmxStringNull
 #define MF_GetAmxStringLen g_fn_GetAmxStringLen
 #define MF_CopyAmxMemory g_fn_CopyAmxMemory
 void MF_Log(const char *fmt, ...);


### PR DESCRIPTION
`NULL_VECTOR` will be required for future engine updates, and is generally nice to have. For module use `get_amxstring_null` and `get_amxvector_null` obviously have to be exposed to the API.