### PR TITLE
Fix set_amxstring_utf8 insconsistency

### DIFF
--- a/amxmodx/amxmodx.cpp
+++ b/amxmodx/amxmodx.cpp
@@ -649,7 +649,7 @@ static cell AMX_NATIVE_CALL show_dhudmessage(AMX *amx, cell *params) /* 2 param 
 static cell AMX_NATIVE_CALL get_user_name(AMX *amx, cell *params) /* 3 param */
 {
 	int index = params[1];
-	int maxlen = params[3] + 1; // EOS.
+	int maxlen = params[3];
 
 	if (index < 1 || index > gpGlobals->maxClients)
 		return set_amxstring_utf8(amx, params[2], hostname->string, strlen(hostname->string), maxlen);
@@ -1640,8 +1640,8 @@ static cell AMX_NATIVE_CALL get_concmd(AMX *amx, cell *params) /* 7 param */
 	if (cmd == 0)
 		return 0;
 	
-	set_amxstring_utf8(amx, params[2], cmd->getCmdLine(), strlen(cmd->getCmdLine()), params[3] + 1); // + EOS
-	set_amxstring_utf8(amx, params[5], cmd->getCmdInfo(), strlen(cmd->getCmdInfo()), params[6] + 1); // + EOS
+	set_amxstring_utf8(amx, params[2], cmd->getCmdLine(), strlen(cmd->getCmdLine()), params[3]);
+	set_amxstring_utf8(amx, params[5], cmd->getCmdInfo(), strlen(cmd->getCmdInfo()), params[6]);
 	cell *cpFlags = get_amxaddr(amx, params[4]);
 	*cpFlags = cmd->getFlags();
 	
@@ -1677,8 +1677,8 @@ static cell AMX_NATIVE_CALL get_clcmd(AMX *amx, cell *params) /* 7 param */
 	if (cmd == 0)
 		return 0;
 
-	set_amxstring_utf8(amx, params[2], cmd->getCmdLine(), strlen(cmd->getCmdLine()), params[3] + 1); // + EOS
-	set_amxstring_utf8(amx, params[5], cmd->getCmdInfo(), strlen(cmd->getCmdInfo()), params[6] + 1); // + EOS
+	set_amxstring_utf8(amx, params[2], cmd->getCmdLine(), strlen(cmd->getCmdLine()), params[3]);
+	set_amxstring_utf8(amx, params[5], cmd->getCmdInfo(), strlen(cmd->getCmdInfo()), params[6]);
 	cell *cpFlags = get_amxaddr(amx, params[4]);
 	*cpFlags = cmd->getFlags();
 
@@ -1692,8 +1692,8 @@ static cell AMX_NATIVE_CALL get_srvcmd(AMX *amx, cell *params)
 	if (cmd == 0)
 		return 0;
 	
-	set_amxstring_utf8(amx, params[2], cmd->getCmdLine(), strlen(cmd->getCmdLine()), params[3] + 1); // + EOS
-	set_amxstring_utf8(amx, params[5], cmd->getCmdInfo(), strlen(cmd->getCmdInfo()), params[6] + 1); // + EOS
+	set_amxstring_utf8(amx, params[2], cmd->getCmdLine(), strlen(cmd->getCmdLine()), params[3]);
+	set_amxstring_utf8(amx, params[5], cmd->getCmdInfo(), strlen(cmd->getCmdInfo()), params[6]);
 	cell *cpFlags = get_amxaddr(amx, params[4]);
 	*cpFlags = cmd->getFlags();
 	
@@ -2030,7 +2030,7 @@ static cell AMX_NATIVE_CALL format_time(AMX *amx, cell *params) /* 3 param */
 	char szDate[512];
 	ilen = strftime(szDate, 511, sptemp, lt);
 	
-	return set_amxstring_utf8(amx, params[1], szDate, ilen, params[2] + 1); // + EOS
+	return set_amxstring_utf8(amx, params[1], szDate, ilen, params[2]);
 
 }
 
@@ -2096,7 +2096,7 @@ static cell AMX_NATIVE_CALL read_data(AMX *amx, cell *params) /* 3 param */
 			return g_events.getArgInteger(params[1]);
 		case 3:
 			return set_amxstring_utf8(amx, params[2], g_events.getArgString(params[1]), 
-				strlen(g_events.getArgString(params[1])),*get_amxaddr(amx, params[3]) + 1); // + EOS
+				strlen(g_events.getArgString(params[1])),*get_amxaddr(amx, params[3]));
 		default:
 			cell *fCell = get_amxaddr(amx, params[2]);
 			REAL fparam = (REAL)g_events.getArgFloat(params[1]);
@@ -2300,7 +2300,7 @@ static cell AMX_NATIVE_CALL get_localinfo(AMX *amx, cell *params) /* 3 param */
 	char* sptemp = get_amxstring(amx, params[1], 0, ilen);
 	
 	char *value = LOCALINFO(sptemp);
-	return set_amxstring_utf8(amx, params[2], value, strlen(value), params[3] + 1); //  + EOS
+	return set_amxstring_utf8(amx, params[2], value, strlen(value), params[3]);
 }
 
 static cell AMX_NATIVE_CALL set_localinfo(AMX *amx, cell *params) /* 2 param */
@@ -2376,13 +2376,13 @@ static cell AMX_NATIVE_CALL read_argv(AMX *amx, cell *params) /* 3 param */
 	int argc = params[1];
 
 	const char *value = g_fakecmd.notify ? (argc >= 0 && argc < 3 ? g_fakecmd.argv[argc] : "") : CMD_ARGV(argc);
-	return set_amxstring_utf8(amx, params[2], value, strlen(value), params[3] + 1); // + EOS
+	return set_amxstring_utf8(amx, params[2], value, strlen(value), params[3]);
 }
 
 static cell AMX_NATIVE_CALL read_args(AMX *amx, cell *params) /* 2 param */
 {
 	const char* sValue = g_fakecmd.notify ? (g_fakecmd.argc > 1 ? g_fakecmd.args : g_fakecmd.argv[0]) : CMD_ARGS();
-	return set_amxstring_utf8(amx, params[1], sValue ? sValue : "", sValue ? strlen(sValue) : 0, params[2] + 1); // +EOS
+	return set_amxstring_utf8(amx, params[1], sValue ? sValue : "", sValue ? strlen(sValue) : 0, params[2]);
 }
 
 static cell AMX_NATIVE_CALL get_user_msgid(AMX *amx, cell *params) /* 1 param */
@@ -2925,7 +2925,7 @@ static cell AMX_NATIVE_CALL force_unmodified(AMX *amx, cell *params)
 static cell AMX_NATIVE_CALL read_logdata(AMX *amx, cell *params)
 {
 	const char *value = g_logevents.getLogString();
-	return set_amxstring_utf8(amx, params[1], value, strlen(value), params[2] + 1); // + EOS
+	return set_amxstring_utf8(amx, params[1], value, strlen(value), params[2]);
 }
 
 static cell AMX_NATIVE_CALL read_logargc(AMX *amx, cell *params)
@@ -2936,7 +2936,7 @@ static cell AMX_NATIVE_CALL read_logargc(AMX *amx, cell *params)
 static cell AMX_NATIVE_CALL read_logargv(AMX *amx, cell *params)
 {
 	const char *value = g_logevents.getLogArg(params[1]);
-	return set_amxstring_utf8(amx, params[2], value, strlen(value), params[3] + 1); // + EOS
+	return set_amxstring_utf8(amx, params[2], value, strlen(value), params[3]);
 }
 
 static cell AMX_NATIVE_CALL parse_loguser(AMX *amx, cell *params)
@@ -3224,9 +3224,9 @@ static cell AMX_NATIVE_CALL get_module(AMX *amx, cell *params)
 		const char *author = info && info->author ? info->author : "unk";
 		const char *version = info && info->version ? info->version : "unk";
 
-		set_amxstring_utf8(amx, params[2], name, strlen(name), params[3]  + 1); // + EOS
-		set_amxstring_utf8(amx, params[4], author, strlen(author), params[5] + 1); // + EOS
-		set_amxstring_utf8(amx, params[6], version, strlen(version), params[7] + 1); // + EOS
+		set_amxstring_utf8(amx, params[2], name, strlen(name), params[3]);
+		set_amxstring_utf8(amx, params[4], author, strlen(author), params[5]);
+		set_amxstring_utf8(amx, params[6], version, strlen(version), params[7]);
 	}
 
 	// compatibility problem possible

--- a/amxmodx/cvars.cpp
+++ b/amxmodx/cvars.cpp
@@ -207,7 +207,7 @@ static cell AMX_NATIVE_CALL get_cvar_string(AMX *amx, cell *params)
 	const char *value = info ? info->var->string : "";
 	length = info ? strlen(value) : 0;
 
-	return set_amxstring_utf8(amx, params[2], value, length, params[3] + 1); // + EOS
+	return set_amxstring_utf8(amx, params[2], value, length, params[3]);
 }
 
 // set_cvar_flags(const cvar[], flags)
@@ -336,7 +336,7 @@ static cell AMX_NATIVE_CALL get_pcvar_string(AMX *amx, cell *params)
 		return 0;
 	}
 
-	return set_amxstring_utf8(amx, params[2], ptr->string ? ptr->string : "", ptr->string ? strlen(ptr->string) : 0, params[3] + 1); // EOS
+	return set_amxstring_utf8(amx, params[2], ptr->string ? ptr->string : "", ptr->string ? strlen(ptr->string) : 0, params[3]);
 }
 
 // get_pcvar_bounds(pcvar, CvarBounds:type, &Float:value)

--- a/amxmodx/datapacks.cpp
+++ b/amxmodx/datapacks.cpp
@@ -143,7 +143,7 @@ static cell AMX_NATIVE_CALL ReadPackString(AMX* amx, cell* params)
 	size_t len;
 	const char *str = d->ReadString(&len);
 
-	return set_amxstring_utf8(amx, params[2], str, len, params[3] + 1); // + EOS
+	return set_amxstring_utf8(amx, params[2], str, len, params[3]);
 }
 
 static cell AMX_NATIVE_CALL ResetPack(AMX* amx, cell* params)

--- a/amxmodx/datastructs.cpp
+++ b/amxmodx/datastructs.cpp
@@ -240,7 +240,7 @@ static cell AMX_NATIVE_CALL ArrayGetString(AMX* amx, cell* params)
 	}
 
 	cell *blk = vec->at(idx);
-	return set_amxstring_utf8(amx, params[3], blk, amxstring_len(blk), params[4] + 1); // + EOS.
+	return set_amxstring_utf8(amx, params[3], blk, amxstring_len(blk), params[4]);
 }
 
 // native ArraySetArray(Array:which, item, const any:input[], size =-1);

--- a/amxmodx/file.cpp
+++ b/amxmodx/file.cpp
@@ -62,7 +62,7 @@ static cell AMX_NATIVE_CALL read_dir(AMX *amx, cell *params)
 	const char* entry = dir->GetEntryName();
 	cell* outputLen = get_amxaddr(amx, params[5]);
 
-	*outputLen = set_amxstring_utf8(amx, params[3], entry, strlen(entry), params[4] + 1);
+	*outputLen = set_amxstring_utf8(amx, params[3], entry, strlen(entry), params[4]);
 
 	return offset;
 }
@@ -103,7 +103,7 @@ static cell AMX_NATIVE_CALL read_file(AMX *amx, cell *params)
 			buffer[--length] = '\0';
 
 		cell* textLen = get_amxaddr(amx, params[5]);
-		*textLen = set_amxstring_utf8(amx, params[3], buffer, length, params[4] + 1); // + EOS
+		*textLen = set_amxstring_utf8(amx, params[3], buffer, length, params[4]);
 
 		return currentLine;
 	}
@@ -624,7 +624,7 @@ static cell AMX_NATIVE_CALL amx_fgets(AMX *amx, cell *params)
 
 	fp->ReadLine(buffer, sizeof(buffer) - 1);
 
-	return set_amxstring_utf8(amx, params[2], buffer, strlen(buffer), params[3] + 1); // + EOS
+	return set_amxstring_utf8(amx, params[2], buffer, strlen(buffer), params[3]);
 }
 
 // native fseek(file, position, start);
@@ -776,7 +776,7 @@ static cell AMX_NATIVE_CALL amx_open_dir(AMX *amx, cell *params)
 			return 0;
 		}
 
-		set_amxstring_utf8(amx, params[2], pFirst, strlen(pFirst), params[3] + 1);
+		set_amxstring_utf8(amx, params[2], pFirst, strlen(pFirst), params[3]);
 		cell* fileType = get_amxaddr(amx, params[4]);
 
 		*fileType = g_FileSystem->FindIsDirectory(handle) ? FileType_Directory : FileType_File;
@@ -798,7 +798,7 @@ static cell AMX_NATIVE_CALL amx_open_dir(AMX *amx, cell *params)
 	}
 
 	const char* entry = dir->GetEntryName();
-	set_amxstring_utf8(amx, params[2], entry, strlen(entry), params[3] + 1);
+	set_amxstring_utf8(amx, params[2], entry, strlen(entry), params[3]);
 
 	return reinterpret_cast<cell>(new DirectoryHandle(reinterpret_cast<void*>(dir), false));
 }
@@ -861,7 +861,7 @@ static cell AMX_NATIVE_CALL amx_get_dir(AMX *amx, cell *params)
 			*fileType = g_FileSystem->FindIsDirectory(*handle) ? FileType_Directory : FileType_File;
 		}
 
-		set_amxstring_utf8(amx, params[2], entry, strlen(entry), params[3] + 1);
+		set_amxstring_utf8(amx, params[2], entry, strlen(entry), params[3]);
 	}
 	else
 	{
@@ -887,7 +887,7 @@ static cell AMX_NATIVE_CALL amx_get_dir(AMX *amx, cell *params)
 
 		const char* entry = handle->GetEntryName();
 
-		set_amxstring_utf8(amx, params[2], entry, strlen(entry), params[3] + 1);
+		set_amxstring_utf8(amx, params[2], entry, strlen(entry), params[3]);
 	}
 
 	return 1;

--- a/amxmodx/stackstructs.cpp
+++ b/amxmodx/stackstructs.cpp
@@ -184,7 +184,7 @@ static cell AMX_NATIVE_CALL PopStackString(AMX* amx, cell* params)
 	size_t idx = vec->size() - 1;
 	cell *blk = vec->at(idx);
 
-	int numWritten = set_amxstring_utf8(amx, params[2], blk, amxstring_len(blk), params[3] + 1);
+	int numWritten = set_amxstring_utf8(amx, params[2], blk, amxstring_len(blk), params[3]);
 	*get_amxaddr(amx, params[4]) = numWritten;
 
 	vec->remove(idx);

--- a/amxmodx/string.cpp
+++ b/amxmodx/string.cpp
@@ -113,9 +113,9 @@ int set_amxstring_utf8(AMX *amx, cell amx_addr, const T *source, size_t sourcele
 	register cell* dest = (cell *)(amx->base + (int)(((AMX_HEADER *)amx->base)->dat + amx_addr));
 	register cell* start = dest;
 
-	if (len >= maxlen)
+	if (len > maxlen)
 	{
-		len = maxlen - 1;
+		len = maxlen;
 		needtocheck = true;
 	}
 
@@ -885,8 +885,8 @@ static cell AMX_NATIVE_CALL amx_strtok(AMX *amx, cell *params)
 
 	right[right_pos] = 0;
 	left[left_pos] = 0;
-	set_amxstring_utf8(amx, params[2], left, strlen(left), leftMax + 1); // +EOS
-	set_amxstring_utf8(amx, params[4], right, strlen(right), rightMax + 1); // +EOS
+	set_amxstring_utf8(amx, params[2], left, strlen(left), leftMax);
+	set_amxstring_utf8(amx, params[4], right, strlen(right), rightMax);
 	delete [] left;
 	delete [] right;
 	
@@ -960,8 +960,8 @@ static cell AMX_NATIVE_CALL amx_strtok2(AMX *amx, cell *params)
 	right[right_pos] = 0;
 	left[left_pos] = 0;
 
-	set_amxstring_utf8(amx, params[2], left, strlen(left), left_max + 1); // + EOS
-	set_amxstring_utf8(amx, params[4], right, strlen(right), right_max + 1); // + EOS
+	set_amxstring_utf8(amx, params[2], left, strlen(left), left_max);
+	set_amxstring_utf8(amx, params[4], right, strlen(right), right_max);
 
 	delete [] left;
 	delete [] right;
@@ -1061,7 +1061,7 @@ do_copy:
 				                    : end - beg
 				                   )
 				                 : 0;
-				set_amxstring_utf8(amx, params[2], start, strlen(start), copylen + 1); // + EOS
+				set_amxstring_utf8(amx, params[2], start, strlen(start), copylen);
 
 				end = (len-i+1 > (size_t)RightMax) ? (size_t)RightMax : len-i+1;
 				if (end)
@@ -1077,7 +1077,7 @@ do_copy:
 	}
 
 	//if we got here, there was nothing to break
-	set_amxstring_utf8(amx, params[2], &(string[beg]), strlen(&(string[beg])), LeftMax + 1); // + EOS
+	set_amxstring_utf8(amx, params[2], &(string[beg]), strlen(&(string[beg])), LeftMax);
 	if (RightMax)
 		*right = '\0';
 
@@ -1106,13 +1106,13 @@ static cell AMX_NATIVE_CALL split_string(AMX *amx, cell *params)
 		if (strncmp(&text[i], split, splitLen) == 0)
 		{
 			/* Split hereeeee */
-			if (i >= maxLen + 1) // + null terminator
+			if (i > maxLen)
 			{
-				set_amxstring_utf8(amx, params[3], text, textLen, maxLen + 1); // + null terminator
+				set_amxstring_utf8(amx, params[3], text, textLen, maxLen);
 			}
 			else
 			{
-				set_amxstring_utf8(amx, params[3], text, textLen, i + 1);
+				set_amxstring_utf8(amx, params[3], text, textLen, i);
 			}
 			return i + splitLen;
 		}
@@ -1134,7 +1134,7 @@ static cell AMX_NATIVE_CALL format_args(AMX *amx, cell *params)
 
 	char* string = format_arguments(amx, pos, len); // indexed from 0
 	
-	return set_amxstring_utf8(amx, params[1], string, len, params[2] + 1); // + EOS
+	return set_amxstring_utf8(amx, params[1], string, len, params[2]);
 }
 
 static cell AMX_NATIVE_CALL is_digit(AMX *amx, cell *params)

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -213,7 +213,7 @@ static cell AMX_NATIVE_CALL TrieGetString(AMX *amx, cell *params)
 		return 0;
 	}
 
-	*pSize = (cell)set_amxstring_utf8(amx, params[3], r->value.chars(), strlen(r->value.chars()), params[4] + 1); // + EOS
+	*pSize = (cell)set_amxstring_utf8(amx, params[3], r->value.chars(), strlen(r->value.chars()), params[4]);
 
 	return 1;
 }
@@ -425,7 +425,7 @@ static cell AMX_NATIVE_CALL TrieSnapshotGetKey(AMX *amx, cell *params)
 	}
 
 	const char *str = snapshot->strings.GetString(snapshot->keys[index]);
-	return set_amxstring_utf8(amx, params[3], str, strlen(str), params[4] + 1);
+	return set_amxstring_utf8(amx, params[3], str, strlen(str), params[4]);
 }
 
 //native TrieSnapshotDestroy(&Snapshot:handle)

--- a/modules/geoip/geoip_natives.cpp
+++ b/modules/geoip/geoip_natives.cpp
@@ -115,7 +115,7 @@ static cell AMX_NATIVE_CALL amx_geoip_country(AMX *amx, cell *params)
 		return MF_SetAmxString(amx, params[2], "error", params[3]);
 	}
 
-	return MF_SetAmxStringUTF8Char(amx, params[2], country, length, params[3] + 1);
+	return MF_SetAmxStringUTF8Char(amx, params[2], country, length, params[3]);
 }
 
 // native geoip_country_ex(const ip[], result[], len, id = -1);
@@ -127,7 +127,7 @@ static cell AMX_NATIVE_CALL amx_geoip_country_ex(AMX *amx, cell *params)
 	const char *path[] = { "country", "names", getLang(params[4]), NULL };
 	const char *country = lookupString(ip, path, &length);
 
-	return MF_SetAmxStringUTF8Char(amx, params[2], country ? country : "", length, params[3] + 1);
+	return MF_SetAmxStringUTF8Char(amx, params[2], country ? country : "", length, params[3]);
 }
 
 // native geoip_city(const ip[], result[], len, id = -1);
@@ -139,7 +139,7 @@ static cell AMX_NATIVE_CALL amx_geoip_city(AMX *amx, cell *params)
 	const char *path[] = { "city", "names", getLang(params[4]), NULL };
 	const char *city = lookupString(ip, path, &length);
 
-	return MF_SetAmxStringUTF8Char(amx, params[2], city ? city : "", length, params[3] + 1);
+	return MF_SetAmxStringUTF8Char(amx, params[2], city ? city : "", length, params[3]);
 }
 
 // native geoip_region_code(const ip[], result[], len);
@@ -185,7 +185,7 @@ static cell AMX_NATIVE_CALL amx_geoip_region_name(AMX *amx, cell *params)
 	const char *path[] = { "subdivisions", "0", "names", getLang(params[4]), NULL }; // First result.
 	const char *region = lookupString(ip, path, &length);
 
-	return MF_SetAmxStringUTF8Char(amx, params[2], region ? region : "", length, params[3] + 1);
+	return MF_SetAmxStringUTF8Char(amx, params[2], region ? region : "", length, params[3]);
 }
 
 // native geoip_timezone(const ip[], result[], len);
@@ -260,7 +260,7 @@ static cell AMX_NATIVE_CALL amx_geoip_continent_name(AMX *amx, cell *params)
 	const char *path[] = { "continent", "names", getLang(params[4]), NULL };
 	const char *continent = lookupString(ip, path, &length);
 
-	return MF_SetAmxStringUTF8Char(amx, params[2], continent ? continent : "", length, params[3] + 1);
+	return MF_SetAmxStringUTF8Char(amx, params[2], continent ? continent : "", length, params[3]);
 }
 
 


### PR DESCRIPTION
Originally code was copied from SM, and last argument is max length including null terminator. In AMXX, plugins returns the length without null terminator, so it makes sense that max length doesn't include it. This is also more consistent wiht `set_amxstring`. 