### PR TITLE
Fix a ML parser crash on key with an associated empty value

### DIFF
--- a/amxmodx/CLang.cpp
+++ b/amxmodx/CLang.cpp
@@ -393,7 +393,7 @@ bool CLangMngr::ReadINI_KeyValue(const char *key, const char *value, bool invali
 	{
 		Data.lastKey = key;
 
-		if (colons_token || equal_token)
+		if (colons_token || (equal_token && value))
 		{
 			int iKey = GetKeyEntry(key);
 


### PR DESCRIPTION
Reported by `New.ZM.Life`.
Related to #260.

Fix a crash with ML parser not expecting a null value. 
For now, this will just trigger the same "Invalid multi-lingual line" error message.