### PR TITLE
Update sockets module

### DIFF
--- a/modules/sockets/AMBuilder
+++ b/modules/sockets/AMBuilder
@@ -8,9 +8,13 @@ binary.sources = [
   'sockets.cpp',
 ]
 
+binary.compiler.defines += [
+  'HAVE_STDINT_H',
+]
+
 if builder.target_platform == 'windows':
   binary.sources += ['version.rc']
-  
+
 if builder.target_platform == 'windows':
   binary.compiler.postlink += ['wsock32.lib', 'ws2_32.lib']
 

--- a/modules/sockets/moduleconfig.h
+++ b/modules/sockets/moduleconfig.h
@@ -19,9 +19,9 @@
 // Module info
 #define MODULE_NAME "Sockets"
 #define MODULE_VERSION AMXX_VERSION
-#define MODULE_AUTHOR "HLSW Dev Team"
-#define MODULE_URL "http://www.hlsw.net/"
-#define MODULE_LOGTAG "SOCKET"
+#define MODULE_AUTHOR "AMX Mod X Dev Team"
+#define MODULE_URL "http://www.amxmodx.org"
+#define MODULE_LOGTAG "SOCKETS"
 #define MODULE_LIBRARY "sockets"
 #define MODULE_LIBCLASS ""
 // If you want the module not to be reloaded on mapchange, remove / comment out the next line

--- a/modules/sockets/msvc12/sockets.vcxproj
+++ b/modules/sockets/msvc12/sockets.vcxproj
@@ -55,7 +55,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\;..\..\..\public;..\..\..\public\sdk;..\..\..\public\amtl;..\..\third_party;..\..\third_party\hashing;$(METAMOD)\metamod;$(HLSDK)\common;$(HLSDK)\engine;$(HLSDK)\dlls;$(HLSDK)\pm_shared;$(HLSDK)\public;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;SOCKETS_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;HAVE_STDINT_H;_DEBUG;_WINDOWS;_USRDLL;SOCKETS_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -66,7 +66,7 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>wsock32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>$(OutDir)sockets.pdb</ProgramDatabaseFile>
       <SubSystem>Windows</SubSystem>
@@ -79,7 +79,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>..\;..\..\..\public;..\..\..\public\sdk;..\..\..\public\amtl;..\..\third_party;..\..\third_party\hashing;$(METAMOD)\metamod;$(HLSDK)\common;$(HLSDK)\engine;$(HLSDK)\dlls;$(HLSDK)\pm_shared;$(HLSDK)\public;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;SOCKETS_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;HAVE_STDINT_H;NDEBUG;_WINDOWS;_USRDLL;SOCKETS_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <PrecompiledHeader>
@@ -88,7 +88,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>wsock32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>

--- a/modules/sockets/sockets.cpp
+++ b/modules/sockets/sockets.cpp
@@ -3,10 +3,6 @@
 // AMX Mod X, based on AMX Mod by Aleksander Naszko ("OLO").
 // Copyright (C) The AMX Mod X Development Team.
 //
-// Codebase from Ivan, -g-s-ivan@web.de (AMX 0.9.3)
-// Modification by Olaf Reusch, kenterfie@hlsw.de (AMXX 0.16, AMX 0.96)
-// Modification by David Anderson, dvander@tcwonline.org (AMXx 0.20)
-//
 // This software is licensed under the GNU General Public License, version 3 or higher.
 // Additional exceptions apply. For full license details, see LICENSE.txt or visit:
 //     https://alliedmods.net/amxmodx-license
@@ -15,233 +11,370 @@
 // Sockets Module
 //
 
-#include <stdlib.h>
-#include <fcntl.h>
-#include <errno.h>
-#include <string.h>
+#include "amxxmodule.h"
+#include <amtl/am-string.h>
 
 #ifdef _WIN32
-/* Windows */
-#include <winsock.h>
-#include <io.h>
-#define socklen_t int
+	#include <winsock2.h>
+	#include <ws2tcpip.h>
+
+	#undef errno
+	#undef close
+
+	#define errno WSAGetLastError()
+	#define close(sockfd) closesocket(sockfd)
+
+	#define EINPROGRESS WSAEINPROGRESS
+	#define EWOULDBLOCK WSAEWOULDBLOCK
 #else
-/* Unix/Linux */
-#include <unistd.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <netdb.h>
-#include <arpa/inet.h>
-#define closesocket(s) close(s)
+	#include <netinet/in.h>
+	#include <sys/socket.h>
+	#include <sys/types.h>
+	#include <arpa/inet.h>
+	#include <unistd.h>
+	#include <errno.h>
+	#include <netdb.h>
+	#include <fcntl.h>
 #endif
 
-// AMX Headers
-#include "amxxmodule.h"
+// Backwards compatibility
+#define ERROR_CREATE_SOCKET 1		// Couldn't create a socket
+#define ERROR_SERVER_UNKNOWN 2		// Server unknown
+#define ERROR_WHILE_CONNECTING 3	// Error while connecting
+#define ERROR_EHOSTUNREACH 113		// libc error code: No route to host
 
-#define SOCKET_TCP 1
-#define SOCKET_UDP 2
+#ifdef _WIN32
+	bool g_winsock_initialized = false;
+#endif
 
-// And global Variables:
+static char *g_send2_buffer = nullptr;
+static int g_send2_buffer_length = 0;
 
-// native socket_open(_hostname[], _port, _protocol = SOCKET_TCP, &_error);
-static cell AMX_NATIVE_CALL socket_open(AMX *amx, cell *params)  /* 2 param */
-{ 
-    unsigned int port = params[2];
-    int len;
-    char* hostname = MF_GetAmxString(amx,params[1],0,&len); // Get the hostname from AMX
-	cell *err = MF_GetAmxAddr(amx, params[4]);
-    if(len == 0) { // just to prevent to work with a nonset hostname
-        *err = 2;  // server unknown
-        return -1;
-    }
-    *err = 0; // params[4] is error backchannel
-    struct sockaddr_in server;
-    struct hostent *host_info;
-    unsigned long addr;
-    int sock=-1;
-    int contr;
-    // Create a Socket
-    sock = socket(AF_INET, params[3]==SOCKET_TCP?SOCK_STREAM:SOCK_DGRAM, 0);
-    if (sock < 0) {
-        // Error, couldn't create a socket, so set an error and return.
-        *err = 1;
-        return -1;
-    }
-    
-    // Clear the server structure (set everything to 0)
-    memset( &server, 0, sizeof (server));
-    // Test the hostname, and resolve if needed
-    if ((addr = inet_addr(hostname)) != INADDR_NONE) {
-        // seems like hostname is a numeric ip, so put it into the structure
-        memcpy( (char *)&server.sin_addr, &addr, sizeof(addr));
-    }
-    else {
-        // hostname is a domain, so resolve it to an ip
-        host_info = gethostbyname(hostname);
-        if (host_info == NULL) {
-            // an error occured, the hostname is unknown
-            *err = 2;  // server unknown
-            return -1;
-        }
-        // If not, put it in the Server structure
-        memcpy( (char *)&server.sin_addr, host_info->h_addr, host_info->h_length);
-    }
-    // Set the type of the Socket
-    server.sin_family = AF_INET;
-    // Change the port to network byte order, and put it into the structure
-    server.sin_port = htons(port);
-    
-    // Not, let's try to open a connection to the server
-    contr = connect(sock, (struct sockaddr*)&server, sizeof( server));
-    if (contr < 0) {
-            // If an error occured cancel
-            *err = 3;  //error while connecting
-            return -1;
-    }
-    // Everything went well, so return the socket
-    return sock;
+// native socket_open(_hostname[], _port, _protocol = SOCKET_TCP, &_error, _libc_errors = DISABLE_LIBC_ERRORS);
+static cell AMX_NATIVE_CALL socket_open(AMX *amx, cell *params)
+{
+	int length = 0;
+	char *hostname = MF_GetAmxString(amx, params[1], 0, &length);
+
+	cell *error = MF_GetAmxAddr(amx, params[4]);
+	*error = 0;
+
+	bool libc_errors = false;
+
+	if((*params / sizeof(cell)) == 5)
+		libc_errors = (params[5] == 1) ? true : false;
+
+	if(length == 0)
+	{
+		*error = libc_errors ? ERROR_EHOSTUNREACH : ERROR_SERVER_UNKNOWN;
+		return -1;
+	}
+
+	char port_number[6];
+	ke::SafeSprintf(port_number, sizeof(port_number), "%d", params[2]);
+
+	int sockfd = -1, getaddrinfo_status = -1, connect_status = -1;
+	struct addrinfo hints, *server_info, *server;
+
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = AF_UNSPEC;
+	hints.ai_socktype = params[3];
+
+	if((getaddrinfo_status = getaddrinfo(hostname, port_number, &hints, &server_info)) != 0)
+	{
+		*error = libc_errors ? getaddrinfo_status : ERROR_SERVER_UNKNOWN;
+		return -1;
+	}
+
+	server = server_info;
+
+	do
+	{
+		if((sockfd = socket(server->ai_family, server->ai_socktype, server->ai_protocol)) != -1)
+		{
+			if((connect_status = connect(sockfd, server->ai_addr, server->ai_addrlen)) == -1)
+			{
+				*error = libc_errors ? errno : ERROR_WHILE_CONNECTING;
+				close(sockfd);
+			}
+			else
+			{
+				*error = 0;
+			}
+		}
+		else
+		{
+			if(*error == 0)
+				*error = libc_errors ? errno : ERROR_CREATE_SOCKET;
+		}
+
+	} while(connect_status != 0 && (server = server->ai_next) != nullptr);
+
+	freeaddrinfo(server_info);
+
+	if(sockfd == -1 || server == nullptr)
+		return -1;
+
+	return sockfd;
+}
+
+int set_nonblocking(int sockfd)
+{
+#ifdef _WIN32
+	unsigned long flags = 1;
+
+	if(ioctlsocket(sockfd, FIONBIO, &flags) == 0)
+		return 0;
+	else
+		return errno;
+#else
+	int flags = -1;
+
+	if((flags = fcntl(sockfd, F_GETFL, 0)) == -1)
+		return errno;
+
+	if(fcntl(sockfd, F_SETFL, flags | O_NONBLOCK) == -1)
+		return errno;
+
+	return 0;
+#endif
+}
+
+// native socket_open_nb(_hostname[], _port, _protocol = SOCKET_TCP, &_error);
+static cell AMX_NATIVE_CALL socket_open_nb(AMX *amx, cell *params)
+{
+	int length = 0;
+	char *hostname = MF_GetAmxString(amx, params[1], 0, &length);
+
+	cell *error = MF_GetAmxAddr(amx, params[4]);
+	*error = 0;
+
+	if(length == 0)
+	{
+		*error = ERROR_EHOSTUNREACH;
+		return -1;
+	}
+
+	char port_number[6];
+	ke::SafeSprintf(port_number, sizeof(port_number), "%d", params[2]);
+
+	int sockfd = -1, getaddrinfo_status = -1, connect_status = -1, setnonblocking_status = -1;
+	bool connect_inprogress = false;
+	struct addrinfo hints, *server_info, *server;
+
+	memset(&hints, 0, sizeof(hints));
+
+	// Both hostname and port should be numeric to prevent the name resolution service from being called and potentially blocking the call for a long time
+	hints.ai_flags = AI_NUMERICHOST | AI_NUMERICSERV; 
+	hints.ai_family = AF_UNSPEC;
+	hints.ai_socktype = params[3];
+
+	if((getaddrinfo_status = getaddrinfo(hostname, port_number, &hints, &server_info)) != 0)
+	{
+		*error = getaddrinfo_status;
+		return -1;
+	}
+
+	server = server_info;
+
+	do
+	{
+		if((sockfd = socket(server->ai_family, server->ai_socktype, server->ai_protocol)) != -1)
+		{
+			setnonblocking_status = set_nonblocking(sockfd);
+
+			if(setnonblocking_status == 0)
+			{
+				if((connect_status = connect(sockfd, server->ai_addr, server->ai_addrlen)) == -1)
+				{
+					*error = errno;
+
+					if(*error == EINPROGRESS)
+						connect_inprogress = true;
+					else
+						close(sockfd);
+				}
+				else
+				{
+					*error = 0;
+				}
+			}
+			else
+			{
+				if(*error == 0)
+					*error = setnonblocking_status;
+			}
+		}
+		else
+		{
+			if(*error == 0)
+				*error = errno;
+		}
+
+	} while(connect_inprogress == false && connect_status != 0 && (server = server->ai_next) != nullptr);
+
+	freeaddrinfo(server_info);
+
+	if(sockfd == -1 || server == nullptr)
+		return -1;
+
+	return sockfd;
 }
 
 // native socket_close(_socket);
-static cell AMX_NATIVE_CALL socket_close(AMX *amx, cell *params)  /* 2 param */
+static cell AMX_NATIVE_CALL socket_close(AMX *amx, cell *params)
 {
-    int socket = params[1];
-    //PRINT_CONSOLE("Function: Close | Socket: %i\n", socket);
-    #ifdef _WIN32 // On windows, check whether the sockets are initialized correctly
-    closesocket(socket);
-    #else
-    // Close the socket (linux/unix styled systems)
-    close(socket);
-    #endif
-    return 0;
-}
-
-// native socket_change(_socket, _timeout=100000);
-// 1 sec =1000000 usec
-static cell AMX_NATIVE_CALL socket_change(AMX *amx, cell *params)  /* 2 param */
-{
-    int socket = params[1];
-    unsigned int timeout = params[2];
-    //PRINT_CONSOLE("Function: Change | Socket: %i | Timeout: %i\n", socket, timeout);
-    // We need both a timeout structure and a fdset for our filedescriptor
-    fd_set rfds;
-    struct timeval tv;
-    // Fill in ...
-    FD_ZERO(&rfds);
-    FD_SET(socket, &rfds);
-    tv.tv_sec = 0;
-    tv.tv_usec = timeout;
-    // Now we "select", which will show us if new data is waiting in the socket's buffer
-    if (select(socket+1, &rfds, NULL, NULL, &tv) > 0) 
-       return 1; // Ok, new data, return it
-     else 
-       return 0; // No new data, return it
+	return (close(params[1]) == -1) ? -1 : 1;
 }
 
 // native socket_recv(_socket, _data[], _length);
-static cell AMX_NATIVE_CALL socket_recv(AMX *amx, cell *params)  /* 2 param */
+static cell AMX_NATIVE_CALL socket_recv(AMX *amx, cell *params)
 {
-    int socket = params[1];
-    int length = params[3];
-    int tmp = -1;
-    // First we dynamicly allocate a block of heap memory for recieving our data
-    char *tmpchar = new char[length];
-    if(tmpchar == NULL) return -1; // If we didn't got a block, we have to quit here to avoid sigsegv
-    // And set it all to 0, because the memory could contain old trash
-    memset(tmpchar, 0, length);
-    // Now we recieve
-    tmp = recv(socket, tmpchar, length-1, 0);
-	if (tmp == -1)
+	int sockfd = params[1];
+	int length = params[3];
+
+	char *recv_buffer = new char[length];
+
+	if(recv_buffer == nullptr)
+		return -1;
+
+	memset(recv_buffer, 0, length);
+
+	int bytes_received = -1;
+	bytes_received = recv(sockfd, recv_buffer, length - 1, 0);
+
+	if(bytes_received == -1)
 	{
-		delete [] tmpchar;
+		delete[] recv_buffer;
 		return -1;
 	}
-    // And put a copy of our recieved data into amx's string
-    tmpchar[tmp]='\0';
-    int nlen = 0;
-    //int max = params[3];
-    int max = length-1;
-    const char* src = tmpchar;
-    cell* dest = MF_GetAmxAddr(amx,params[2]);
-    while(max--&&nlen<tmp){
-     *dest++ = (cell)*src++;
-     nlen++;
-    }
-    *dest = 0;
-    // And we need to free up the space to avoid wasting memory
-    delete [] tmpchar;
-    // And finnally, return the what recv returnd
-    return tmp;
+
+	recv_buffer[bytes_received] = '\0';
+
+	cell* destination = MF_GetAmxAddr(amx, params[2]);
+	strncopy(destination, recv_buffer, length - 1);
+
+	delete[] recv_buffer;
+
+	return bytes_received;
 }
 
 // native socket_send(_socket, _data[], _length);
-static cell AMX_NATIVE_CALL socket_send(AMX *amx, cell *params)  /* 3 param */
+static cell AMX_NATIVE_CALL socket_send(AMX *amx, cell *params)
 {
-	// We get the string from amx
-	int len;
-	int socket = params[1];
-	char* data = MF_GetAmxString(amx,params[2],0,&len);
-	// And send it to the socket
-	return send(socket, data, len, 0);
-}
+	int sockfd = params[1];
+	int length = 0;
+	
+	char *data = MF_GetAmxString(amx, params[2], 0, &length);
 
-static char *g_buffer = NULL;
-static size_t g_buflen = 0;
+	return send(sockfd, data, length, 0);
+}
 
 // native socket_send2(_socket, _data[], _length);
-static cell AMX_NATIVE_CALL socket_send2(AMX *amx, cell *params)  /* 3 param */
+static cell AMX_NATIVE_CALL socket_send2(AMX *amx, cell *params)
 {
-	// We get the string from amx
-	int len = params[3];
-	int socket = params[1];
-	if ((size_t)len > g_buflen)
+	int sockfd = params[1];
+	int length = params[3];
+	
+	if(length > g_send2_buffer_length)
 	{
-		delete [] g_buffer;
-		g_buffer = new char[len+1];
-		g_buflen = len;
+		delete[] g_send2_buffer;
+
+		g_send2_buffer = new char[length + 1];
+		g_send2_buffer_length = length;
 	}
 
-	cell *pData = MF_GetAmxAddr(amx, params[2]);
-	char *pBuffer = g_buffer;
+	cell *data = MF_GetAmxAddr(amx, params[2]);
 
-	while (len--)
-		*pBuffer++ = (char)*pData++;
+	while(length--)
+		*g_send2_buffer++ = (char)*data++;
 
-	// And send it to the socket
-    return send(socket, g_buffer, params[3], 0);
+	return send(sockfd, g_send2_buffer, length, 0);
 }
 
-AMX_NATIVE_INFO sockets_natives[] = {
+// native socket_change(_socket, _timeout = 100000);
+static cell AMX_NATIVE_CALL socket_change(AMX *amx, cell *params)
+{
+	int sockfd = params[1];
+	unsigned int timeout = params[2];
+
+	struct timeval tv;
+	tv.tv_sec = 0;
+	tv.tv_usec = timeout;
+
+	fd_set readfds;
+	FD_ZERO(&readfds);
+	FD_SET(sockfd, &readfds);
+
+	return (select(sockfd + 1, &readfds, nullptr, nullptr, &tv) > 0) ? 1 : -1;
+}
+
+// native socket_is_readable(_socket, _timeout = 100000);
+static cell AMX_NATIVE_CALL socket_is_readable(AMX *amx, cell *params)
+{
+	return socket_change(amx, params);
+}
+
+// native socket_is_writable(_socket, _timeout = 100000);
+static cell AMX_NATIVE_CALL socket_is_writable(AMX *amx, cell *params)
+{
+	int sockfd = params[1];
+	unsigned int timeout = params[2];
+
+	struct timeval tv;
+	tv.tv_sec = 0;
+	tv.tv_usec = timeout;
+
+	fd_set writefds;
+	FD_ZERO(&writefds);
+	FD_SET(sockfd, &writefds);
+
+	return (select(sockfd + 1, nullptr, &writefds, nullptr, &tv) > 0) ? 1 : -1;
+}
+
+AMX_NATIVE_INFO sockets_natives[] =
+{
 	{"socket_open", socket_open},
+	{"socket_open_nb", socket_open_nb},
+
 	{"socket_close", socket_close},
-	{"socket_change", socket_change},
+
 	{"socket_recv", socket_recv},
+
 	{"socket_send", socket_send},
 	{"socket_send2", socket_send2},
+
+	{"socket_change", socket_change},
+	{"socket_is_readable", socket_is_readable},
+	{"socket_is_writable", socket_is_writable},
+
 	{NULL, NULL}
 };
 
 void OnAmxxAttach()
 {
+#ifdef _WIN32  
+	WSADATA WSAData;
+	int errorcode = WSAStartup(MAKEWORD(2, 2), &WSAData);
+
+	if(errorcode != 0)
+	{
+		MF_Log("[%s]: WSAStartup failed with error code %d. Natives will not be available.", MODULE_LOGTAG, errorcode);
+		return;
+	}
+	
+	g_winsock_initialized = true;
+#endif
+
 	MF_AddNatives(sockets_natives);
-    // And, if win32, we have to specially start up the winsock environment
-    #ifdef _WIN32  
-        short wVersionRequested;
-        WSADATA wsaData;
-        wVersionRequested = MAKEWORD (1, 1);
-        if (WSAStartup (wVersionRequested, &wsaData) != 0) {
-            MF_Log("Sockets Module: Error while starting up winsock environment.!");
-        }
-    #endif
-    return;
 }
 
 void OnAmxxDetach()
 {
-    #ifdef _WIN32
-    WSACleanup();
-    #endif
-    delete [] g_buffer;
-    return;
+#ifdef _WIN32
+	if(g_winsock_initialized)
+		WSACleanup();
+#endif
+
+	delete[] g_send2_buffer;
 }

--- a/modules/sockets/sockets.cpp
+++ b/modules/sockets/sockets.cpp
@@ -228,6 +228,13 @@ static cell AMX_NATIVE_CALL socket_send2(AMX *amx, cell *params)
 		delete[] g_send2_buffer;
 
 		g_send2_buffer = new char[length + 1];
+
+		if(g_send2_buffer == nullptr)
+		{
+			g_send2_buffer_length = 0;
+			return -1;
+		}
+		
 		g_send2_buffer_length = length;
 	}
 

--- a/modules/sockets/sockets.cpp
+++ b/modules/sockets/sockets.cpp
@@ -75,11 +75,11 @@ static cell AMX_NATIVE_CALL socket_open(AMX *amx, cell *params)
 		SOCK_LIBC_ERRORS = (1 << 1)
 	};
 
-	#define SOCK_ERROR_OK               0 // No error
-	#define SOCK_ERROR_CREATE_SOCKET    1 // Couldn't create a socket
-	#define SOCK_ERROR_SERVER_UNKNOWN   2 // Server unknown
-	#define SOCK_ERROR_WHILE_CONNECTING 3 // Error while connecting
-	#define ERROR_EHOSTUNREACH 113		// libc error code: No route to host
+	#define SOCK_ERROR_OK               0    // No error
+	#define SOCK_ERROR_CREATE_SOCKET    1    // Couldn't create a socket
+	#define SOCK_ERROR_SERVER_UNKNOWN   2    // Server unknown
+	#define SOCK_ERROR_WHILE_CONNECTING 3    // Error while connecting
+	#define ERROR_EHOSTUNREACH          113  // libc error code: No route to host
 
 	int hostname_length = 0;
 	char *hostname = MF_GetAmxString(amx, params[1], 0, &hostname_length);

--- a/modules/sockets/sockets.cpp
+++ b/modules/sockets/sockets.cpp
@@ -237,7 +237,7 @@ static cell AMX_NATIVE_CALL socket_send2(AMX *amx, cell *params)
 	while(length--)
 		*buffer++ = (char)*data++;
 
-	return send(sockfd, g_send2_buffer, length, 0);
+	return send(sockfd, g_send2_buffer, params[3], 0);
 }
 
 // native socket_change(_socket, _timeout = 100000);

--- a/modules/sockets/sockets.cpp
+++ b/modules/sockets/sockets.cpp
@@ -199,7 +199,17 @@ static cell AMX_NATIVE_CALL socket_recv(AMX *amx, cell *params)
 	recv_buffer[bytes_received] = '\0';
 
 	cell* destination = MF_GetAmxAddr(amx, params[2]);
-	strncopy(destination, recv_buffer, length - 1);
+
+	int current_length = 0;
+	int max_length = length - 1;
+
+	while(max_length-- && current_length < bytes_received)
+	{
+		*destination++ = (cell)*recv_buffer++;
+		current_length++;
+	}
+
+	*destination = 0;
 
 	delete[] recv_buffer;
 

--- a/plugins/include/sockets.inc
+++ b/plugins/include/sockets.inc
@@ -82,30 +82,6 @@
 native socket_open(const _hostname[], _port, _protocol = SOCKET_TCP, &_error, _flags = 0);
 
 /**
- * Nonblocking sockets error handler
- *
- * @param error    Error code returned by socket_open()
- *
- * @note           A newly created nonblocking socket may be still finishing his connection when
- *                 socket_open() returns the socket descriptor. This stock should be used to
- *                 check if socket_open() succeded on creating a new socket, and socket_is_writable()
- *                 should be used later on the socket descriptor when data is about to be sent to check if 
- *                 the connection ended up being established.
- * 
- * @note           The error numbers can be looked up on the links provided about the libc errors on socket_open()                
- *                 
- * @return         true if the socket is succesfully created and connected or currently connecting
- *                 false if the socket failed to be created
- */
-stock bool:SOCK_ERROR_EINPROGRESS(error) 
-{
-    return (error == 0
-         || error == 10035    // WINDOWS, WSAEWOULDBLOCK
-         || error == 10036    // WINDOWS, WSAEINPROGRESS 
-         || error == 115)     // POSIX, EINPROGRESS
-}
-
-/**
  * Closes a socket
  *
  * @param _socket    Socket descriptor

--- a/plugins/include/sockets.inc
+++ b/plugins/include/sockets.inc
@@ -21,45 +21,71 @@
 	#pragma loadlib sockets
 #endif
 
-// Socket flags
-#define SOCK_NON_BLOCKING (1 << 0)    // Set the socket a nonblocking
-#define SOCK_LIBC_ERRORS  (1 << 1)    // Enable libc error reporting
-
-// Error reporting
-#define SOCK_ERROR_OK               0 // No error
-#define SOCK_ERROR_CREATE_SOCKET    1 // Couldn't create a socket
-#define SOCK_ERROR_SERVER_UNKNOWN   2 // Server unknown
-#define SOCK_ERROR_WHILE_CONNECTING 3 // Error while connecting
-
-// Nonblocking sockets error handler
-stock SOCK_ERROR_EINPROGRESS(error) return (error == 0 || error == 10035 || error == 10036 || error == 115)
-
-// Socket connection type (TCP/UDP)
+/*
+ * Socket connection type (TCP/UDP)
+ */
 #define SOCKET_TCP 1
 #define SOCKET_UDP 2
 
 /**
+ * Socket flags
+ */
+#define SOCK_NON_BLOCKING (1 << 0)    /* Set the socket a nonblocking */
+#define SOCK_LIBC_ERRORS  (1 << 1)    /* Enable libc error reporting */
+
+/*
+ * Error reporting
+ */
+#define SOCK_ERROR_OK               0 /* No error */
+#define SOCK_ERROR_CREATE_SOCKET    1 /* Couldn't create a socket */
+#define SOCK_ERROR_SERVER_UNKNOWN   2 /* Server unknown */
+#define SOCK_ERROR_WHILE_CONNECTING 3 /* Error while connecting */
+
+/*
+ * Nonblocking sockets error handler
+ *
+ * @param error    Error code returned by socket_open()
+ *
+ * @note           A newly created nonblocking socket may be still finishing his connection when
+ *                 socket_open() returns the socket descriptor. This stock should be used to
+ *                 check if socket_open() succeded on creating a new socket, and socket_is_writable()
+ *                 should be used later on the socket descriptor when data is about to be sent to check if 
+ *                 the connection ended up being established.
+ *                 
+ *                 
+ * @return         true if the socket is succesfully created and connected or currently connecting
+ *                 false if the socket failed to be created
+ */
+stock bool:SOCK_ERROR_EINPROGRESS(error) return (error == 0 || error == 10035 || error == 10036 || error == 115)
+
+/**
  * Connects to the given node and service via TCP/UDP.
  *
- * @note There's 2 types of error reporting on this function that you can use, for backwards compatibility reasons libc errors are disabled by default
- * @note Old, default error codes:
+ * @note There's 2 types of error reporting on this function that you can use.
+ * @note Default error codes:
  *       0 - No error
  *       1 - Error while creating socket
  *       2 - Couldn't resolve hostname
  *       3 - Couldn't connect
- * @note New, libc error codes:
+ * @note New, more expressive libc error codes:
  *       https://www.gnu.org/software/libc/manual/html_node/Error-Codes.html
  *       https://github.com/torvalds/linux/blob/master/include/uapi/asm-generic/errno.h
  *       https://msdn.microsoft.com/en-us/library/ms740668.aspx
  *
  * @note The currently available bit flags are:
- *       - SOCK_NON_BLOCKING : if set, the socket would be on nonblocking mode
- *       - SOCK_LIBC_ERRORS : if set, the new libc errors will be seen on _error instead of the old, made up ones
- * @note If no flags are set, the behaviour of the function will not be modified (default blocking mode and error reporting).
- * @note Multiple flags may be set at the same time using the | operator. For example, SOCK_NON_BLOCKING|SOCK_LIBC_ERRORS will create a nonblocking socket with libc error codes.
+ *       - SOCK_NON_BLOCKING : if set, the socket will be on nonblocking mode
+ *       - SOCK_LIBC_ERRORS : if set, the new libc errors will be seen on _error
  *
- * @note If you're creating a new nonblocking socket, _hostname should be numeric to avoid calling the name resolution server and potentially blocking the call
- * @note If the socket is a nonblocking one, the returned socket descriptor may be still connecting and further checks should be done with socket_is_writable() before trying to send data
+ * @note If no flags are set, the behaviour of the function will not be modified.
+ *
+ * @note Multiple flags may be set at the same time using the | operator. 
+ *       For example, SOCK_NON_BLOCKING|SOCK_LIBC_ERRORS will create a nonblocking socket with libc error codes.
+ *
+ * @note If you're creating a new nonblocking socket, _hostname should be numeric to avoid calling the 
+ *       name resolution server and potentially blocking the call
+ *
+ * @note If the socket is a nonblocking one, the returned socket descriptor may be still connecting and 
+ *       further checks should be done with socket_is_writable() before trying to send data
  *
  * @param _hostname    Node to connect to
  * @param _port        Service to connect to
@@ -85,13 +111,13 @@ native socket_close(_socket);
 /**
  * Receives data.
  *
- * @note The ammount of bytes than you end up receiving can be less than the one you expected
+ * @note The amount of bytes than you end up receiving can be less than the one you expected
  *
  * @param _socket    Socket descriptor
  * @param _data      Array to save the data
  * @param _length    Length of the array
  *
- * @return           Ammount of bytes received
+ * @return           Amount of bytes received
  *                   0 if the peer closed the connection
  *                   -1 on failure
  */
@@ -100,13 +126,14 @@ native socket_recv(_socket, _data[], _length);
 /**
  * Sends data.
  *
- * @note The ammount of bytes than you end up sending can be less than expected, you're responsible of sending the rest later
+ * @note The amount of bytes that end up being sent may be lower than the total length of the array,
+ *       check the return value and send the rest if needed
  *
  * @param _socket    Socket descriptor
  * @param _data      Array with the data to send
  * @param _length    Length of the array
  *
- * @return           Ammount of bytes sent
+ * @return           Amount of bytes sent
  *                   -1 on failure
  */
 native socket_send(_socket, const _data[], _length);
@@ -114,41 +141,36 @@ native socket_send(_socket, const _data[], _length);
 /**
  * Sends data that can contain null bytes.
  *
- * @note The ammount of bytes than you end up sending can be less than expected, you're responsible of sending the rest later
+ * @note The amount of bytes that end up being sent may be lower than the total length of the array,
+ *       check the return value and send the rest if needed
  *
  * @param _socket    Socket descriptor
  * @param _data      Array with the data to send
  * @param _length    Length of the array
  *
- * @return           Ammount of bytes sent
+ * @return           Amount of bytes sent
  *                   -1 on failure
  */
 native socket_send2(_socket, const _data[], _length);
 
 /**
- * Check if a socket is marked as readable.
+ * Backwards compatible function
  *
- * @note You can use this function to make sure there's something on the socket and avoiding a blocking call
- * @note Set _timeout to 0 avoid blocking the call
- * @note A socket will become readable if there's any data or an EOF
- *
- * @param _socket    Socket descriptor
- * @param _timeout   Ammount of time to block the call waiting for the socket to be marked as readable or for the timeout to expire, in µSeconds (1 sec = 1000000 µsec)
- *
- * @return           1 if the socket is marked as readable
- *                   -1 otherwise
+ * @deprecated Renamed to socket_is_readable
  */
+#pragma deprecated Use socket_is_readable() instead
 native socket_change(_socket, _timeout = 100000);
 
 /**
- * Check if a socket is marked as readable.
+ * Checks if a socket is marked as readable.
  *
  * @note You can use this function to make sure there's something on the socket and avoiding a blocking call
  * @note Set _timeout to 0 avoid blocking the call
  * @note A socket will become readable if there's any data or an EOF
  *
  * @param _socket    Socket descriptor
- * @param _timeout   Ammount of time to block the call waiting for the socket to be marked as readable or for the timeout to expire, in µSeconds (1 sec = 1000000 µsec)
+ * @param _timeout   Amount of time to block the call waiting for the socket to be marked as readable or
+ *                   for the timeout to expire, in µSeconds (1 sec = 1000000 µsec)
  *
  * @return           1 if the socket is marked as readable
  *                   -1 otherwise
@@ -156,14 +178,15 @@ native socket_change(_socket, _timeout = 100000);
 native socket_is_readable(_socket, _timeout = 100000);
 
 /**
- * Check if a socket is marked as writable.
+ * Checks if a socket is marked as writable.
  *
  * @note Use this function to check if a nonblocking socket is ready to be used
  * @note Set _timeout to 0 avoid blocking the call
  * @note An UDP socket is always writable
  *
  * @param _socket    Socket descriptor
- * @param _timeout   Ammount of time to block the call waiting for the socket to be marked as writable or for the timeout to expire, in µSeconds (1 sec = 1000000 µsec)
+ * @param _timeout   Amount of time to block the call waiting for the socket to be marked as writable or
+ *                   for the timeout to expire, in µSeconds (1 sec = 1000000 µsec)
  *
  * @return           1 if the socket is marked as writable
  *                   -1 otherwise

--- a/plugins/include/sockets.inc
+++ b/plugins/include/sockets.inc
@@ -3,9 +3,6 @@
 // AMX Mod X, based on AMX Mod by Aleksander Naszko ("OLO").
 // Copyright (C) The AMX Mod X Development Team.
 //
-// Codebase from Ivan, -g-s-ivan@web.de (AMX 0.9.3)
-// Modification by Olaf Reusch, kenterfie@hlsw.de (AMXX 0.16, AMX 0.96)
-//
 // This software is licensed under the GNU General Public License, version 3 or higher.
 // Additional exceptions apply. For full license details, see LICENSE.txt or visit:
 //     https://alliedmods.net/amxmodx-license
@@ -24,43 +21,159 @@
 	#pragma loadlib sockets
 #endif
 
-// Use SOCKET_TCP for TCP Socket connections
+// Backwards compatibility and error reporting
+#define ERROR_CREATE_SOCKET       1 // Couldn't create a socket
+#define ERROR_SERVER_UNKNOWN      2 // Server unknown
+#define ERROR_WHILE_CONNECTING    3 // Error while connecting
 
+#define DISABLE_LIBC_ERRORS 0 // Old, default error reporting
+#define ENABLE_LIBC_ERRORS  1 // Enable libc error reporting
+
+// Use SOCKET_TCP for TCP Socket connections
 #define SOCKET_TCP 1
 
 // Use SOCKET_UDP for UDP Socket connections
-
 #define SOCKET_UDP 2
 
-/* Opens a new connection to hostname:port via protocol (either SOCKET_TCP or SOCKET_UDP),
- * returns a socket (positive) or negative or zero on error.
- * States of error:
- * 0 - no error
- * 1 - error while creating socket
- * 2 - couldn't resolve hostname
- * 3 - couldn't connect to given hostname:port
+/**
+ * Connects to the given node and service via TCP/UDP.
+ *
+ * @note There's 2 types of error reporting on this function that you can use, for backwards compatibility reasons libc errors are disabled by default
+ * @note Old, default error codes:
+ *       0 - No error
+ *       1 - Error while creating socket
+ *       2 - Couldn't resolve hostname
+ *       3 - Couldn't connect
+ * @note New, libc error codes:
+ *       https://www.gnu.org/software/libc/manual/html_node/Error-Codes.html
+ *       https://github.com/torvalds/linux/blob/master/include/uapi/asm-generic/errno.h
+ *       https://msdn.microsoft.com/en-us/library/ms740668.aspx
+ *
+ * @param _hostname    Node to connect to
+ * @param _port        Service to connect to
+ * @param _protocol    Connect via SOCKET_TCP or SOCKET_UDP
+ * @param _error       Set an error code here if anything goes wrong
+ * @param _libc_errors Optional parameter that defaults to DISABLE_LIBC_ERRORS. If set to ENABLE_LIBC_ERRORS the new libc errors will be set on _error instead of the old, made up ones
+ *
+ * @return             A socket descriptor (a positive integer) on success
+ *                     -1 on failure
 */
+native socket_open(const _hostname[], _port, _protocol = SOCKET_TCP, &_error, _libc_errors = DISABLE_LIBC_ERRORS);
 
-native socket_open(const _hostname[], _port, _protocol = SOCKET_TCP, &_error);
+/**
+ * Connects on nonblocking mode to the given node and service via TCP/UDP.
+ *
+ * @note _hostname should be numeric to avoid calling the name resolution server and potentially blocking the call
+ * @note The returned socket descriptor may be still connecting, further checks should be done with socket_is_writable()
+ * @note Unlike in socket_open() libc error codes are used. They can be found at:
+ *       https://www.gnu.org/software/libc/manual/html_node/Error-Codes.html
+ *       https://github.com/torvalds/linux/blob/master/include/uapi/asm-generic/errno.h
+ *       https://msdn.microsoft.com/en-us/library/ms740668.aspx
+ *
+ * @param _hostname    Node to connect to
+ * @param _port        Service to connect to
+ * @param _protocol    Connect via SOCKET_TCP or SOCKET_UDP
+ * @param _error       Set an error code here if anything goes wrong
 
-/* Closes a Socket */
+ * @return             A socket descriptor (a positive integer) on success
+ *                     -1 on failure
+*/
+native socket_open_nb(const _hostname[], _port, _protocol = SOCKET_TCP, &_error);
 
+/**
+ * Closes a socket
+ *
+ * @param _socket    Socket descriptor
+ *
+ * @return           1 on success
+ *                   -1 on failure
+ */
 native socket_close(_socket);
 
-/* Recieves Data to string with the given length */
-
+/**
+ * Receives data.
+ *
+ * @note The ammount of bytes than you end up receiving can be less than the one you expected
+ *
+ * @param _socket    Socket descriptor
+ * @param _data      Array to save the data
+ * @param _length    Length of the array
+ *
+ * @return           Ammount of bytes received
+ *                   0 if the peer closed the connection
+ *                   -1 on failure
+ */
 native socket_recv(_socket, _data[], _length);
 
-/* Sends data to the Socket */
-
+/**
+ * Sends data.
+ *
+ * @note The ammount of bytes than you end up sending can be less than expected, you're responsible of sending the rest later
+ *
+ * @param _socket    Socket descriptor
+ * @param _data      Array with the data to send
+ * @param _length    Length of the array
+ *
+ * @return           Ammount of bytes sent
+ *                   -1 on failure
+ */
 native socket_send(_socket, const _data[], _length);
 
-/* Same as socket_send but Data can contain null bytes */
-
+/**
+ * Sends data that can contain null bytes.
+ *
+ * @note The ammount of bytes than you end up sending can be less than expected, you're responsible of sending the rest later
+ *
+ * @param _socket    Socket descriptor
+ * @param _data      Array with the data to send
+ * @param _length    Length of the array
+ *
+ * @return           Ammount of bytes sent
+ *                   -1 on failure
+ */
 native socket_send2(_socket, const _data[], _length);
 
-/* This function will return true if the state (buffer content) have changed within the last recieve or
-* the timeout, where timeout is a value in µSeconds, (1 sec =1000000 µsec).
-* Use to check if new data is in your socket. */
+/**
+ * Check if a socket is marked as readable.
+ *
+ * @note You can use this function to make sure there's something on the socket and avoiding a blocking call
+ * @note Set _timeout to 0 avoid blocking the call
+ * @note A socket will become readable if there's any data or an EOF
+ *
+ * @param _socket    Socket descriptor
+ * @param _timeout   Ammount of time to block the call waiting for the socket to be marked as readable or for the timeout to expire, in µSeconds (1 sec = 1000000 µsec)
+ *
+ * @return           1 if the socket is marked as readable
+ *                   -1 otherwise
+ */
+native socket_change(_socket, _timeout = 100000);
 
-native socket_change(_socket, _timeout=100000);
+/**
+ * Check if a socket is marked as readable.
+ *
+ * @note You can use this function to make sure there's something on the socket and avoiding a blocking call
+ * @note Set _timeout to 0 avoid blocking the call
+ * @note A socket will become readable if there's any data or an EOF
+ *
+ * @param _socket    Socket descriptor
+ * @param _timeout   Ammount of time to block the call waiting for the socket to be marked as readable or for the timeout to expire, in µSeconds (1 sec = 1000000 µsec)
+ *
+ * @return           1 if the socket is marked as readable
+ *                   -1 otherwise
+ */
+native socket_is_readable(_socket, _timeout = 100000);
+
+/**
+ * Check if a socket is marked as writable.
+ *
+ * @note Use this function to check if a nonblocking socket is ready to be used
+ * @note Set _timeout to 0 avoid blocking the call
+ * @note An UDP socket is always writable
+ *
+ * @param _socket    Socket descriptor
+ * @param _timeout   Ammount of time to block the call waiting for the socket to be marked as writable or for the timeout to expire, in µSeconds (1 sec = 1000000 µsec)
+ *
+ * @return           1 if the socket is marked as writable
+ *                   -1 otherwise
+ */
+native socket_is_writable(_socket, _timeout = 100000);

--- a/plugins/include/sockets.inc
+++ b/plugins/include/sockets.inc
@@ -21,7 +21,7 @@
 	#pragma loadlib sockets
 #endif
 
-/*
+/**
  * Socket connection type (TCP/UDP)
  */
 #define SOCKET_TCP 1
@@ -33,30 +33,13 @@
 #define SOCK_NON_BLOCKING (1 << 0)    /* Set the socket a nonblocking */
 #define SOCK_LIBC_ERRORS  (1 << 1)    /* Enable libc error reporting */
 
-/*
+/**
  * Error reporting
  */
 #define SOCK_ERROR_OK               0 /* No error */
 #define SOCK_ERROR_CREATE_SOCKET    1 /* Couldn't create a socket */
 #define SOCK_ERROR_SERVER_UNKNOWN   2 /* Server unknown */
 #define SOCK_ERROR_WHILE_CONNECTING 3 /* Error while connecting */
-
-/*
- * Nonblocking sockets error handler
- *
- * @param error    Error code returned by socket_open()
- *
- * @note           A newly created nonblocking socket may be still finishing his connection when
- *                 socket_open() returns the socket descriptor. This stock should be used to
- *                 check if socket_open() succeded on creating a new socket, and socket_is_writable()
- *                 should be used later on the socket descriptor when data is about to be sent to check if 
- *                 the connection ended up being established.
- *                 
- *                 
- * @return         true if the socket is succesfully created and connected or currently connecting
- *                 false if the socket failed to be created
- */
-stock bool:SOCK_ERROR_EINPROGRESS(error) return (error == 0 || error == 10035 || error == 10036 || error == 115)
 
 /**
  * Connects to the given node and service via TCP/UDP.
@@ -97,6 +80,30 @@ stock bool:SOCK_ERROR_EINPROGRESS(error) return (error == 0 || error == 10035 ||
  *                     -1 on failure
 */
 native socket_open(const _hostname[], _port, _protocol = SOCKET_TCP, &_error, _flags = 0);
+
+/**
+ * Nonblocking sockets error handler
+ *
+ * @param error    Error code returned by socket_open()
+ *
+ * @note           A newly created nonblocking socket may be still finishing his connection when
+ *                 socket_open() returns the socket descriptor. This stock should be used to
+ *                 check if socket_open() succeded on creating a new socket, and socket_is_writable()
+ *                 should be used later on the socket descriptor when data is about to be sent to check if 
+ *                 the connection ended up being established.
+ * 
+ * @note           The error numbers can be looked up on the links provided about the libc errors on socket_open()                
+ *                 
+ * @return         true if the socket is succesfully created and connected or currently connecting
+ *                 false if the socket failed to be created
+ */
+stock bool:SOCK_ERROR_EINPROGRESS(error) 
+{
+    return (error == 0
+         || error == 10035    // WINDOWS, WSAEWOULDBLOCK
+         || error == 10036    // WINDOWS, WSAEINPROGRESS 
+         || error == 115)     // POSIX, EINPROGRESS
+}
 
 /**
  * Closes a socket

--- a/plugins/include/sockets.inc
+++ b/plugins/include/sockets.inc
@@ -21,18 +21,21 @@
 	#pragma loadlib sockets
 #endif
 
-// Backwards compatibility and error reporting
-#define ERROR_CREATE_SOCKET       1 // Couldn't create a socket
-#define ERROR_SERVER_UNKNOWN      2 // Server unknown
-#define ERROR_WHILE_CONNECTING    3 // Error while connecting
+// Socket flags
+#define SOCK_NON_BLOCKING (1 << 0)    // Set the socket a nonblocking
+#define SOCK_LIBC_ERRORS  (1 << 1)    // Enable libc error reporting
 
-#define DISABLE_LIBC_ERRORS 0 // Old, default error reporting
-#define ENABLE_LIBC_ERRORS  1 // Enable libc error reporting
+// Error reporting
+#define SOCK_ERROR_OK               0 // No error
+#define SOCK_ERROR_CREATE_SOCKET    1 // Couldn't create a socket
+#define SOCK_ERROR_SERVER_UNKNOWN   2 // Server unknown
+#define SOCK_ERROR_WHILE_CONNECTING 3 // Error while connecting
 
-// Use SOCKET_TCP for TCP Socket connections
+// Nonblocking sockets error handler
+stock SOCK_ERROR_EINPROGRESS(error) return (error == 0 || error == 10035 || error == 10036 || error == 115)
+
+// Socket connection type (TCP/UDP)
 #define SOCKET_TCP 1
-
-// Use SOCKET_UDP for UDP Socket connections
 #define SOCKET_UDP 2
 
 /**
@@ -49,36 +52,25 @@
  *       https://github.com/torvalds/linux/blob/master/include/uapi/asm-generic/errno.h
  *       https://msdn.microsoft.com/en-us/library/ms740668.aspx
  *
- * @param _hostname    Node to connect to
- * @param _port        Service to connect to
- * @param _protocol    Connect via SOCKET_TCP or SOCKET_UDP
- * @param _error       Set an error code here if anything goes wrong
- * @param _libc_errors Optional parameter that defaults to DISABLE_LIBC_ERRORS. If set to ENABLE_LIBC_ERRORS the new libc errors will be set on _error instead of the old, made up ones
+ * @note The currently available bit flags are:
+ *       - SOCK_NON_BLOCKING : if set, the socket would be on nonblocking mode
+ *       - SOCK_LIBC_ERRORS : if set, the new libc errors will be seen on _error instead of the old, made up ones
+ * @note If no flags are set, the behaviour of the function will not be modified (default blocking mode and error reporting).
+ * @note Multiple flags may be set at the same time using the | operator. For example, SOCK_NON_BLOCKING|SOCK_LIBC_ERRORS will create a nonblocking socket with libc error codes.
  *
- * @return             A socket descriptor (a positive integer) on success
- *                     -1 on failure
-*/
-native socket_open(const _hostname[], _port, _protocol = SOCKET_TCP, &_error, _libc_errors = DISABLE_LIBC_ERRORS);
-
-/**
- * Connects on nonblocking mode to the given node and service via TCP/UDP.
- *
- * @note _hostname should be numeric to avoid calling the name resolution server and potentially blocking the call
- * @note The returned socket descriptor may be still connecting, further checks should be done with socket_is_writable()
- * @note Unlike in socket_open() libc error codes are used. They can be found at:
- *       https://www.gnu.org/software/libc/manual/html_node/Error-Codes.html
- *       https://github.com/torvalds/linux/blob/master/include/uapi/asm-generic/errno.h
- *       https://msdn.microsoft.com/en-us/library/ms740668.aspx
+ * @note If you're creating a new nonblocking socket, _hostname should be numeric to avoid calling the name resolution server and potentially blocking the call
+ * @note If the socket is a nonblocking one, the returned socket descriptor may be still connecting and further checks should be done with socket_is_writable() before trying to send data
  *
  * @param _hostname    Node to connect to
  * @param _port        Service to connect to
  * @param _protocol    Connect via SOCKET_TCP or SOCKET_UDP
  * @param _error       Set an error code here if anything goes wrong
-
+ * @param _flags       Optional bit flags that change the behaviour of the function
+ *
  * @return             A socket descriptor (a positive integer) on success
  *                     -1 on failure
 */
-native socket_open_nb(const _hostname[], _port, _protocol = SOCKET_TCP, &_error);
+native socket_open(const _hostname[], _port, _protocol = SOCKET_TCP, &_error, _flags = 0);
 
 /**
  * Closes a socket

--- a/plugins/include/sockets.inc
+++ b/plugins/include/sockets.inc
@@ -87,7 +87,7 @@ native socket_open(const _hostname[], _port, _protocol = SOCKET_TCP, &_error, _f
  * @param _socket    Socket descriptor
  *
  * @return           1 on success
- *                   -1 on failure
+ *                   0 on failure
  */
 native socket_close(_socket);
 
@@ -156,7 +156,7 @@ native socket_change(_socket, _timeout = 100000);
  *                   for the timeout to expire, in µSeconds (1 sec = 1000000 µsec)
  *
  * @return           1 if the socket is marked as readable
- *                   -1 otherwise
+ *                   0 otherwise
  */
 native socket_is_readable(_socket, _timeout = 100000);
 
@@ -172,6 +172,6 @@ native socket_is_readable(_socket, _timeout = 100000);
  *                   for the timeout to expire, in µSeconds (1 sec = 1000000 µsec)
  *
  * @return           1 if the socket is marked as writable
- *                   -1 otherwise
+ *                   0 otherwise
  */
 native socket_is_writable(_socket, _timeout = 100000);

--- a/plugins/include/sockets.inc
+++ b/plugins/include/sockets.inc
@@ -41,23 +41,6 @@
 #define SOCK_ERROR_SERVER_UNKNOWN   2 /* Server unknown */
 #define SOCK_ERROR_WHILE_CONNECTING 3 /* Error while connecting */
 
-/*
- * Nonblocking sockets error handler
- *
- * @param error    Error code returned by socket_open()
- *
- * @note           A newly created nonblocking socket may be still finishing his connection when
- *                 socket_open() returns the socket descriptor. This stock should be used to
- *                 check if socket_open() succeded on creating a new socket, and socket_is_writable()
- *                 should be used later on the socket descriptor when data is about to be sent to check if 
- *                 the connection ended up being established.
- *                 
- *                 
- * @return         true if the socket is succesfully created and connected or currently connecting
- *                 false if the socket failed to be created
- */
-stock bool:SOCK_ERROR_EINPROGRESS(error) return (error == 0 || error == 10035 || error == 10036 || error == 115)
-
 /**
  * Connects to the given node and service via TCP/UDP.
  *
@@ -97,6 +80,29 @@ stock bool:SOCK_ERROR_EINPROGRESS(error) return (error == 0 || error == 10035 ||
  *                     -1 on failure
 */
 native socket_open(const _hostname[], _port, _protocol = SOCKET_TCP, &_error, _flags = 0);
+
+/*
+ * Nonblocking sockets error handler
+ *
+ * @param error    Error code returned by socket_open()
+ *
+ * @note           A newly created nonblocking socket may be still finishing his connection when
+ *                 socket_open() returns the socket descriptor. This stock should be used to
+ *                 check if socket_open() succeded on creating a new socket, and socket_is_writable()
+ *                 should be used later on the socket descriptor when data is about to be sent to check if 
+ *                 the connection ended up being established.
+ * 
+ *                 
+ * @return         true if the socket is succesfully created and connected or currently connecting
+ *                 false if the socket failed to be created
+ */
+stock bool:SOCK_ERROR_EINPROGRESS(error) 
+{
+    return (error == 0
+         || error == 10035    // WINDOWS, WSAEWOULDBLOCK
+         || error == 10036    // WINDOWS, WSAEINPROGRESS 
+         || error == 115)     // POSIX, EINPROGRESS
+}
 
 /**
  * Closes a socket

--- a/plugins/include/sockets.inc
+++ b/plugins/include/sockets.inc
@@ -41,6 +41,23 @@
 #define SOCK_ERROR_SERVER_UNKNOWN   2 /* Server unknown */
 #define SOCK_ERROR_WHILE_CONNECTING 3 /* Error while connecting */
 
+/*
+ * Nonblocking sockets error handler
+ *
+ * @param error    Error code returned by socket_open()
+ *
+ * @note           A newly created nonblocking socket may be still finishing his connection when
+ *                 socket_open() returns the socket descriptor. This stock should be used to
+ *                 check if socket_open() succeded on creating a new socket, and socket_is_writable()
+ *                 should be used later on the socket descriptor when data is about to be sent to check if 
+ *                 the connection ended up being established.
+ *                 
+ *                 
+ * @return         true if the socket is succesfully created and connected or currently connecting
+ *                 false if the socket failed to be created
+ */
+stock bool:SOCK_ERROR_EINPROGRESS(error) return (error == 0 || error == 10035 || error == 10036 || error == 115)
+
 /**
  * Connects to the given node and service via TCP/UDP.
  *
@@ -80,29 +97,6 @@
  *                     -1 on failure
 */
 native socket_open(const _hostname[], _port, _protocol = SOCKET_TCP, &_error, _flags = 0);
-
-/*
- * Nonblocking sockets error handler
- *
- * @param error    Error code returned by socket_open()
- *
- * @note           A newly created nonblocking socket may be still finishing his connection when
- *                 socket_open() returns the socket descriptor. This stock should be used to
- *                 check if socket_open() succeded on creating a new socket, and socket_is_writable()
- *                 should be used later on the socket descriptor when data is about to be sent to check if 
- *                 the connection ended up being established.
- * 
- *                 
- * @return         true if the socket is succesfully created and connected or currently connecting
- *                 false if the socket failed to be created
- */
-stock bool:SOCK_ERROR_EINPROGRESS(error) 
-{
-    return (error == 0
-         || error == 10035    // WINDOWS, WSAEWOULDBLOCK
-         || error == 10036    // WINDOWS, WSAEINPROGRESS 
-         || error == 115)     // POSIX, EINPROGRESS
-}
 
 /**
  * Closes a socket

--- a/plugins/include/sockets.inc
+++ b/plugins/include/sockets.inc
@@ -65,10 +65,10 @@
  *       For example, SOCK_NON_BLOCKING|SOCK_LIBC_ERRORS will create a nonblocking socket with libc error codes.
  *
  * @note If you're creating a new nonblocking socket, _hostname should be numeric to avoid calling the 
- *       name resolution server and potentially blocking the call
+ *       name resolution server and potentially blocking the call.
  *
  * @note If the socket is a nonblocking one, the returned socket descriptor may be still connecting and 
- *       further checks should be done with socket_is_writable() before trying to send data
+ *       further checks should be done with socket_is_writable() before trying to send data.
  *
  * @param _hostname    Node to connect to
  * @param _port        Service to connect to
@@ -82,7 +82,7 @@
 native socket_open(const _hostname[], _port, _protocol = SOCKET_TCP, &_error, _flags = 0);
 
 /**
- * Closes a socket
+ * Closes a socket.
  *
  * @param _socket    Socket descriptor
  *
@@ -94,7 +94,7 @@ native socket_close(_socket);
 /**
  * Receives data.
  *
- * @note The amount of bytes than you end up receiving can be less than the one you expected
+ * @note The amount of bytes than you end up receiving can be less than the one you expected.
  *
  * @param _socket    Socket descriptor
  * @param _data      Array to save the data
@@ -110,7 +110,7 @@ native socket_recv(_socket, _data[], _length);
  * Sends data.
  *
  * @note The amount of bytes that end up being sent may be lower than the total length of the array,
- *       check the return value and send the rest if needed
+ *       check the return value and send the rest if needed.
  *
  * @param _socket    Socket descriptor
  * @param _data      Array with the data to send
@@ -125,7 +125,9 @@ native socket_send(_socket, const _data[], _length);
  * Sends data that can contain null bytes.
  *
  * @note The amount of bytes that end up being sent may be lower than the total length of the array,
- *       check the return value and send the rest if needed
+ *       check the return value and send the rest if needed.
+ *
+ * @note strlen(_data) will return the wrong length if the array contains null bytes.
  *
  * @param _socket    Socket descriptor
  * @param _data      Array with the data to send
@@ -137,9 +139,9 @@ native socket_send(_socket, const _data[], _length);
 native socket_send2(_socket, const _data[], _length);
 
 /**
- * Backwards compatible function
+ * Backwards compatible function.
  *
- * @deprecated Renamed to socket_is_readable
+ * @deprecated Renamed to socket_is_readable()
  */
 #pragma deprecated Use socket_is_readable() instead
 native socket_change(_socket, _timeout = 100000);
@@ -147,9 +149,9 @@ native socket_change(_socket, _timeout = 100000);
 /**
  * Checks if a socket is marked as readable.
  *
- * @note You can use this function to make sure there's something on the socket and avoiding a blocking call
- * @note Set _timeout to 0 avoid blocking the call
- * @note A socket will become readable if there's any data or an EOF
+ * @note You can use this function to make sure there's something on the socket and avoid a blocking call.
+ * @note Set _timeout to 0 avoid blocking the call.
+ * @note A socket will become readable if there's any data or an EOF.
  *
  * @param _socket    Socket descriptor
  * @param _timeout   Amount of time to block the call waiting for the socket to be marked as readable or
@@ -163,9 +165,9 @@ native socket_is_readable(_socket, _timeout = 100000);
 /**
  * Checks if a socket is marked as writable.
  *
- * @note Use this function to check if a nonblocking socket is ready to be used
- * @note Set _timeout to 0 avoid blocking the call
- * @note An UDP socket is always writable
+ * @note Use this function to check if a nonblocking socket is ready to be used.
+ * @note Set _timeout to 0 avoid blocking the call.
+ * @note An UDP socket is always writable.
  *
  * @param _socket    Socket descriptor
  * @param _timeout   Amount of time to block the call waiting for the socket to be marked as writable or


### PR DESCRIPTION
Been working on this some time. Changelog:
- WinSock version changed from 1.1 to 2.2.
- Properly check for WinSock initialization on OnAmxxAttach/Detach.
- Now natives will not be added if we can't start up WinSock.
- socket_open() is now IP version agnostic (both IPv4 and IPv6 are
  supported).
- Error reporting has been changed on socket_open(), a new parameter
  called _libc_errors has been added, and, if enabled, libc errors will be
  returned instead of the previous made-up errors.
- socket_close() now returns a value on success/failure.
- Added non-blocking sockets at socket_open_nb().
- Added socket_is_writable() to check if a socket is ready for write.
- Added socket_is_readable() as an alias to socket_change().
- Code rewritten to be more readable, it should be self-explaining now.

Sorry for the ugly diff @Arkshine 
