### PR TITLE
Update sockets.cpp

### DIFF
--- a/plugins/include/sockets.inc
+++ b/plugins/include/sockets.inc
@@ -45,7 +45,7 @@ native socket_open(const _hostname[], _port, _protocol = SOCKET_TCP, &_error);
 
 /* Closes a Socket */
 
-native socket_close(_socket);
+native socket_close(&_socket);
 
 /* Recieves Data to string with the given length */
 


### PR DESCRIPTION
Update sockets.cpp improving the next features.

* socket_open() - Closes the Socket ID after initializing it, if connect() or inet_addr()/ gethostbyname() fail.
* socket_close() - Sets Socket ID to -1 (INVALID_SOCKET) after closing it, inside the AMX Mod X script.
* All the functions - Add **if (socket < 0)** sanity checks because we do not operate with invalid Sockets.
* Remove unused **return** keyword at the end of OnAmxx[Attach|Detach] void functions.
