### PR TITLE
Fix typo in newmenus (bug 6394)

### DIFF
--- a/amxmodx/newmenus.cpp
+++ b/amxmodx/newmenus.cpp
@@ -529,7 +529,7 @@ const char *Menu::GetTextString(int player, page_t page, int &keys)
 					UTIL_Format(buffer, sizeof(buffer)-1, "#. %s\n", m_OptNames[abs(MENU_BACK)].chars());
 				}
 			}
-			m_Text + m_Text + buffer;
+			m_Text = m_Text + buffer;
 	
 			if (flags & Display_Next)
 			{


### PR DESCRIPTION
I can't believe this has not been spotted after several reviews nor compiler would not whine about it. Too bad we can't do += directly.

Related to #260.