### PR TITLE
Fix crash when dynamic native is executed with the max number of params

### DIFF
--- a/amxmodx/natives.cpp
+++ b/amxmodx/natives.cpp
@@ -35,7 +35,7 @@ bool g_Initialized = false;
 /* Stack stuff */
 regnative *g_pCurNative = NULL;
 AMX *g_pCaller = NULL;
-cell g_Params[CALLFUNC_MAXPARAMS];
+cell g_Params[CALLFUNC_MAXPARAMS + 1];
 int g_CurError = AMX_ERR_NONE;
 
 int amxx_DynaCallback(int idx, AMX *amx, cell *params)


### PR DESCRIPTION
This fixes a buffer overflow with `g_Params`, which has a size of 16 but params index starts to 1. As consequence when 16 params are passed, `g_Params[16]` is indexed and likely overwrites something important which leads to a crash at some point.

It doesn't happen in 1.8.2. Possible reasons why it happens in dev version is this uses newer compiler and compiling optimization are better , resulting crash is triggered now. 

Reported here https://forums.alliedmods.net/showthread.php?t=271103.