### PR TITLE
Update compiler - 3

### DIFF
--- a/compiler/libpc300/sc1.c
+++ b/compiler/libpc300/sc1.c
@@ -2190,15 +2190,19 @@ static int base;
  *
  *  Global references: litidx (altered)
  */
-static void initials(int ident,int tag,cell *size,int dim[],int numdim,
-                     constvalue *enumroot)
+static void initials2(int ident,int tag,cell *size,int dim[],int numdim,
+                     constvalue *enumroot, int eq_match_override, int curlit_override)
 {
   int ctag;
   cell tablesize;
-  int curlit=litidx;
+  int curlit=(curlit_override == -1) ? litidx : curlit_override;
   int err=0;
 
-  if (!matchtoken('=')) {
+  if (eq_match_override == -1) {
+    eq_match_override = matchtoken('=');
+  }
+
+  if (!eq_match_override) {
     assert(ident!=iARRAY || numdim>0);
     if (ident==iARRAY && dim[numdim-1]==0) {
       /* declared as "myvar[];" which is senseless (note: this *does* make
@@ -2248,7 +2252,7 @@ static void initials(int ident,int tag,cell *size,int dim[],int numdim,
       /* now initialize the sub-arrays */
       memset(counteddim,0,sizeof counteddim);
       initarray(ident,tag,dim,numdim,0,curlit,counteddim,&lastdim,enumroot,&errorfound);
-      /* check the specified array dimensions with the initialler counts */
+      /* check the specified array dimensions with the initializer counts */
       for (idx=0; idx<numdim-1; idx++) {
         if (dim[idx]==0) {
           dim[idx]=counteddim[idx];
@@ -2289,6 +2293,12 @@ static void initials(int ident,int tag,cell *size,int dim[],int numdim,
 
   if (*size==0)
     *size=litidx-curlit;        /* number of elements defined */
+}
+
+static void initials(int ident, int tag, cell *size, int dim[], int numdim,
+                     constvalue *enumroot)
+{
+  initials2(ident, tag, size, dim, numdim, enumroot, -1, -1);	
 }
 
 static cell initarray(int ident,int tag,int dim[],int numdim,int cur,
@@ -3699,27 +3709,46 @@ static void doarg(char *name,int ident,int offset,int tags[],int numtags,
     } while (matchtoken('['));
     ident=iREFARRAY;            /* "reference to array" (is a pointer) */
     if (matchtoken('=')) {
-      lexpush();                /* initials() needs the "=" token again */
       assert(litidx==0);        /* at the start of a function, this is reset */
       assert(numtags>0);
-      initials(ident,tags[0],&size,arg->dim,arg->numdim,enumroot);
-      assert(size>=litidx);
-      /* allocate memory to hold the initial values */
-      arg->defvalue.array.data=(cell *)malloc(litidx*sizeof(cell));
-      if (arg->defvalue.array.data!=NULL) {
-        int i;
-        memcpy(arg->defvalue.array.data,litq,litidx*sizeof(cell));
-        arg->hasdefault=TRUE;   /* argument has default value */
-        arg->defvalue.array.size=litidx;
-        arg->defvalue.array.addr=-1;
-        /* calulate size to reserve on the heap */
-        arg->defvalue.array.arraysize=1;
-        for (i=0; i<arg->numdim; i++)
-          arg->defvalue.array.arraysize*=arg->dim[i];
-        if (arg->defvalue.array.arraysize < arg->defvalue.array.size)
-          arg->defvalue.array.arraysize = arg->defvalue.array.size;
-      } /* if */
-      litidx=0;                 /* reset */
+      /* Check if there is a symbol */
+      if (matchtoken(tSYMBOL)) {
+        symbol *sym;
+        char *name;
+        cell val;
+        tokeninfo(&val,&name);
+        if ((sym=findglb(name)) == NULL) {
+          error(17, name);      /* undefined symbol */
+        } else {
+          arg->hasdefault=TRUE; /* argument as a default value */
+          memset(&arg->defvalue, 0, sizeof(arg->defvalue));
+          arg->defvalue.array.data=NULL;
+          arg->defvalue.array.addr=sym->addr;
+          arg->defvalue_tag=sym->tag;
+          if (sc_status==statWRITE && (sym->usage & uREAD)==0) {
+            markusage(sym, uREAD);
+          }
+        }
+      } else {
+        initials2(ident, tags[0], &size, arg->dim, arg->numdim, enumroot, 1, 0);
+        assert(size >= litidx);
+        /* allocate memory to hold the initial values */
+        arg->defvalue.array.data=(cell *)malloc(litidx*sizeof(cell));
+        if (arg->defvalue.array.data!=NULL) {
+          int i;
+          memcpy(arg->defvalue.array.data,litq,litidx*sizeof(cell));
+          arg->hasdefault=TRUE;   /* argument has default value */
+          arg->defvalue.array.size=litidx;
+          arg->defvalue.array.addr=-1;
+          /* calulate size to reserve on the heap */
+          arg->defvalue.array.arraysize=1;
+          for (i=0; i<arg->numdim; i++)
+            arg->defvalue.array.arraysize*=arg->dim[i];
+          if (arg->defvalue.array.arraysize < arg->defvalue.array.size)
+            arg->defvalue.array.arraysize = arg->defvalue.array.size;
+        } /* if */
+        litidx=0;                 /* reset */
+      }
     } /* if */
   } else {
     if (matchtoken('=')) {

--- a/compiler/libpc300/sc1.c
+++ b/compiler/libpc300/sc1.c
@@ -2202,6 +2202,23 @@ static void initials2(int ident,int tag,cell *size,int dim[],int numdim,
     eq_match_override = matchtoken('=');
   }
 
+  if (numdim > 2) {
+    int d, hasEmpty = 0;
+    for (d = 0; d < numdim; d++) {
+      if (dim[d] == 0)
+        hasEmpty++;
+    }
+    /* Work around ambug 4977 where indirection vectors are computed wrong. */
+    if (hasEmpty && hasEmpty < numdim-1 && dim[numdim-1]) {
+      error(112);
+      /* This will assert with something like [2][][256] from a separate bug.
+       * To prevent this assert, automatically wipe the rest of the dims.
+       */
+      for (d = 0; d < numdim - 1; d++)
+        dim[d] = 0;
+    }
+  }
+
   if (!eq_match_override) {
     assert(ident!=iARRAY || numdim>0);
     if (ident==iARRAY && dim[numdim-1]==0) {

--- a/compiler/libpc300/sc3.c
+++ b/compiler/libpc300/sc3.c
@@ -1769,8 +1769,6 @@ static void setdefarray(cell *string,cell size,cell array_sz,cell *dataaddr,int 
    * the default array data is "dumped" into the data segment only once (on the
    * first use).
    */
-  assert(string!=NULL);
-  assert(size>0);
   /* check whether to dump the default array */
   assert(dataaddr!=NULL);
   if (sc_status==statWRITE && *dataaddr<0) {
@@ -1784,7 +1782,7 @@ static void setdefarray(cell *string,cell size,cell array_sz,cell *dataaddr,int 
    * does not modify the default value), directly pass the address of the
    * array in the data segment.
    */
-  if (fconst) {
+  if (fconst || !string) {
     ldconst(*dataaddr,sPRI);
   } else {
     /* Generate the code:
@@ -2162,20 +2160,22 @@ static int nesting=0;
                     arg[argidx].defvalue.array.arraysize,
                     &arg[argidx].defvalue.array.addr,
                     (arg[argidx].usage & uCONST)!=0);
-        if ((arg[argidx].usage & uCONST)==0) {
-          heapalloc+=arg[argidx].defvalue.array.arraysize;
-          nest_stkusage+=arg[argidx].defvalue.array.arraysize;
-        } /* if */
-        /* keep the lengths of all dimensions of a multi-dimensional default array */
-        assert(arg[argidx].numdim>0);
-        if (arg[argidx].numdim==1) {
-          append_constval(&arrayszlst,arg[argidx].name,arg[argidx].defvalue.array.arraysize,0);
-        } else {
-          for (level=0; level<arg[argidx].numdim; level++) {
-            assert(level<sDIMEN_MAX);
-            append_constval(&arrayszlst,arg[argidx].name,arg[argidx].dim[level],level);
-          } /* for */
-        } /* if */
+        if (arg[argidx].defvalue.array.data != NULL) {
+          if ((arg[argidx].usage & uCONST)==0) {
+            heapalloc+=arg[argidx].defvalue.array.arraysize;
+            nest_stkusage+=arg[argidx].defvalue.array.arraysize;
+          } /* if */
+          /* keep the lengths of all dimensions of a multi-dimensional default array */
+          assert(arg[argidx].numdim>0);
+          if (arg[argidx].numdim==1) {
+            append_constval(&arrayszlst,arg[argidx].name,arg[argidx].defvalue.array.arraysize,0);
+          } else {
+            for (level=0; level<arg[argidx].numdim; level++) {
+              assert(level<sDIMEN_MAX);
+              append_constval(&arrayszlst,arg[argidx].name,arg[argidx].dim[level],level);
+            } /* for */
+          } /* if */
+        }
       } else if (arg[argidx].ident==iREFERENCE) {
         setheap(arg[argidx].defvalue.val);
         /* address of the value on the heap in PRI */

--- a/compiler/libpc300/sc5-in.scp
+++ b/compiler/libpc300/sc5-in.scp
@@ -129,6 +129,7 @@ static char *fatalmsg[] = {
 /*109*/  "invalid path: \"%s\"\n",
 /*110*/  "assertion failed: %s\n",
 /*111*/  "user error: %s\n",
+/*112*/  "specify either all dimensions or only the last dimension\n"
        };
 
 static char *warnmsg[] = {


### PR DESCRIPTION
Necessary update to be able to use `NULL_STRING` and `NULL_VECTOR` as default value for some natives arguments. Same patch as alliedmodders/sourcemod@d8d13f1.

This includes an extra fix as another commit, since it shares the same code. ([bug 4977](https://bugs.alliedmods.net/show_bug.cgi?id=4977))