### PR TITLE
Fix translations for %l specifier

### DIFF
--- a/amxmodx/format.cpp
+++ b/amxmodx/format.cpp
@@ -52,7 +52,13 @@ const char *translate(AMX *amx, cell amxaddr, const char *key)
 	const char *pLangName = NULL;
 	const char *def = NULL;
 	int status;
-	cell *addr = get_amxaddr(amx, amxaddr);
+	cell *addr = NULL;
+
+	if(amxaddr >= LANG_SERVER && amxaddr <= gpGlobals->maxClients)
+		addr = &amxaddr;
+	else
+		addr = get_amxaddr(amx, amxaddr);
+	
 	char name[4];
 	if (addr[0] == LANG_PLAYER)
 	{


### PR DESCRIPTION
Related to #229.

This bug occurs when we use ```%l``` format specifier. It sets server's language when it is used instead of player's.
The problem lies in the __translate__ function. When we use ```%l``` specifier it passes player's or server's index as amxaddr (but it's not amxaddr really) to the function so if we call __get_amxaddr__ for player/server index it'll return 0 (set server's language).