### PR TITLE
Fix an SortADTArray() issue where strings are not properly sorted

### DIFF
--- a/amxmodx/sorting.cpp
+++ b/amxmodx/sorting.cpp
@@ -402,14 +402,27 @@ enum SortType
 	Sort_String,
 };
 
+int strcellcmp(cell *s1, cell *s2)
+{
+	for (; *s1 == *s2; s1++, s2++)
+	{
+		if (*s1 == '\0')
+		{
+			return 0;
+		}
+	}
+
+	return (*(byte *)s1 < *(byte *)s2) ? -1 : +1;
+}
+
 int sort_adtarray_strings_asc(const void *str1, const void *str2)
 {
-	return strcmp((char *) str1, (char *) str2);
+	return strcellcmp((cell *)str1, (cell *)str2);
 }
 
 int sort_adtarray_strings_desc(const void *str1, const void *str2)
 {
-	return strcmp((char *) str2, (char *) str1);
+	return strcellcmp((cell *)str2, (cell *)str1);
 }
 
 void sort_adt_random(CellArray *cArray)


### PR DESCRIPTION
Related to 5a6d3fde61d5d5993bd5c0995b46c42e79f57ccd.

A situation of mixed `char*` and `cell*`. The arguments `str1` and `str2` were returning only the first character of the string, resulting an array partially sorted.