### PR TITLE
Added CSI_KNIFE (CSW_KNIFE) and CSI_MAX_VALUE

### DIFF
--- a/plugins/include/cstrike.inc
+++ b/plugins/include/cstrike.inc
@@ -127,6 +127,7 @@ enum
 #define CSI_DEAGLE              CSW_DEAGLE
 #define CSI_SG552               CSW_SG552
 #define CSI_AK47                CSW_AK47
+#define CSI_KNIFE               CSW_KNIFE
 #define CSI_P90                 CSW_P90
 #define CSI_SHIELDGUN           CSW_SHIELDGUN   // The real CS value, use CSI_SHELD instead.
 #define CSI_VEST                CSW_VEST        // Custom
@@ -136,6 +137,7 @@ enum
 #define CSI_PRIAMMO             36              // Custom
 #define CSI_SECAMMO             37              // Custom
 #define CSI_SHIELD              38              // Custom - The value passed by the forward, more convenient for plugins.
+#define CSI_MAX_VALUE           CSI_SHIELD      // Highest CSI_* value, intended to be used for iterations
 
 /**
  * Returns client's deaths.


### PR DESCRIPTION
I believe CSI_KNIFE was missed when copying over the constants, as there is no corresponding value for CSW_KNIFE. I also felt that defining the max value is useful for iterations and declaring an array where the CSI_* constants can be used to index. The benefit of using this over CSI_SHIELD is that if more are added in the future (similar to how CSI constants were added in preference to the CSW constants), then this value will only need to be changed to represent the new highest constant.