### PR TITLE
Retrieve log type in MetaAttach to allow log to be written earlier

### DIFF
--- a/amxmodx/amxxlog.cpp
+++ b/amxmodx/amxxlog.cpp
@@ -112,6 +112,19 @@ void CLog::UseFile(const ke::AString &fileName)
 	m_LogFile = build_pathname_r(file, sizeof(file) - 1, "%s/%s", g_log_dir.chars(), fileName.chars());
 }
 
+void CLog::SetLogType(const char* localInfo)
+{
+	m_LogType = atoi(get_localinfo(localInfo, "1"));
+
+	if (m_LogType < 0 || m_LogType > 3)
+	{
+		SET_LOCALINFO(localInfo, "1");
+		m_LogType = 1;
+
+		print_srvconsole("[AMXX] Invalid amxx_logging value; setting back to 1...");
+	}
+}
+
 void CLog::MapChange()
 {
 	// create dir if not existing
@@ -122,14 +135,7 @@ void CLog::MapChange()
 	mkdir(build_pathname_r(file, sizeof(file) - 1, "%s", g_log_dir.chars()));
 #endif
 
-	m_LogType = atoi(get_localinfo("amxx_logging", "1"));
-	
-	if (m_LogType < 0 || m_LogType > 3)
-	{
-		SET_LOCALINFO("amxx_logging", "1");
-		m_LogType = 1;
-		print_srvconsole("[AMXX] Invalid amxx_logging value; setting back to 1...");
-	}
+	SetLogType("amxx_logging");
 
 	m_LoggedErrMap = false;
 

--- a/amxmodx/amxxlog.h
+++ b/amxmodx/amxxlog.h
@@ -26,6 +26,7 @@ public:
 	
 	void CreateNewFile();
 	void CloseFile();
+	void SetLogType(const char* localInfo);
 	void MapChange();
 	void Log(const char *fmt, ...);
 	void LogError(const char *fmt, ...);

--- a/amxmodx/meta_api.cpp
+++ b/amxmodx/meta_api.cpp
@@ -1477,6 +1477,7 @@ C_DLLEXPORT	int	Meta_Attach(PLUG_LOADTIME now, META_FUNCTIONS *pFunctionTable, m
 
 	// ###### Initialize logging here
 	g_log_dir = get_localinfo("amxx_logs", "addons/amxmodx/logs");
+	g_log.SetLogType("amxx_logging");
 
 	// ###### Now attach metamod modules
 	// This will also call modules Meta_Query and Meta_Attach functions


### PR DESCRIPTION
Small issue. Before log type was retrieved only when the map world spawns. By default value is set to 0 and is not reset afterward. To write in the log, you need a value > 0. This means, at first server start, any attempt to write in the log before this time was ignored.
Considering we do now a lot of stuffs at startup, this needs to be fixed.