### PR TITLE
Add a CS_NORESET constant for use with cs_set_user_team for skipping the model reset

### DIFF
--- a/modules/cstrike/cstrike/CstrikeNatives.cpp
+++ b/modules/cstrike/cstrike/CstrikeNatives.cpp
@@ -534,8 +534,11 @@ static cell AMX_NATIVE_CALL cs_set_user_team(AMX *amx, cell *params)
 		set_pdata<int>(pPlayer, m_iModelName, model);
 	}
 
-	Players[index].ResetModel(pPlayer);
-
+	if (model >= 0)
+	{
+		Players[index].ResetModel(pPlayer);
+	}
+	
 	bool sendTeamInfo = true;
 
 	if (*params / sizeof(cell) >= 4)

--- a/plugins/include/cstrike.inc
+++ b/plugins/include/cstrike.inc
@@ -32,6 +32,7 @@
  */
 enum CsInternalModel
 {
+	CS_NORESET = -1,
 	CS_DONTCHANGE = 0,
 	CS_CT_URBAN = 1,
 	CS_T_TERROR = 2,
@@ -474,6 +475,7 @@ native cs_set_user_plant(index, plant = 1, showbombicon = 1);
  * @param index         Client index
  * @param team          Team id
  * @param model         Internal model id, if CS_DONTCHANGE the game will choose the model
+ 			or if CS_NORESET the game will not update it.
  * @param send_teaminfo If true, a TeamInfo message will be sent
  *
  * @noreturn


### PR DESCRIPTION
When the player change of team with CS_DONTCHANGE its change anyway! 
Plugin to test: http://pastebin.com/HCixm6UL