### PR TITLE
Plugins: Close Array/Trie handles on map end

### DIFF
--- a/plugins/admincmd.sma
+++ b/plugins/admincmd.sma
@@ -1332,3 +1332,9 @@ public cmdLast(id, level, cid)
 	
 	return PLUGIN_HANDLED;
 }
+
+public plugin_end()
+{
+	TrieDestroy(g_tempBans);
+	TrieDestroy(g_tXvarsFlags);
+}

--- a/plugins/imessage.sma
+++ b/plugins/imessage.sma
@@ -117,4 +117,7 @@ public plugin_end()
 
 	num_to_str(g_Current, lastinfo, charsmax(lastinfo))
 	set_localinfo("lastinfomsg", lastinfo)
+
+	ArrayDestroy(g_Messages)
+	ArrayDestroy(g_Values)
 }

--- a/plugins/mapchooser.sma
+++ b/plugins/mapchooser.sma
@@ -289,4 +289,6 @@ public plugin_end()
 
 	get_mapname(current_map, charsmax(current_map))
 	set_localinfo("lastMap", current_map)
+
+	ArrayDestroy(g_mapName)
 }

--- a/plugins/mapsmenu.sma
+++ b/plugins/mapsmenu.sma
@@ -574,3 +574,8 @@ load_settings(filename[])
 
 	return 1;
 }
+
+public plugin_end()
+{
+	ArrayDestroy(g_mapName)
+}

--- a/plugins/plmenu.sma
+++ b/plugins/plmenu.sma
@@ -1243,3 +1243,9 @@ load_settings(szFilename[])
 
 	return 1;
 }
+
+public plugin_end()
+{
+	ArrayDestroy(g_bantimes);
+	ArrayDestroy(g_slapsettings);
+}


### PR DESCRIPTION
from `cellarray.inc` and so:
"""
 * @note Plugins are responsible for freeing all Array handles they acquire,
 *       including those from ArrayClone. Failing to free handles will result
 *       in the plugin and AMXX leaking memory.
"""