### PR TITLE
Fix a potential crash if SV_DropClient address could not be found

### DIFF
--- a/amxmodx/meta_api.cpp
+++ b/amxmodx/meta_api.cpp
@@ -1566,7 +1566,7 @@ C_DLLEXPORT	int	Meta_Attach(PLUG_LOADTIME now, META_FUNCTIONS *pFunctionTable, m
 
 	void *address = nullptr;
 
-	if (CommonConfig && CommonConfig->GetMemSig("SV_DropClient", &address))
+	if (CommonConfig && CommonConfig->GetMemSig("SV_DropClient", &address) && address)
 	{
 		DropClientDetour = DETOUR_CREATE_STATIC_FIXED(SV_DropClient, address);
 		DropClientDetour->EnableDetour();

--- a/modules/cstrike/cstrike/CstrikeHacks.cpp
+++ b/modules/cstrike/cstrike/CstrikeHacks.cpp
@@ -543,11 +543,11 @@ void InitGlobalVars()
 
 	if (!ServerStatic)
 	{
-		MF_Log("svs global variable is not available\n");
+		MF_Log("svs global variable is not available");
 	}
 
 	if (!Server)
 	{
-		MF_Log("sv global variable is not available\n");
+		MF_Log("sv global variable is not available");
 	}
 }


### PR DESCRIPTION
Missing sanity check resulting core trying to hook the function from null pointer.
Related to #264.