### PR TITLE
Fix typo in AutoExecConfig native

### DIFF
--- a/amxmodx/amxmodx.cpp
+++ b/amxmodx/amxmodx.cpp
@@ -4506,7 +4506,7 @@ static cell AMX_NATIVE_CALL AutoExecConfig(AMX *amx, cell *params)
 		}
 
 		static char newName[PLATFORM_MAX_PATH];
-		UTIL_Format(newName, sizeof(newName), "plugin.%s", pluginName);
+		UTIL_Format(newName, sizeof(newName), "plugin-%s", pluginName);
 
 		name = newName;
 	}

--- a/plugins/include/amxmodx.inc
+++ b/plugins/include/amxmodx.inc
@@ -3217,9 +3217,10 @@ forward OnAutoConfigsBuffered();
 
 /**
  * Specifies that the given config file should be executed after plugin load.
- * 
- * @note OnConfigsExecuted() will not be called until the config file has executed, 
+ *
+ * @note OnConfigsExecuted() will not be called until the config file has executed,
  *       but it will be called if the execution fails.
+ * @note The name parameter should not contain dots, otherwise file will not be executed.
  *
  * @param autoCreate    If true, and the config file does not exist, such a config
  *                      file will be automatically created and populated with


### PR DESCRIPTION
Related to #266. Looks like I've changed the prefix afterward at some point for some reason, but engine is retarded and with `plugin.something.cfg` it will understand extension is `something` instead  of `cfg` ; and will fail to execute as it's an invalid extension (only `cfg` and `rc` are allowed).

Prefix is now `plugin-`.