### PR TITLE
Fix EngFunc_ChangeLevel

### DIFF
--- a/modules/fakemeta/engfunc.cpp
+++ b/modules/fakemeta/engfunc.cpp
@@ -105,7 +105,7 @@ static cell AMX_NATIVE_CALL engfunc(AMX *amx, cell *params)
 		// pfnChangeLevel (is this needed?)
 	case		EngFunc_ChangeLevel:			// void )			(char* s1, char* s2);
 		temp = MF_GetAmxString(amx,params[2],0,&len);
-		temp2 = MF_GetAmxString(amx,params[3],1,&len);
+		temp2 = MF_GetAmxStringNull(amx,params[3],1,&len);
 		(*g_engfuncs.pfnChangeLevel)(temp,temp2);
 		return 1;
 		


### PR DESCRIPTION
This fixes `EngFunc_ChangeLevel` which never worked from the start.

This function takes 2 arguments, and the second is used on single player game only. To act like a `changelevel` command, second param needs to be `NULL`.  But the original code was passing always a non-null string, even though empty, and since engine disallows this if server is multiplayer, function could not work.

Even though the function is redundant and because we can't delete this, we might want to fix this.
Function is now supporting `NULL_STRING` identifier on the second param. Documentation will be updated in another PR.
