### PR TITLE
Implement a game config parser and expose functionnalities to the module/plugin API

### DIFF
--- a/amxmodx/AMBuilder
+++ b/amxmodx/AMBuilder
@@ -91,9 +91,11 @@ binary.sources = [
   'textparse.cpp',
   'CvarManager.cpp',
   'cvars.cpp',
+  '../public/memtools/MemoryUtils.cpp',
   '../public/memtools/CDetour/detours.cpp',
   '../public/memtools/CDetour/asm/asm.c',
   'CLibrarySys.cpp',
+  'CGameConfigs.cpp',
 ]
 
 if builder.target_platform == 'windows':

--- a/amxmodx/AMBuilder
+++ b/amxmodx/AMBuilder
@@ -96,6 +96,7 @@ binary.sources = [
   '../public/memtools/CDetour/asm/asm.c',
   'CLibrarySys.cpp',
   'CGameConfigs.cpp',
+  'gameconfigs.cpp',
 ]
 
 if builder.target_platform == 'windows':

--- a/amxmodx/CGameConfigs.cpp
+++ b/amxmodx/CGameConfigs.cpp
@@ -1,0 +1,894 @@
+// vim: set ts=4 sw=4 tw=99 noet:
+//
+// AMX Mod X, based on AMX Mod by Aleksander Naszko ("OLO").
+// Copyright (C) The AMX Mod X Development Team.
+//
+// This software is licensed under the GNU General Public License, version 3 or higher.
+// Additional exceptions apply. For full license details, see LICENSE.txt or visit:
+//     https://alliedmods.net/amxmodx-license
+
+#include "CGameConfigs.h"
+#include <MemoryUtils.h>
+#include <amxmodx.h>
+
+CGameConfigManager ConfigManager;
+static CGameMasterReader MasterReader;
+
+// 
+// GAME CONFIG
+//
+
+enum
+{
+	PSTATE_NONE,
+	PSTATE_GAMES,
+	PSTATE_GAMEDEFS,
+	PSTATE_GAMEDEFS_OFFSETS,
+	PSTATE_GAMEDEFS_OFFSETS_OFFSET,
+	PSTATE_GAMEDEFS_KEYS,
+	PSTATE_GAMEDEFS_SUPPORTED,
+	PSTATE_GAMEDEFS_SIGNATURES,
+	PSTATE_GAMEDEFS_SIGNATURES_SIG,
+	PSTATE_GAMEDEFS_CUSTOM,
+	PSTATE_GAMEDEFS_ADDRESSES,
+	PSTATE_GAMEDEFS_ADDRESSES_ADDRESS,
+	PSTATE_GAMEDEFS_ADDRESSES_ADDRESS_READ,
+};
+
+struct TempSigInfo
+{
+	void Reset()
+	{
+		library[0] = '\0';
+		signature[0] = '\0';
+	}
+
+	char signature[1024];
+	char library[64];
+
+} TempSig;
+
+static char ParseEngine[32];
+
+static bool DoesGameMatch(const char *value)
+{
+	return g_mod_name.compare(value) == 0;
+}
+
+static bool DoesEngineMatch(const char* value)
+{
+	return strcmp(ParseEngine, value) == 0;
+}
+
+CGameConfig::CGameConfig(const char *path)
+{
+	strncopy(m_File, path, sizeof(m_File));
+	strncopy(ParseEngine, IS_DEDICATED_SERVER() ? "engine_ds" : "engine_ls", sizeof(ParseEngine));
+
+	m_CustomLevel = 0;
+	m_CustomHandler = nullptr;
+}
+
+CGameConfig::~CGameConfig()
+{
+	ConfigManager.RemoveCachedConfig(this);
+}
+
+SMCResult CGameConfig::ReadSMC_NewSection(const SMCStates *states, const char *name)
+{
+	if (m_IgnoreLevel)
+	{
+		m_IgnoreLevel++;
+		return SMCResult_Continue;
+	}
+
+	switch (m_ParseState)
+	{
+		case PSTATE_NONE:
+		{
+			if (strcmp(name, "Games") == 0)
+			{
+				m_ParseState = PSTATE_GAMES;
+			}
+			else
+			{
+				m_IgnoreLevel++;
+			}
+			break;
+		}
+		case PSTATE_GAMES:
+		{
+			if (strcmp(name, "*") == 0 || strcmp(name, "#default") == 0 || DoesGameMatch(name))
+			{
+				m_ShouldBeReadingDefault = true;
+				strncopy(m_Game, name, sizeof(m_Game));
+
+				m_ParseState = PSTATE_GAMEDEFS;
+			}
+			else
+			{
+				m_IgnoreLevel++;
+			}
+			break;
+		}
+		case PSTATE_GAMEDEFS:
+		{
+			if (strcmp(name, "Offsets") == 0)
+			{
+				m_ParseState = PSTATE_GAMEDEFS_OFFSETS;
+			}
+			else if (strcmp(name, "Keys") == 0)
+			{
+				m_ParseState = PSTATE_GAMEDEFS_KEYS;
+			}
+			else if (strcmp(name, "#supported") == 0 && strcmp(m_Game, "#default") == 0)
+			{
+				m_ParseState = PSTATE_GAMEDEFS_SUPPORTED;
+
+				m_ShouldBeReadingDefault = false;
+				m_HadGame                = false;
+				m_MatchedGame            = false;
+				m_HadEngine              = false;
+				m_MatchedEngine          = false;
+			}
+			else if (strcmp(name, "Signatures") == 0)
+			{
+				m_ParseState = PSTATE_GAMEDEFS_SIGNATURES;
+			}
+			else if (strcmp(name, "Addresses") == 0)
+			{
+				m_ParseState = PSTATE_GAMEDEFS_ADDRESSES;
+			}
+			else
+			{
+				if (ConfigManager.m_customHandlers.retrieve(name, &m_CustomHandler))
+				{
+					m_CustomLevel = 0;
+					m_ParseState = PSTATE_GAMEDEFS_CUSTOM;
+					m_CustomHandler->ReadSMC_ParseStart();
+					break;
+				}
+
+				m_IgnoreLevel++;
+			}
+			break;
+		}
+		case PSTATE_GAMEDEFS_OFFSETS:
+		{
+			m_Class[0] = '\0';
+
+			strncopy(m_Offset, name, sizeof(m_Offset));
+
+			m_ParseState = PSTATE_GAMEDEFS_OFFSETS_OFFSET;
+			m_MatchedPlatform = false;
+			break;
+		}
+		case PSTATE_GAMEDEFS_SIGNATURES:
+		{
+			strncopy(m_Offset, name, sizeof(m_Offset));
+			TempSig.Reset();
+
+			m_ParseState = PSTATE_GAMEDEFS_SIGNATURES_SIG;
+			m_MatchedPlatform = false;
+			break;
+		}
+		case PSTATE_GAMEDEFS_CUSTOM:
+		{
+			m_CustomLevel++;
+			return m_CustomHandler->ReadSMC_NewSection(states, name);
+			break;
+		}
+		case PSTATE_GAMEDEFS_ADDRESSES:
+		{
+			m_Address[0]          = '\0';
+			m_AddressSignature[0] = '\0';
+			m_AddressReadCount    = 0;
+
+			strncopy(m_Address, name, sizeof(m_Address));
+
+			m_ParseState = PSTATE_GAMEDEFS_ADDRESSES_ADDRESS;
+			break;
+		}
+		case PSTATE_GAMEDEFS_ADDRESSES_ADDRESS:
+		{
+			if (g_LibSys.DoesPlatformMatch(name))
+			{
+				m_ParseState = PSTATE_GAMEDEFS_ADDRESSES_ADDRESS_READ;
+			}
+			else
+			{
+				if (strcmp(name, PLATFORM_LINUX_NAME) != 0 && strcmp(name, PLATFORM_WINDOWNS_NAME) != 0 && strcmp(name, PLATFORM_MAC_NAME) != 0)
+				{
+					AMXXLOG_Error("Error while parsing Address section for \"%s\" (%s):", m_Address, m_CurrentPath);
+					AMXXLOG_Error("Unrecognized platform \"%s\"", name);
+				}
+
+				m_IgnoreLevel = 1;
+			}
+			break;
+		}
+		default:
+		{
+			m_IgnoreLevel++;
+			break;
+		}
+	}
+
+	return SMCResult_Continue;
+}
+
+SMCResult CGameConfig::ReadSMC_KeyValue(const SMCStates *states, const char *key, const char *value)
+{
+	if (m_IgnoreLevel)
+	{
+		return SMCResult_Continue;
+	}
+
+	switch (m_ParseState)
+	{
+		case PSTATE_GAMEDEFS_OFFSETS_OFFSET:
+		{
+			if (strcmp(key, "class") == 0)
+			{
+				strncopy(m_Class, value, sizeof(m_Class));
+			}
+			else if (g_LibSys.IsPlatformCompatible(key, &m_MatchedPlatform))
+			{
+				if (m_Class[0])
+				{
+					auto ic = m_OffsetsByClass.findForAdd(m_Class);
+
+					if (ic.found())
+					{
+						ic->value->list.replace(m_Offset, atoi(value));
+					}
+					else if (m_OffsetsByClass.add(ic, m_Class))
+					{
+						ic->value = new OffsetClass;
+						ic->value->list.insert(m_Offset, atoi(value));
+					}			
+				}
+				else
+				{
+					m_Offsets.replace(m_Offset, atoi(value));
+				}
+			}
+			break;
+		}
+		case PSTATE_GAMEDEFS_KEYS:
+		{
+			ke::AString vstr(value);
+			m_Keys.replace(key, ke::Move(vstr));
+			break;
+		}
+		case PSTATE_GAMEDEFS_SUPPORTED:
+		{
+			if (strcmp(key, "game") == 0)
+			{
+				m_HadGame = true;
+
+				if (DoesGameMatch(value))
+				{
+					m_MatchedGame = true;
+				}
+
+				if ((!m_HadEngine && m_MatchedGame) || (m_MatchedEngine && m_MatchedGame))
+				{
+					m_ShouldBeReadingDefault = true;
+				}
+			}
+			else if (strcmp(key, "engine") == 0)
+			{
+				m_HadEngine = true;
+
+				if (DoesEngineMatch(value))
+				{
+					m_MatchedEngine = true;
+				}
+
+				if ((!m_HadGame && m_MatchedEngine) || (m_MatchedGame && m_MatchedEngine))
+				{
+					m_ShouldBeReadingDefault = true;
+				}
+			}
+			break;
+		}
+		case PSTATE_GAMEDEFS_SIGNATURES_SIG:
+		{
+			if (g_LibSys.IsPlatformCompatible(key, &m_MatchedPlatform))
+			{
+				strncopy(TempSig.signature, value, sizeof(TempSig.signature));
+			}
+			else if (strcmp(key, "library") == 0)
+			{
+				strncopy(TempSig.library, value, sizeof(TempSig.library));
+			}
+			break;
+		}
+		case PSTATE_GAMEDEFS_ADDRESSES_ADDRESS:
+		case PSTATE_GAMEDEFS_ADDRESSES_ADDRESS_READ:
+		{
+			if (strcmp(key, "read") == 0)
+			{
+				int limit = sizeof(m_AddressRead) / sizeof(m_AddressRead[0]);
+
+				if (m_AddressReadCount < limit)
+				{
+					m_AddressRead[m_AddressReadCount] = atoi(value);
+					m_AddressReadCount++;
+				}
+				else
+				{
+					AMXXLOG_Error("[SM] Error parsing Address \"%s\", does not support more than %d read offsets (gameconf \"%s\")", 
+								  m_Address, limit, m_CurrentPath);
+				}
+			}
+			else if (strcmp(key, "signature") == 0)
+			{
+				strncopy(m_AddressSignature, value, sizeof(m_AddressSignature));
+			}
+			break;
+		}
+		case PSTATE_GAMEDEFS_CUSTOM:
+		{
+			return m_CustomHandler->ReadSMC_KeyValue(states, key, value);
+		}
+	}
+
+	return SMCResult_Continue;
+}
+
+SMCResult CGameConfig::ReadSMC_LeavingSection(const SMCStates *states)
+{
+	if (m_IgnoreLevel)
+	{
+		m_IgnoreLevel--;
+		return SMCResult_Continue;
+	}
+
+	if (m_CustomLevel)
+	{
+		m_CustomLevel--;
+		m_CustomHandler->ReadSMC_LeavingSection(states);
+		return SMCResult_Continue;
+	}
+
+	switch (m_ParseState)
+	{
+		case PSTATE_GAMES:
+		{
+			m_ParseState = PSTATE_NONE;
+			break;
+		}
+		case PSTATE_GAMEDEFS:
+		{
+			m_ParseState = PSTATE_GAMES;
+			break;
+		}
+		case PSTATE_GAMEDEFS_CUSTOM:
+		{
+			m_ParseState = PSTATE_GAMEDEFS;
+			m_CustomHandler->ReadSMC_ParseEnd(false, false);
+			break;
+		}
+		case PSTATE_GAMEDEFS_KEYS:
+		case PSTATE_GAMEDEFS_OFFSETS:
+		{
+			m_ParseState = PSTATE_GAMEDEFS;
+			break;
+		}
+		case PSTATE_GAMEDEFS_OFFSETS_OFFSET:
+		{
+			m_ParseState = PSTATE_GAMEDEFS_OFFSETS;
+			break;
+		}
+		case PSTATE_GAMEDEFS_SUPPORTED:
+		{
+			if (!m_ShouldBeReadingDefault)
+			{
+				m_IgnoreLevel = 1;
+				m_ParseState = PSTATE_GAMES;
+			}
+			else 
+			{
+				m_ParseState = PSTATE_GAMEDEFS;
+			}
+			break;
+		}
+		case PSTATE_GAMEDEFS_SIGNATURES:
+		{
+			m_ParseState = PSTATE_GAMEDEFS;
+			break;
+		}
+		case PSTATE_GAMEDEFS_SIGNATURES_SIG:
+		{
+			if (TempSig.library[0] == '\0')
+			{
+				strncopy(TempSig.library, "server", sizeof(TempSig.library));
+			}
+
+			void *addressInBase = nullptr;
+
+			if (strcmp(TempSig.library, "server") == 0)
+			{
+				addressInBase = reinterpret_cast<void*>(MDLL_Spawn);
+			}
+			else if (strcmp(TempSig.library, "engine") == 0) 
+			{
+				addressInBase = reinterpret_cast<void*>(gpGlobals);
+			}
+
+			void *finalAddress = nullptr;
+
+			if (!addressInBase)
+			{
+				AMXXLOG_Error("Unrecognized library \"%s\" (gameconf \"%s\")", TempSig.library, m_CurrentPath);
+			}
+			else if (TempSig.signature[0])
+			{
+				if (TempSig.signature[0] == '@')
+				{
+#if defined PLATFORM_WINDOWS
+					MEMORY_BASIC_INFORMATION mem;
+
+					if (VirtualQuery(addressInBase, &mem, sizeof(mem)))
+					{
+						finalAddress = g_MemUtils.ResolveSymbol(mem.AllocationBase, &TempSig.signature[1]);
+					}
+					else
+					{
+						AMXXLOG_Error("Unable to find library \"%s\" in memory (gameconf \"%s\")", TempSig.library, m_File);
+					}
+
+#elif defined PLATFORM_POSIX
+					Dl_info info;
+		
+					if (dladdr(addressInBase, &info) != 0)
+					{
+						void *handle = dlopen(info.dli_fname, RTLD_NOW);
+
+						if (handle)
+						{
+							finalAddress = g_MemUtils.ResolveSymbol(handle, &TempSig.signature[1]);
+							dlclose(handle);
+						}
+						else
+						{
+							AMXXLOG_Error("Unable to load library \"%s\" (gameconf \"%s\")", TempSig.library, m_File);
+						}
+					}
+					else 
+					{
+						AMXXLOG_Error("Unable to find library \"%s\" in memory (gameconf \"%s\")", TempSig.library, m_File);
+					}
+#endif
+				}
+
+				if (!finalAddress)
+				{
+					finalAddress = g_MemUtils.DecodeAndFindPattern(addressInBase, TempSig.signature);
+				}
+
+				m_Sigs.replace(m_Offset, finalAddress);
+			}
+
+			m_ParseState = PSTATE_GAMEDEFS_SIGNATURES;
+			break;
+		}
+		case PSTATE_GAMEDEFS_ADDRESSES:
+		{
+			m_ParseState = PSTATE_GAMEDEFS;
+			break;
+		}
+		case PSTATE_GAMEDEFS_ADDRESSES_ADDRESS:
+		{
+			m_ParseState = PSTATE_GAMEDEFS_ADDRESSES;
+
+			if (m_Address[0] != '\0' && m_AddressSignature[0] != '\0')
+			{
+				AddressConf addrConf(m_AddressSignature, sizeof(m_AddressSignature), m_AddressReadCount, m_AddressRead);
+				m_Addresses.replace(m_Address, addrConf);
+			}
+
+			break;
+		}
+		case PSTATE_GAMEDEFS_ADDRESSES_ADDRESS_READ:
+		{
+			m_ParseState = PSTATE_GAMEDEFS_ADDRESSES_ADDRESS;
+			break;
+		}
+	}
+
+	return SMCResult_Continue;
+}
+
+bool CGameConfig::Reparse(char *error, size_t maxlength)
+{
+	m_Offsets.clear();
+	m_OffsetsByClass.clear();
+	m_Keys.clear();
+	m_Addresses.clear();
+
+	char path[PLATFORM_MAX_PATH];
+	const char *dataDir = get_localinfo("amxx_datadir", "addons/amxmodx/data");
+
+	build_pathname_r(path, sizeof(path), "%s/gamedata/%s/master.games.txt", dataDir, m_File);
+
+	if (!g_LibSys.PathExists(path))
+	{
+		return false;
+	}
+
+	SMCError err;
+	SMCStates state = { 0, 0 };
+
+	ke::Vector<ke::AString> fileList;
+	MasterReader.m_FileList = &fileList;
+
+	err = textparsers->ParseSMCFile(path, &MasterReader, &state, error, maxlength);
+
+	if (err != SMCError_Okay)
+	{
+		const char *msg = textparsers->GetSMCErrorString(err);
+
+		AMXXLOG_Error("Error parsing master gameconf file \"%s\":", path);
+		AMXXLOG_Error("Error %d on line %d, col %d: %s", err, state.line, state.col, msg ? msg : "Unknown error");
+
+		return false;
+	}
+
+	for (size_t i = 0; i < fileList.length(); ++i)
+	{
+		g_LibSys.PathFormat(path, sizeof(path), "%s/%s", m_File, fileList[i].chars());
+
+		if (!EnterFile(path, error, maxlength))
+		{
+			return false;
+		}
+	}
+
+	build_pathname_r(path, sizeof(path), "%s/gamedata/%s/custom", dataDir, m_File);
+	CDirectory *customDir = g_LibSys.OpenDirectory(path);
+
+	if (!customDir)
+	{
+		return true;
+	}
+
+	while (customDir->MoreFiles())
+	{
+		if (!customDir->IsEntryFile())
+		{
+			customDir->NextEntry();
+			continue;
+		}
+
+		const char *currentFile = customDir->GetEntryName();
+
+		size_t length = strlen(currentFile);
+
+		if (length > 4 && strcmp(&currentFile[length - 4], ".txt") != 0)
+		{
+			customDir->NextEntry();
+			continue;
+		}
+
+		g_LibSys.PathFormat(path, sizeof(path), "%s/custom/%s", m_File, currentFile);
+
+		if (!EnterFile(path, error, maxlength))
+		{
+			g_LibSys.CloseDirectory(customDir);
+			return false;
+		}
+
+		customDir->NextEntry();
+	}
+
+	g_LibSys.CloseDirectory(customDir);
+
+	return true;
+}
+
+bool CGameConfig::EnterFile(const char *file, char *error, size_t maxlength)
+{
+	char path[PLATFORM_MAX_PATH];
+	build_pathname_r(path, sizeof(path), "%s/gamedata/%s", get_localinfo("amxx_datadir", "addons/amxmodx/data"), file);
+
+	strncopy(m_CurrentPath, path, sizeof(m_CurrentPath));
+
+	m_IgnoreLevel = 0;
+	m_ShouldBeReadingDefault = true;
+	m_ParseState = PSTATE_NONE;
+
+	SMCError err;
+	SMCStates state = { 0, 0 };
+
+	if ((err = textparsers->ParseSMCFile(m_CurrentPath, this, &state, error, maxlength)) != SMCError_Okay)
+	{
+		const char *msg = textparsers->GetSMCErrorString(err);
+
+		AMXXLOG_Error("Error parsing gameconfig file \"%s\":", m_CurrentPath);
+		AMXXLOG_Error("Error %d on line %d, col %d: %s", err, state.line, state.col, msg ? msg : "Unknown error");
+
+		if (m_ParseState == PSTATE_GAMEDEFS_CUSTOM)
+		{
+			m_CustomHandler->ReadSMC_ParseEnd(true, true);
+			m_CustomHandler = nullptr;
+			m_CustomLevel = 0;
+		}
+
+		return false;
+	}
+
+	return true;
+}
+
+bool CGameConfig::GetOffset(const char *key, int *value)
+{
+	return m_Offsets.retrieve(key, value);
+}
+
+bool CGameConfig::GetOffsetByClass(const char *classname, const char *key, int *value)
+{
+	auto r = m_OffsetsByClass.find(classname);
+
+	if (!r.found())
+	{
+		return false;
+	}
+
+	return r->value->list.retrieve(key, value);
+}
+
+const char *CGameConfig::GetKeyValue(const char *key)
+{
+	auto r = m_Keys.find(key);
+
+	if (!r.found())
+	{
+		return nullptr;
+	}
+
+	return r->value.chars();
+}
+
+//memory addresses below 0x10000 are automatically considered invalid for dereferencing
+#define VALID_MINIMUM_MEMORY_ADDRESS 0x10000
+
+bool CGameConfig::GetAddress(const char *key, void **retaddr)
+{
+	auto r = m_Addresses.find(key);
+
+	if (!r.found())
+	{
+		*retaddr = nullptr;
+		return false;
+	}
+
+	AddressConf &addrConf = r->value;
+
+	void *address;
+
+	if (!GetMemSig(addrConf.m_SignatureName, &address))
+	{
+		*retaddr = nullptr;
+		return false;
+	}
+
+	for (size_t i = 0; i < addrConf.m_ReadCount; ++i)
+	{
+		int offset = addrConf.m_ReadBytes[i];
+
+		if (!address || reinterpret_cast<uintptr_t>(address) < VALID_MINIMUM_MEMORY_ADDRESS)
+		{
+			*retaddr = nullptr;
+			return false;
+		}
+		address = *(reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(address) + offset));
+	}
+
+	*retaddr = address;
+
+	return true;
+}
+
+CGameConfig::AddressConf::AddressConf(const char *sigName, size_t sigLength, size_t readCount, int *read)
+{
+	size_t limit = sizeof(m_ReadBytes) / sizeof(m_ReadBytes[0]);
+	size_t readLimit = (readCount <= limit) ? readCount : limit;
+
+	strncopy(m_SignatureName, sigName, sizeof(m_SignatureName));
+
+	m_ReadCount = readLimit;
+	memcpy(&this->m_ReadBytes[0], read, sizeof(this->m_ReadBytes[0]) * readLimit);
+}
+
+bool CGameConfig::GetMemSig(const char *key, void **addr)
+{
+	return m_Sigs.retrieve(key, addr);
+}
+
+
+// 
+// CONFIG MASTER READER
+//
+
+#define MSTATE_NONE		0
+#define MSTATE_MAIN		1
+#define MSTATE_FILE		2
+
+void CGameMasterReader::ReadSMC_ParseStart()
+{
+	m_State = MSTATE_NONE;
+	m_IgnoreLevel = 0;
+}
+
+SMCResult CGameMasterReader::ReadSMC_NewSection(const SMCStates *states, const char *name)
+{
+	if (m_IgnoreLevel)
+	{
+		return SMCResult_Continue;
+	}
+
+	if (m_State == MSTATE_NONE)
+	{
+		if (strcmp(name, "Game Master") == 0)
+		{
+			m_State = MSTATE_MAIN;
+		}
+		else
+		{
+			m_IgnoreLevel++;
+		}
+	}
+	else if (m_State == MSTATE_MAIN)
+	{
+		strncopy(m_CurrentPath, name, sizeof(m_CurrentPath));
+
+		m_HadEngine     = false;
+		m_MatchedEngine = false;
+		m_HadGame       = false;
+		m_MatchedGame   = false;
+
+		m_State = MSTATE_FILE;
+	}
+	else if (m_State == MSTATE_FILE)
+	{
+		m_IgnoreLevel++;
+	}
+
+	return SMCResult_Continue;
+}
+
+SMCResult CGameMasterReader::ReadSMC_KeyValue(const SMCStates *states, const char *key, const char *value)
+{
+	if (m_IgnoreLevel || m_State != MSTATE_FILE)
+	{
+		return SMCResult_Continue;
+	}
+
+	if (strcmp(key, "engine") == 0)
+	{
+		m_HadEngine = true;
+
+		if (DoesEngineMatch(value))
+		{
+			m_MatchedEngine = true;
+		}
+	}
+	else if (strcmp(key, "game") == 0)
+	{
+		m_HadGame = true;
+
+		if (DoesGameMatch(value))
+		{
+			m_MatchedGame = true;
+		}
+	}
+
+	return SMCResult_Continue;
+}
+
+SMCResult CGameMasterReader::ReadSMC_LeavingSection(const SMCStates *states)
+{
+	if (m_IgnoreLevel)
+	{
+		m_IgnoreLevel--;
+		return SMCResult_Continue;
+	}
+
+	if (m_State == MSTATE_FILE)
+	{
+		// The four success conditions:
+		//   1. Needed nothing.
+		//   2. Needed game only.
+		//   3. Needed engine only.
+		//   4. Needed both engine and game.
+		// Final result is minimized via k-map.
+
+		if ((!m_HadEngine    && !m_HadGame) ||
+			(!m_HadEngine    && m_MatchedGame) ||
+			(!m_HadGame      && m_MatchedEngine) ||
+			(m_MatchedEngine && m_MatchedEngine))
+		{
+			m_FileList->append(m_CurrentPath);
+		}
+
+		m_State = MSTATE_MAIN;
+	}
+	else if (m_State == MSTATE_MAIN)
+	{
+		m_State = MSTATE_NONE;
+	}
+
+	return SMCResult_Continue;
+}
+
+
+// 
+// CONFIG MANAGER
+//
+
+CGameConfigManager::CGameConfigManager()
+{
+}
+
+CGameConfigManager::~CGameConfigManager()
+{
+}
+
+bool CGameConfigManager::LoadGameConfigFile(const char *file, IGameConfig **config, char *error, size_t maxlength)
+{
+	CGameConfig *configFromCache;
+
+	if (m_Lookup.retrieve(file, &configFromCache))
+	{
+		configFromCache->AddRef();
+		*config = configFromCache;
+
+		return true;
+	}
+
+	configFromCache = new CGameConfig(file);
+	configFromCache->AddRef();
+
+	bool returnValue = returnValue = configFromCache->Reparse(error, maxlength);
+
+	m_Lookup.insert(file, configFromCache);
+	*config = configFromCache;
+
+	return returnValue;
+}
+
+void CGameConfigManager::CloseGameConfigFile(IGameConfig *config)
+{
+	CGameConfig *currentConfig = static_cast<CGameConfig*>(config);
+	currentConfig->Release();
+}
+
+void CGameConfigManager::AddUserConfigHook(const char *sectionName, ITextListener_SMC *listener)
+{
+	m_customHandlers.insert(sectionName, listener);
+}
+
+void CGameConfigManager::RemoveUserConfigHook(const char *sectionName, ITextListener_SMC *listener)
+{
+	ITextListener_SMC *listenerFromCache;
+
+	if (!m_customHandlers.retrieve(sectionName, &listenerFromCache))
+	{
+		return;
+	}
+
+	if (listenerFromCache != listener)
+	{
+		return;
+	}
+
+	m_customHandlers.remove(sectionName);
+}
+
+void CGameConfigManager::RemoveCachedConfig(CGameConfig *config)
+{
+	m_Lookup.remove(config->m_File);
+}

--- a/amxmodx/CGameConfigs.cpp
+++ b/amxmodx/CGameConfigs.cpp
@@ -516,7 +516,21 @@ bool CGameConfig::Reparse(char *error, size_t maxlength)
 
 	if (!g_LibSys.PathExists(path))
 	{
-		return false;
+		g_LibSys.PathFormat(path, sizeof(path), "%s.txt", m_File);
+
+		if (!EnterFile(path, error, maxlength))
+		{
+			return false;
+		}
+
+		build_pathname_r(path, sizeof(path), "%s/gamedata/custom/%s.txt", dataDir, m_File);
+
+		if (g_LibSys.PathExists(path))
+		{
+			g_LibSys.PathFormat(path, sizeof(path), "custom/%s.txt", m_File);
+			return EnterFile(path, error, maxlength);
+		}
+		return true;
 	}
 
 	SMCError err;

--- a/amxmodx/CGameConfigs.h
+++ b/amxmodx/CGameConfigs.h
@@ -81,6 +81,7 @@ class CGameConfig
 		char                       m_Offset[64];
 		char                       m_Game[256];
 
+		bool                       m_MatchedClasses;
 		bool                       m_ShouldBeReadingDefault;
 		bool                       m_HadGame;
 		bool                       m_MatchedGame;

--- a/amxmodx/CGameConfigs.h
+++ b/amxmodx/CGameConfigs.h
@@ -1,0 +1,167 @@
+// vim: set ts=4 sw=4 tw=99 noet:
+//
+// AMX Mod X, based on AMX Mod by Aleksander Naszko ("OLO").
+// Copyright (C) The AMX Mod X Development Team.
+//
+// This software is licensed under the GNU General Public License, version 3 or higher.
+// Additional exceptions apply. For full license details, see LICENSE.txt or visit:
+//     https://alliedmods.net/amxmodx-license
+
+#ifndef _INCLUDE_GAMECONFIG_H_
+#define _INCLUDE_GAMECONFIG_H_
+
+#include <IGameConfigs.h>
+#include "CLibrarySys.h"
+#include <am-vector.h>
+#include <am-string.h>
+#include <am-refcounting.h>
+#include <sm_stringhashmap.h>
+#include <sm_namehashset.h>
+
+class CGameConfig 
+	:
+	public ITextListener_SMC,
+	public IGameConfig,
+	public ke::Refcounted <CGameConfig>
+{
+	friend class CGameConfigManager;
+
+	public:
+
+		CGameConfig(const char *file);
+		~CGameConfig();
+
+	public:
+
+		bool Reparse(char *error, size_t maxlength);
+		bool EnterFile(const char *file, char *error, size_t maxlength);
+
+	public: // ITextListener_SMC
+
+		SMCResult ReadSMC_NewSection(const SMCStates *states, const char *name);
+		SMCResult ReadSMC_KeyValue(const SMCStates *states, const char *key, const char *value);
+		SMCResult ReadSMC_LeavingSection(const SMCStates *states);
+
+	public: // IGameConfig
+
+		const char* GetKeyValue(const char *key);
+		bool        GetOffset(const char *key, int *value);
+		bool        GetOffsetByClass(const char *classname, const char *key, int *value);
+		bool        GetMemSig(const char *key, void **addr);
+		bool        GetAddress(const char *key, void **addr);
+
+	public: // NameHashSet
+
+		static inline bool matches(const char *key, const CGameConfig *value)
+		{
+			return strcmp(key, value->m_File) == 0;
+		}
+
+	private:
+
+		struct OffsetClass
+		{
+			StringHashMap<int> list;
+		};
+
+		typedef StringHashMap<ke::AutoPtr<OffsetClass>> OffsetClassMap;
+
+		char                       m_File[PLATFORM_MAX_PATH];
+		char                       m_CurrentPath[PLATFORM_MAX_PATH];
+
+		StringHashMap<int>         m_Offsets;
+		OffsetClassMap             m_OffsetsByClass;
+		StringHashMap<ke::AString> m_Keys;
+		StringHashMap<void*>       m_Sigs;
+
+		int                        m_ParseState;
+		unsigned int               m_IgnoreLevel;
+
+		char                       m_Class[64];
+		char                       m_Offset[64];
+		char                       m_Game[256];
+
+		bool                       m_ShouldBeReadingDefault;
+		bool                       m_HadGame;
+		bool                       m_MatchedGame;
+		bool                       m_HadEngine;
+		bool                       m_MatchedEngine;
+		bool                       m_MatchedPlatform;
+
+		unsigned int               m_CustomLevel;
+		ITextListener_SMC*         m_CustomHandler;
+
+		struct AddressConf
+		{
+			char    m_SignatureName[64];
+			size_t  m_ReadCount;
+			int     m_ReadBytes[8];
+
+			AddressConf(const char *sigName, size_t sigLength, size_t readCount, int *read);
+			AddressConf() {}
+		};
+
+		char m_Address[64];
+		char m_AddressSignature[64];
+		int  m_AddressReadCount;
+		int  m_AddressRead[8];
+		StringHashMap<AddressConf> m_Addresses;
+
+		char m_pEngine[64];
+};
+
+class CGameMasterReader : public ITextListener_SMC
+{
+	public:
+
+		void ReadSMC_ParseStart();
+
+		SMCResult ReadSMC_NewSection(const SMCStates *states, const char *name);
+		SMCResult ReadSMC_KeyValue(const SMCStates *states, const char *key, const char *value);
+		SMCResult ReadSMC_LeavingSection(const SMCStates *states);
+
+	public:
+
+		ke::Vector<ke::AString>* m_FileList;
+
+		unsigned int m_State;
+		unsigned int m_IgnoreLevel;
+
+		char         m_CurrentPath[PLATFORM_MAX_PATH];
+
+		bool         m_HadEngine;
+		bool         m_MatchedEngine;
+		bool         m_HadGame;
+		bool         m_MatchedGame;
+};
+
+class CGameConfigManager : public IGameConfigManager
+{
+	public:
+
+		CGameConfigManager();
+		~CGameConfigManager();
+
+	public: // IGameConfigManager
+
+		bool LoadGameConfigFile(const char *file, IGameConfig **pConfig, char *error, size_t maxlength);
+		void CloseGameConfigFile(IGameConfig *cfg);
+		void AddUserConfigHook(const char *sectionname, ITextListener_SMC *listener);
+		void RemoveUserConfigHook(const char *sectionname, ITextListener_SMC *listener);
+
+	public:
+
+		void RemoveCachedConfig(CGameConfig *config);
+
+	private:
+
+		NameHashSet<CGameConfig*> m_Lookup;
+
+	public:
+
+		StringHashMap<ITextListener_SMC*> m_customHandlers;
+};
+
+extern CGameConfigManager ConfigManager;
+
+#endif // _INCLUDE_GAMECONFIG_H_

--- a/amxmodx/CLibrarySys.cpp
+++ b/amxmodx/CLibrarySys.cpp
@@ -530,3 +530,29 @@ bool LibrarySystem::FileTime(const char* path, FileTimeType type, time_t* pTime)
 
 	return true;
 }
+
+bool LibrarySystem::DoesPlatformMatch(const char *platform)
+{
+	return strcmp(platform, PLATFORM_NAME) == 0;
+}
+
+bool LibrarySystem::IsPlatformCompatible(const char *platform, bool *hadPrimaryMatch)
+{
+	if (DoesPlatformMatch(platform))
+	{
+#if defined PLATFORM_COMPAT_ALT
+		*hadPrimaryMatch = true;
+#endif
+		return true;
+	}
+
+#if defined PLATFORM_COMPAT_ALT
+	/* If entry hasn't been found for the primary platform name, check for compatible alternate */
+	if (!*hadPrimaryMatch)
+	{
+		return strcmp(platform, PLATFORM_COMPAT_ALT) == 0;
+	}
+#endif
+
+	return false;
+}

--- a/amxmodx/CLibrarySys.h
+++ b/amxmodx/CLibrarySys.h
@@ -14,6 +14,9 @@
 #include <interface.h>  // Interface (HLSDK)
 #include <am-utility.h> // AutoPtr
 
+#define PLATFORM_WINDOWNS_NAME "windows"
+#define PLATFORM_LINUX_NAME    "linux"
+#define PLATFORM_MAC_NAME      "mac"
 #if defined(WIN32)
 #  ifndef PLATFORM_WINDOWS
 #  define PLATFORM_WINDOWS  1
@@ -25,6 +28,7 @@
 #  include <direct.h>
 #  include <io.h>
 #  define PLATFORM_LIB_EXT      "dll"
+#  define PLATFORM_NAME         PLATFORM_WINDOWNS_NAME
 #  define PLATFORM_SEP_CHAR     '\\'
 #  define PLATFORM_SEP_ALTCHAR  '/'
 #  define PLATFORM_EXTERN_C     extern "C" __declspec(dllexport)
@@ -32,9 +36,13 @@
 #  if defined(__linux__)
 #    define PLATFORM_LINUX      1
 #    define PLATFORM_LIB_EXT    "so"
+#    define PLATFORM_NAME       PLATFORM_LINUX_NAME
+#    define PLATFORM_COMPAT_ALT PLATFORM_MAC_NAME
 #  elif defined(__APPLE__)
 #    define PLATFORM_APPLE      1
 #    define PLATFORM_LIB_EXT    "dylib"
+#    define PLATFORM_NAME       PLATFORM_MAC_NAME
+#    define PLATFORM_COMPAT_ALT PLATFORM_LINUX_NAME
 #  endif
 #  ifndef PLATFORM_POSIX
 #    define PLATFORM_POSIX      1
@@ -153,6 +161,9 @@ class LibrarySystem
 
 		bool FileTime(const char* path, FileTimeType type, time_t* pTime);
 		void GetLoaderError(char* buffer, size_t maxlength);
+
+		bool DoesPlatformMatch(const char* platform);
+		bool IsPlatformCompatible(const char *platform, bool *hadPrimaryMatch);
 };
 
 extern LibrarySystem g_LibSys;

--- a/amxmodx/amxmodx.h
+++ b/amxmodx/amxmodx.h
@@ -67,6 +67,7 @@ extern AMX_NATIVE_INFO g_DataStructNatives[];
 extern AMX_NATIVE_INFO g_StackNatives[];
 extern AMX_NATIVE_INFO g_TextParserNatives[];
 extern AMX_NATIVE_INFO g_CvarNatives[];
+extern AMX_NATIVE_INFO g_GameConfigNatives[];
 
 #if defined(_WIN32)
 #define DLLOAD(path) (DLHANDLE)LoadLibrary(path)

--- a/amxmodx/gameconfigs.cpp
+++ b/amxmodx/gameconfigs.cpp
@@ -1,0 +1,174 @@
+// vim: set ts=4 sw=4 tw=99 noet:
+//
+// AMX Mod X, based on AMX Mod by Aleksander Naszko ("OLO").
+// Copyright (C) The AMX Mod X Development Team.
+//
+// This software is licensed under the GNU General Public License, version 3 or higher.
+// Additional exceptions apply. For full license details, see LICENSE.txt or visit:
+//     https://alliedmods.net/amxmodx-license
+
+#include "gameconfigs.h"
+#include "amxmodx.h"
+#include "CGameConfigs.h"
+
+Handle<GameConfigNative> GameConfigHandle;
+
+// native GameConfig:LoadGameConfigFile(const file[]);
+static cell AMX_NATIVE_CALL LoadGameConfigFile(AMX *amx, cell *params)
+{
+	int length;
+	const char *filename = get_amxstring(amx, params[1], 0, length);
+
+	IGameConfig *config = nullptr;
+	char error[128];
+
+	if (!ConfigManager.LoadGameConfigFile(filename, &config, error, sizeof(error)))
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Unable to open %s: %s", filename, error);
+		return 0;
+	}
+
+	int handle = GameConfigHandle.create();
+
+	auto configHandle = GameConfigHandle.lookup(handle);
+	
+	if (!configHandle)
+	{
+		return 0;
+	}
+
+	configHandle->m_config = config;
+
+	return handle;
+}
+
+// native GameConfGetOffset(GameConfig:handle, const key[]);
+static cell AMX_NATIVE_CALL GameConfGetOffset(AMX *amx, cell *params)
+{
+	GameConfigNative *handle = GameConfigHandle.lookup(params[1]);
+
+	if (!handle)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Invalid game config handle %d", params[1]);
+		return 0;
+	}
+
+	int length;
+	int value;
+
+	const char *key = get_amxstring(amx, params[2], 0, length);
+
+	if (!handle->m_config->GetOffset(key, &value))
+	{
+		return -1;
+	}
+
+	return value;
+}
+
+// native GameConfGetClassOffset(GameConfig:handle, const classname[], const key[]);
+static cell AMX_NATIVE_CALL GameConfGetClassOffset(AMX *amx, cell *params)
+{
+	GameConfigNative *handle = GameConfigHandle.lookup(params[1]);
+
+	if (!handle)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Invalid game config handle %d", params[1]);
+		return 0;
+	}
+
+	int length;
+	int value;
+
+	const char *classname = get_amxstring(amx, params[2], 0, length);
+	const char *key = get_amxstring(amx, params[3], 1, length);
+
+	if (!handle->m_config->GetOffsetByClass(classname, key, &value))
+	{
+		return -1;
+	}
+
+	return value;
+}
+
+// native bool:GameConfGetKeyValue(GameConfig:handle, const key[], buffer[], maxlen);
+static cell AMX_NATIVE_CALL GameConfGetKeyValue(AMX *amx, cell *params)
+{
+	GameConfigNative *handle = GameConfigHandle.lookup(params[1]);
+
+	if (!handle)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Invalid game config handle %d", params[1]);
+		return 0;
+	}
+
+	int length;
+	const char *value;
+	const char *key = get_amxstring(amx, params[2], 0, length);
+
+	if (!(value = handle->m_config->GetKeyValue(key)))
+	{
+		return 0;
+	}
+
+	set_amxstring_utf8(amx, params[3], value, strlen(value), params[4]);
+
+	return 1;
+}
+
+// native GameConfGetAddress(GameConfig:handle, const name[]);
+static cell AMX_NATIVE_CALL GameConfGetAddress(AMX *amx, cell *params)
+{
+	GameConfigNative *handle = GameConfigHandle.lookup(params[1]);
+
+	if (!handle)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Invalid game config handle %d", params[1]);
+		return 0;
+	}
+
+	int length;
+	void *value;
+
+	const char *key = get_amxstring(amx, params[2], 0, length);
+
+	if (!handle->m_config->GetAddress(key, &value))
+	{
+		return 0;
+	}
+
+	return reinterpret_cast<cell>(value);
+}
+
+// native CloseGameConfigFile(&GameConfig:handle);
+static cell AMX_NATIVE_CALL CloseGameConfigFile(AMX *amx, cell *params)
+{
+	cell *address = get_amxaddr(amx, params[1]);
+
+	GameConfigNative *handle = GameConfigHandle.lookup(*address);
+
+	if (!handle)
+	{
+		return 0;
+	}
+
+	if (GameConfigHandle.destroy(*address))
+	{
+		*address = 0;
+		return 1;
+	}
+
+	return 0;
+}
+
+
+AMX_NATIVE_INFO g_GameConfigNatives[] = 
+{
+	{ "LoadGameConfigFile"    , LoadGameConfigFile     },
+	{ "GameConfGetOffset"     , GameConfGetOffset      },
+	{ "GameConfGetClassOffset", GameConfGetClassOffset },
+	{ "GameConfGetKeyValue"   , GameConfGetKeyValue    },
+	{ "GameConfGetAddress"    , GameConfGetAddress     },
+	{ "CloseGameConfigFile"   , CloseGameConfigFile    },
+	{ nullptr                 , nullptr                }
+};

--- a/amxmodx/gameconfigs.h
+++ b/amxmodx/gameconfigs.h
@@ -1,0 +1,18 @@
+// vim: set ts=4 sw=4 tw=99 noet:
+//
+// AMX Mod X, based on AMX Mod by Aleksander Naszko ("OLO").
+// Copyright (C) The AMX Mod X Development Team.
+//
+// This software is licensed under the GNU General Public License, version 3 or higher.
+// Additional exceptions apply. For full license details, see LICENSE.txt or visit:
+//     https://alliedmods.net/amxmodx-license
+
+#include "IGameConfigs.h"
+#include "natives_handles.h"
+
+struct GameConfigNative
+{
+	IGameConfig *m_config;
+};
+
+extern Handle<GameConfigNative> GameConfigHandle;

--- a/amxmodx/meta_api.cpp
+++ b/amxmodx/meta_api.cpp
@@ -27,6 +27,7 @@
 #include "CvarManager.h"
 #include "CLibrarySys.h"
 #include "CFileSystem.h"
+#include "gameconfigs.h"
 
 plugin_info_t Plugin_info = 
 {
@@ -408,6 +409,7 @@ int	C_Spawn(edict_t *pent)
 	g_TrieSnapshotHandles.clear();
 	g_DataPackHandles.clear();
 	g_TextParsersHandles.clear();
+	GameConfigHandle.clear();
 
 	char map_pluginsfile_path[256];
 	char prefixed_map_pluginsfile[256];

--- a/amxmodx/modules.cpp
+++ b/amxmodx/modules.cpp
@@ -31,6 +31,7 @@
 #include "messages.h"
 #include "trie_natives.h"
 #include "CDataPack.h"
+#include "CGameConfigs.h"
 
 CList<CModule, const char*> g_modules;
 CList<CScript, AMX*> g_loadedscripts;
@@ -1810,6 +1811,11 @@ int amx_Execv()
 	return AMX_ERR_NOTFOUND;
 }
 
+IGameConfigManager *MNF_GetConfigManager()
+{
+	return &ConfigManager;
+}
+
 void Module_CacheFunctions()
 {
 	func_s *pFunc;
@@ -1824,6 +1830,7 @@ void Module_CacheFunctions()
 	REGISTER_FUNC("Format", MNF_Format)
 	REGISTER_FUNC("RegisterFunction", MNF_RegisterFunction);
 	REGISTER_FUNC("RegisterFunctionEx", MNF_RegisterFunctionEx);
+	REGISTER_FUNC("GetConfigManager", MNF_GetConfigManager);
 
 	// Amx scripts loading / unloading / managing
 	REGISTER_FUNC("GetAmxScript", MNF_GetAmxScript)

--- a/amxmodx/modules.cpp
+++ b/amxmodx/modules.cpp
@@ -531,6 +531,7 @@ int set_amxnatives(AMX* amx, char error[128])
 	amx_Register(amx, g_StackNatives, -1);
 	amx_Register(amx, g_TextParserNatives, -1);
 	amx_Register(amx, g_CvarNatives, -1);
+	amx_Register(amx, g_GameConfigNatives, -1);
 
 	//we're not actually gonna check these here anymore
 	amx->flags |= AMX_FLAG_PRENIT;

--- a/amxmodx/msvc12/amxmodx_mm.vcxproj
+++ b/amxmodx/msvc12/amxmodx_mm.vcxproj
@@ -278,6 +278,7 @@
     <ClCompile Include="..\format.cpp">
       <AssemblerOutput Condition="'$(Configuration)|$(Platform)'=='JITRelease|Win32'">AssemblyAndSourceCode</AssemblerOutput>
     </ClCompile>
+    <ClCompile Include="..\gameconfigs.cpp" />
     <ClCompile Include="..\libraries.cpp" />
     <ClCompile Include="..\messages.cpp" />
     <ClCompile Include="..\meta_api.cpp" />
@@ -361,10 +362,12 @@
     <ClInclude Include="..\debugger.h" />
     <ClInclude Include="..\fakemeta.h" />
     <ClInclude Include="..\format.h" />
+    <ClInclude Include="..\gameconfigs.h" />
     <ClInclude Include="..\libraries.h" />
     <ClInclude Include="..\messages.h" />
     <ClInclude Include="..\modules.h" />
     <ClInclude Include="..\natives.h" />
+    <ClInclude Include="..\natives_handles.h" />
     <ClInclude Include="..\newmenus.h" />
     <ClInclude Include="..\nongpl_matches.h" />
     <ClInclude Include="..\optimizer.h" />
@@ -383,6 +386,7 @@
     <None Include="..\..\plugins\include\cellstack.inc" />
     <None Include="..\..\plugins\include\cvars.inc" />
     <None Include="..\..\plugins\include\datapack.inc" />
+    <None Include="..\..\plugins\include\gameconfig.inc" />
     <None Include="..\..\plugins\include\textparse_ini.inc" />
     <None Include="..\..\plugins\include\textparse_smc.inc" />
     <None Include="..\amxdefn.asm" />

--- a/amxmodx/msvc12/amxmodx_mm.vcxproj
+++ b/amxmodx/msvc12/amxmodx_mm.vcxproj
@@ -150,6 +150,7 @@
   <ItemGroup>
     <ClCompile Include="..\..\public\memtools\CDetour\asm\asm.c" />
     <ClCompile Include="..\..\public\memtools\CDetour\detours.cpp" />
+    <ClCompile Include="..\..\public\memtools\MemoryUtils.cpp" />
     <ClCompile Include="..\..\third_party\hashing\hashers\crc32.cpp">
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='JITDebug|Win32'">$(IntDir)hashing\</ObjectFileName>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='JITRelease|Win32'">$(IntDir)hashing\</ObjectFileName>
@@ -255,6 +256,7 @@
     <ClCompile Include="..\CFile.cpp" />
     <ClCompile Include="..\CFlagManager.cpp" />
     <ClCompile Include="..\CForward.cpp" />
+    <ClCompile Include="..\CGameConfigs.cpp" />
     <ClCompile Include="..\CLang.cpp" />
     <ClCompile Include="..\CLibrarySys.cpp" />
     <ClCompile Include="..\CLogEvent.cpp" />
@@ -307,6 +309,7 @@
     <ClInclude Include="..\..\public\memtools\CDetour\asm\asm.h" />
     <ClInclude Include="..\..\public\memtools\CDetour\detourhelpers.h" />
     <ClInclude Include="..\..\public\memtools\CDetour\detours.h" />
+    <ClInclude Include="..\..\public\memtools\MemoryUtils.h" />
     <ClInclude Include="..\..\third_party\hashing\hashers\crc32.h" />
     <ClInclude Include="..\..\third_party\hashing\hashers\keccak.h" />
     <ClInclude Include="..\..\third_party\hashing\hashers\md5.h" />
@@ -338,6 +341,7 @@
     <ClInclude Include="..\CFileSystem.h" />
     <ClInclude Include="..\CFlagManager.h" />
     <ClInclude Include="..\CForward.h" />
+    <ClInclude Include="..\CGameConfigs.h" />
     <ClInclude Include="..\CLang.h" />
     <ClInclude Include="..\CLibrarySys.h" />
     <ClInclude Include="..\CList.h" />

--- a/amxmodx/msvc12/amxmodx_mm.vcxproj.filters
+++ b/amxmodx/msvc12/amxmodx_mm.vcxproj.filters
@@ -288,6 +288,9 @@
     <ClCompile Include="..\..\public\memtools\MemoryUtils.cpp">
       <Filter>Memtools</Filter>
     </ClCompile>
+    <ClCompile Include="..\gameconfigs.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\amx.h">
@@ -497,6 +500,12 @@
     <ClInclude Include="..\..\public\memtools\MemoryUtils.h">
       <Filter>Memtools</Filter>
     </ClInclude>
+    <ClInclude Include="..\natives_handles.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\gameconfigs.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\version.rc">
@@ -592,6 +601,9 @@
       <Filter>Pawn Includes</Filter>
     </None>
     <None Include="..\..\plugins\include\cvars.inc">
+      <Filter>Pawn Includes</Filter>
+    </None>
+    <None Include="..\..\plugins\include\gameconfig.inc">
       <Filter>Pawn Includes</Filter>
     </None>
   </ItemGroup>

--- a/amxmodx/msvc12/amxmodx_mm.vcxproj.filters
+++ b/amxmodx/msvc12/amxmodx_mm.vcxproj.filters
@@ -277,10 +277,16 @@
       <Filter>Third Party\Hashing\hashers</Filter>
     </ClCompile>
     <ClCompile Include="..\CPlugin.cpp">
-    	<Filter>Source Files</Filter>
-	</ClCompile>
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\CLibrarySys.cpp">
       <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CGameConfigs.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\public\memtools\MemoryUtils.cpp">
+      <Filter>Memtools</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -478,12 +484,18 @@
     </ClInclude>
     <ClInclude Include="..\..\third_party\hashing\hashers\sha256.h">
       <Filter>Third Party\Hashing\hashers</Filter>
-	</ClInclude>
+    </ClInclude>
     <ClInclude Include="..\CFileSystem.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\CLibrarySys.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CGameConfigs.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\public\memtools\MemoryUtils.h">
+      <Filter>Memtools</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/amxmodx/natives_handles.h
+++ b/amxmodx/natives_handles.h
@@ -1,0 +1,88 @@
+// vim: set ts=4 sw=4 tw=99 noet:
+//
+// AMX Mod X, based on AMX Mod by Aleksander Naszko ("OLO").
+// Copyright (C) The AMX Mod X Development Team.
+//
+// This software is licensed under the GNU General Public License, version 3 or higher.
+// Additional exceptions apply. For full license details, see LICENSE.txt or visit:
+//     https://alliedmods.net/amxmodx-license
+
+#include <am-vector.h>
+
+template <typename T>
+class Handle
+{
+	private:
+
+		ke::Vector<T*> m_handles;
+
+	public:
+
+		Handle() {}
+		~Handle()
+		{
+			this->clear();
+		}
+
+		void clear()
+		{
+			for (size_t i = 0; i < m_handles.length(); ++i)
+			{
+				if (m_handles[i])
+				{
+					delete m_handles[i];
+				}
+			}
+
+			m_handles.clear();
+		}
+
+		T *lookup(int handle)
+		{
+			--handle;
+
+			if (handle < 0 || handle >= static_cast<int>(m_handles.length()))
+			{
+				return nullptr;
+			}
+
+			return m_handles[handle];
+		}
+
+		int create()
+		{
+			for (size_t i = 0; i < m_handles.length(); ++i)
+			{
+				if (!m_handles[i])
+				{
+					m_handles[i] = new T;
+
+					return static_cast<int>(i) + 1;
+				}
+			}
+
+			m_handles.append(new T);
+
+			return m_handles.length();
+		}
+
+		bool destroy(int handle)
+		{
+			handle--;
+
+			if (handle < 0 || handle >= static_cast<int>(m_handles.length()))
+			{
+				return false;
+			}
+
+			if (!m_handles[handle])
+			{
+				return false;
+			}
+
+			delete m_handles[handle];
+			m_handles[handle] = nullptr;
+
+			return true;
+		}
+};

--- a/plugins/include/amxmodx.inc
+++ b/plugins/include/amxmodx.inc
@@ -30,6 +30,7 @@
 #include <textparse_smc>
 #include <textparse_ini>
 #include <cvars>
+#include <gameconfig>
 
 /**
  * Called just after server activation.

--- a/plugins/include/gameconfig.inc
+++ b/plugins/include/gameconfig.inc
@@ -1,0 +1,93 @@
+// vim: set ts=4 sw=4 tw=99 noet:
+//
+// AMX Mod X, based on AMX Mod by Aleksander Naszko ("OLO").
+// Copyright (C) The AMX Mod X Development Team.
+//
+// This software is licensed under the GNU General Public License, version 3 or higher.
+// Additional exceptions apply. For full license details, see LICENSE.txt or visit:
+//     https://alliedmods.net/amxmodx-license
+
+//
+// Game Config Functions
+//
+
+#if defined _gameconfigs_included
+	#endinput
+#endif
+#define _gameconfigs_included
+
+enum GameConfig
+{
+	Invalid_GameConfig = 0
+};
+
+/**
+ * Loads a game config file.
+ *
+ * @note The file path must be relative to the 'gamedata' folder under the data folder
+ *       and the extension should be omitted.
+ *
+ * @param file          File to load
+ *
+ * @return              A handle to the game config file
+ */
+native GameConfig:LoadGameConfigFile(const file[]);
+
+/**
+ * Returns an offset value.
+ *
+ * @param handle        Game config handle
+ * @param key           Key to retrieve from the offset section
+ *
+ * @return              An offset, or -1 on failure
+ * @error               Invalid game config handle
+ */
+native GameConfGetOffset(GameConfig:handle, const key[]);
+
+/**
+ * Returns an offset value given a classname.
+ *
+ * @param handle        Game config handle
+ * @param classname     Class name to match from the offset section
+ * @param key           Key to retrieve from the offset section
+ *
+ * @return              An offset, or -1 on failure
+ * @error               Invalid game config handle
+ */
+native GameConfGetClassOffset(GameConfig:handle, const classname[], const key[]);
+
+/**
+ * Gets the value of a key from the "Keys" section.
+ *
+ * @param handle        Game config handle
+ * @param key           Key to retrieve from the Keys section
+ * @param buffer        Destination string buffer
+ * @param maxlen        Maximum length of output string buffer
+ *
+ * @return              True if key existed, false otherwise
+ * @error               Invalid game config handle
+ */
+native bool:GameConfGetKeyValue(GameConfig:handle, const key[], buffer[], maxlen);
+
+/**
+ * Finds an address calculation in a GameConfig file.
+ *
+ * @param handle        Game config handle
+ * @param name          Name of the property to find
+ *
+ * @return              An address calculated on success, otherwise 0 on failure.
+ * @error               Invalid game config handle
+ */
+native GameConfGetAddress(GameConfig:handle, const name[]);
+
+/**
+ * Destroys a game config and frees its memory.
+ *
+ * @note The function automatically sets the variable passed to it to 0 to aid
+ *       in preventing accidental usage after destroy.
+ *
+ * @param handle        Game config handle
+ *
+ * @return              1 on success, 0 if an invalid handle was passed in
+ */
+native CloseGameConfigFile(&GameConfig:handle);

--- a/public/IGameConfigs.h
+++ b/public/IGameConfigs.h
@@ -1,0 +1,139 @@
+/**
+ * vim: set ts=4 :
+ * =============================================================================
+ * SourceMod
+ * Copyright (C) 2004-2008 AlliedModders LLC.  All rights reserved.
+ * =============================================================================
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 3.0, as published by the
+ * Free Software Foundation.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * As a special exception, AlliedModders LLC gives you permission to link the
+ * code of this program (as well as its derivative works) to "Half-Life 2," the
+ * "Source Engine," the "SourcePawn JIT," and any Game MODs that run on software
+ * by the Valve Corporation.  You must obey the GNU General Public License in
+ * all respects for all other code used.  Additionally, AlliedModders LLC grants
+ * this exception to all derivative works.  AlliedModders LLC defines further
+ * exceptions, found in LICENSE.txt (as of this writing, version JULY-31-2007),
+ * or <http://www.sourcemod.net/license.php>.
+ *
+ * Version: $Id$
+ */
+
+#ifndef _INCLUDE_IGAMECONFIG_H_
+#define _INCLUDE_IGAMECONFIG_H_
+
+#include <ITextParsers.h>
+
+/**
+ * @brief Describes a game private data config file
+ */
+class IGameConfig
+{
+public:
+	/**
+	 * @brief Returns an offset value.
+	 *
+	 * @param key			Key to retrieve from the offset section.
+	 * @param value			Pointer to store the offset value in.
+	 * @return				True if found, false otherwise.
+	 */
+	virtual bool GetOffset(const char *key, int *value) = 0;
+
+	/**
+	 * @brief Returns an offset value from given class.
+	 *
+	 * @param classname		class name to match from the offset section.
+	 * @param key			Key to retrieve from the offset section.
+	 * @param value			Pointer to store the offset value in.
+	 * @return				True if found, false otherwise.
+	 */
+	virtual bool GetOffsetByClass(const char *classname, const char *key, int *value) = 0;
+ 
+	/**
+	 * @brief Returns the value of a key from the "Keys" section.
+	 *
+	 * @param key			Key to retrieve from the Keys section.
+	 * @return				String containing the value, or NULL if not found.
+	 */
+	virtual const char *GetKeyValue(const char *key) = 0;
+
+	/**
+	 * @brief Retrieves a cached memory signature.
+	 *
+	 * @param key			Name of the signature.
+	 * @param addr			Pointer to store the memory address in.
+	 *						(NULL is copied if signature is not found in binary).
+	 * @return				True if the section exists and key for current
+	 *						platform was found, false otherwise.
+	 */
+	virtual bool GetMemSig(const char *key, void **addr) = 0;
+
+	/**
+	 * @brief Retrieves the value of an address from the "Address" section.
+	 *
+	 * @param key			Key to retrieve from the Address section.
+	 * @param addr          Pointer to store the memory address.
+	 * @return				True on success, false on failure.
+	 */
+	virtual bool GetAddress(const char *key, void **addr) = 0;
+};
+
+/**
+ * @brief Manages game config files
+ */
+class IGameConfigManager
+{
+public:
+	/**
+	 * @brief Loads or finds an already loaded game config file.  
+	 *
+	 * @param file		File to load.  The path must be relative to the 
+	 *					'gamedata' folder and the extension should be 
+	 *					omitted.
+	 * @param pConfig	Pointer to store the game config pointer.  Pointer 
+	 *					will be valid even on failure.
+	 * @param error		Optional error message buffer.
+	 * @param maxlength	Maximum length of the error buffer.
+	 * @return			True on success, false if the file failed.
+	 */
+	virtual bool LoadGameConfigFile(const char *file, IGameConfig **pConfig, char *error, size_t maxlength) = 0;
+
+	/**
+	 * @brief Closes an IGameConfig pointer.  Since a file can be loaded 
+	 * more than once, the file will not actually be removed from memory 
+	 * until it is closed once for each call to LoadGameConfigfile().
+	 *
+	 * @param cfg		Pointer to the IGameConfig to close.
+	 */
+	virtual void CloseGameConfigFile(IGameConfig *cfg) = 0;
+
+	/**
+	 * @brief Adds a custom gamedata section hook.
+	 *
+	 * @param sectionname	Section name to hook.
+	 * @param listener		Listener callback.
+	 * @noreturn
+	 */
+	virtual void AddUserConfigHook(const char *sectionname, ITextListener_SMC *listener) = 0;
+
+	/**
+	 * @brief Removes a custom gamedata section hook.
+	 *
+	 * @param sectionname	Section name to unhook.
+	 * @param listener		Listener callback.
+	 * @noreturn
+	 */
+	virtual void RemoveUserConfigHook(const char *sectionname, ITextListener_SMC *listener) = 0;
+};
+
+#endif //_INCLUDE_IGAMECONFIG_H_

--- a/public/ITextParsers.h
+++ b/public/ITextParsers.h
@@ -32,6 +32,8 @@
 #ifndef _INCLUDE_SOURCEMOD_TEXTPARSERS_INTERFACE_H_
 #define _INCLUDE_SOURCEMOD_TEXTPARSERS_INTERFACE_H_
 
+#include <string.h> // size_t
+
 /**
  * @file ITextParsers.h
  * @brief Defines various text/file parsing functions, as well as UTF-8 support code.

--- a/public/memtools/MemoryUtils.cpp
+++ b/public/memtools/MemoryUtils.cpp
@@ -28,7 +28,7 @@
  */
 
 #include "MemoryUtils.h"
-#include "amxxmodule.h"
+#include <stdio.h> // sscanf
 
 #if defined(__linux__)
 	#include <fcntl.h>
@@ -158,6 +158,13 @@ void *MemoryUtils::ResolveSymbol(void *handle, const char *symbol)
 	return GetProcAddress((HMODULE)handle, symbol);
 	
 #elif defined(__linux__)
+
+	void *addr = dlsym(handle, symbol);
+
+	if (addr)
+	{
+		return addr;
+	}
 
 	struct link_map *dlmap;
 	struct stat dlstat;

--- a/public/memtools/MemoryUtils.cpp
+++ b/public/memtools/MemoryUtils.cpp
@@ -644,7 +644,7 @@ bool MemoryUtils::GetLibraryOfAddress(const void *libPtr, char *buffer, size_t m
 		return false;
 	}
 	const char *dllpath = info.dli_fname;
-	UTIL_Format(buffer, maxlength, "%s", dllpath);
+	Format(buffer, maxlength, "%s", dllpath);
 	if (base)
 	{
 		*base = (uintptr_t)info.dli_fbase;
@@ -708,4 +708,20 @@ size_t MemoryUtils::DecodeHexString(unsigned char *buffer, size_t maxlength, con
 	}
 
 	return written;
+}
+
+size_t MemoryUtils::Format(char *buffer, size_t maxlength, const char *fmt, ...)
+{
+	va_list ap;
+	va_start(ap, fmt);
+	size_t len = vsnprintf(buffer, maxlength, fmt, ap);
+	va_end(ap);
+
+	if (len >= maxlength)
+	{
+		buffer[maxlength - 1] = '\0';
+		return (maxlength - 1);
+	}
+
+	return len;
 }

--- a/public/memtools/MemoryUtils.h
+++ b/public/memtools/MemoryUtils.h
@@ -80,6 +80,7 @@ class MemoryUtils
 
 	public:
 		size_t DecodeHexString(unsigned char *buffer, size_t maxlength, const char *hexstr);
+		size_t Format(char *buffer, size_t maxlength, const char *fmt, ...);
 
 #if defined(__linux__) || defined(__APPLE__)
 	private:

--- a/public/sdk/amxxmodule.cpp
+++ b/public/sdk/amxxmodule.cpp
@@ -2501,6 +2501,7 @@ PFN_GETLOCALINFO			g_fn_GetLocalInfo;
 PFN_AMX_REREGISTER			g_fn_AmxReRegister;
 PFN_REGISTERFUNCTIONEX		g_fn_RegisterFunctionEx;
 PFN_MESSAGE_BLOCK			g_fn_MessageBlock;
+PFN_GET_CONFIG_MANAGER		g_fn_GetConfigManager;
 
 // *** Exports ***
 C_DLLEXPORT int AMXX_Query(int *interfaceVersion, amxx_module_info_s *moduleInfo)
@@ -2560,6 +2561,7 @@ C_DLLEXPORT int AMXX_Attach(PFN_REQ_FNPTR reqFnptrFunc)
 	REQFUNC("Format", g_fn_Format, PFN_FORMAT);
 	REQFUNC("RegisterFunction", g_fn_RegisterFunction, PFN_REGISTERFUNCTION);
 	REQFUNC("RegisterFunctionEx", g_fn_RegisterFunctionEx, PFN_REGISTERFUNCTIONEX);
+	REQFUNC("GetConfigManager", g_fn_GetConfigManager, PFN_GET_CONFIG_MANAGER);
 
 	// Amx scripts
 	REQFUNC("GetAmxScript", g_fn_GetAmxScript, PFN_GET_AMXSCRIPT);
@@ -2787,6 +2789,7 @@ void ValidateMacros_DontCallThis_Smiley()
 	MF_RemoveLibraries(NULL);
 	MF_OverrideNatives(NULL, NULL);
 	MF_MessageBlock(0, 0, NULL);
+	MF_GetConfigManager();
 }
 #endif
 

--- a/public/sdk/amxxmodule.h
+++ b/public/sdk/amxxmodule.h
@@ -18,6 +18,7 @@
 
 // config
 #include "moduleconfig.h"
+#include <IGameConfigs.h>
 
 #include <stddef.h> // size_t
 // metamod include files
@@ -2217,6 +2218,7 @@ typedef const char *	(*PFN_GETLOCALINFO)				(const char * /*name*/, const char *
 typedef int				(*PFN_AMX_REREGISTER)			(AMX * /*amx*/, AMX_NATIVE_INFO * /*list*/, int /*list*/);
 typedef void *			(*PFN_REGISTERFUNCTIONEX)		(void * /*pfn*/, const char * /*desc*/);
 typedef void			(*PFN_MESSAGE_BLOCK)			(int /* mode */, int /* message */, int * /* opt */);
+typedef IGameConfigManager* (*PFN_GET_CONFIG_MANAGER)   ();
 
 extern PFN_ADD_NATIVES				g_fn_AddNatives;
 extern PFN_ADD_NEW_NATIVES			g_fn_AddNewNatives;
@@ -2297,6 +2299,7 @@ extern PFN_GETLOCALINFO				g_fn_GetLocalInfo;
 extern PFN_AMX_REREGISTER			g_fn_AmxReRegister;
 extern PFN_REGISTERFUNCTIONEX		g_fn_RegisterFunctionEx;
 extern PFN_MESSAGE_BLOCK			g_fn_MessageBlock;
+extern PFN_GET_CONFIG_MANAGER		g_fn_GetConfigManager;
 
 #ifdef MAY_NEVER_BE_DEFINED
 // Function prototypes for intellisense and similar systems
@@ -2374,6 +2377,7 @@ const char *	MF_GetLocalInfo				(const char *name, const char *def) { }
 int				MF_AmxReRegister			(AMX *amx, AMX_NATIVE_INFO *list, int number) { return 0; }
 void *			MF_RegisterFunctionEx		(void *pfn, const char *description) { }
 void *			MF_MessageBlock				(int mode, int msg, int *opt) { }
+IGameConfigManager* MF_MessageBlock         () { }
 #endif	// MAY_NEVER_BE_DEFINED
 
 #define MF_AddNatives g_fn_AddNatives
@@ -2456,6 +2460,7 @@ void MF_LogError(AMX *amx, int err, const char *fmt, ...);
 #define MF_AmxReRegister g_fn_AmxReRegister
 #define MF_RegisterFunctionEx g_fn_RegisterFunctionEx
 #define MF_MessageBlock g_fn_MessageBlock
+#define MF_GetConfigManager g_fn_GetConfigManager
 
 #ifdef MEMORY_TEST
 /*** Memory ***/

--- a/public/sdk/amxxmodule.h
+++ b/public/sdk/amxxmodule.h
@@ -2377,7 +2377,7 @@ const char *	MF_GetLocalInfo				(const char *name, const char *def) { }
 int				MF_AmxReRegister			(AMX *amx, AMX_NATIVE_INFO *list, int number) { return 0; }
 void *			MF_RegisterFunctionEx		(void *pfn, const char *description) { }
 void *			MF_MessageBlock				(int mode, int msg, int *opt) { }
-IGameConfigManager* MF_MessageBlock         () { }
+IGameConfigManager* MF_GetConfigManager     (void) { }
 #endif	// MAY_NEVER_BE_DEFINED
 
 #define MF_AddNatives g_fn_AddNatives

--- a/support/PackageScript
+++ b/support/PackageScript
@@ -264,6 +264,7 @@ scripting_files = [
   'include/file.inc',
   'include/float.inc',
   'include/fun.inc',
+  'include/gameconfig.inc',
   'include/geoip.inc',
   'include/lang.inc',
   'include/ns.inc',


### PR DESCRIPTION
First step to improve maintainability. A game config parser stolen form SM. Any hardcoded datas will be eventually moved to some gamedata files.

This is essentially the same as SM with some changes:
* Removed useless/unused code for us (sendprop, crc, class, etc..)
* Added a new node "Classes" , mainly to associate a list of offsets to a class.

The config manager is exposed to module API through `MF_GetConfigManager`.

The parser functions is exposed as well to plugin API, so author can easily share game datas:
* `LoadGameConfigFile`
* `GameConfGetOffse`
* `GameConfGetClassOffset`
* `GameConfGetKeyValue`
* `GameConfGetAddress`
* `CloseGameConfigFile`