### PR TITLE
Avoiding directives that split up parts of statements.

### DIFF
--- a/compiler/libpc300/sc1.c
+++ b/compiler/libpc300/sc1.c
@@ -413,16 +413,17 @@ static void inst_binary_name(char *binfname)
   size_t i, len;
   char *binptr;
   char newpath[512], newname[512];
+  int slashchar;
 
   binptr = NULL;
   len = strlen(binfname);
   for (i = len - 1; i < len; i--)
   {
-    if (binfname[i] == '/'
+    slashchar = binfname[i] == '/';
 #if defined WIN32 || defined _WIN32
-      || binfname[i] == '\\'
+    slashchar = slashchar || binfname[i] == '\\';
 #endif
-      )
+    if (slashchar)
     {
       binptr = &binfname[i + 1];
       break;


### PR DESCRIPTION
A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

- https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
- https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

It might improve code understanding, maintainability and error-proneness.