### PR TITLE
Fix MPROP_NOCOLORS menu property not working

### DIFF
--- a/amxmodx/newmenus.cpp
+++ b/amxmodx/newmenus.cpp
@@ -1018,7 +1018,7 @@ static cell AMX_NATIVE_CALL menu_setprop(AMX *amx, cell *params)
 		}
 	case MPROP_NOCOLORS:
 		{
-			pMenu->m_AutoColors = *get_amxaddr(amx, params[3]) ? true : false;
+			pMenu->m_AutoColors = *get_amxaddr(amx, params[3]) ? false : true;
 			break;
 		}
 	case MPROP_PADMENU:


### PR DESCRIPTION
Reported by GordonFreeman (RU) here: https://forums.alliedmods.net/showthread.php?t=269968

Just a logic issue where `true`/`false` is reversed.

Bug existed since the creation of API. :scream: 