### PR TITLE
Enhance "amxx" client-side command

### DIFF
--- a/amxmodx/meta_api.cpp
+++ b/amxmodx/meta_api.cpp
@@ -958,11 +958,48 @@ void C_ClientCommand(edict_t *pEntity)
 	// Handle "amxx" if not on listenserver
 	if (IS_DEDICATED_SERVER())
 	{
+		static char buf[1024];
+		size_t len = 0;
+
 		if (cmd && stricmp(cmd, "amxx") == 0)
 		{
+		    int argc = CMD_ARGC();
+		    if(argc > 1 && stricmp(arg, "plugins") == 0)
+		    {
+				if(!g_plugins.getPluginsNum())
+				{
+					CLIENT_PRINT(pEntity, print_console, "[AMXX] No plugins found.");
+					RETURN_META(MRES_SUPERCEDE);
+				}
+
+				CPluginMngr::iterator a = g_plugins.begin();
+				size_t i = 0;
+
+				while(a)
+				{
+					if((*a).getStatusCode() == ps_running)
+					{
+						len = ke::SafeSprintf(buf, sizeof(buf), "[%d] \"%s\"", ++i, (*a).getTitle());
+
+						if(*(*a).getVersion())
+						{
+							len += ke::SafeSprintf(&buf[len], sizeof(buf)-len, " (%s)", (*a).getVersion());
+						}
+						if(*(*a).getAuthor())
+						{
+							len += ke::SafeSprintf(&buf[len], sizeof(buf)-len, " by %s", (*a).getAuthor());
+						}
+					
+						len += ke::SafeSprintf(&buf[len], sizeof(buf)-len, " %s\n", (*a).getName());
+						CLIENT_PRINT(pEntity, print_console, buf);
+
+				        ++a;
+					}
+				}
+				RETURN_META(MRES_SUPERCEDE);
+			}
+
 			// Print version
-			static char buf[1024];
-			size_t len = 0;
 			
 			sprintf(buf, "%s %s\n", Plugin_info.name, Plugin_info.version);
 			CLIENT_PRINT(pEntity, print_console, buf);

--- a/amxmodx/meta_api.cpp
+++ b/amxmodx/meta_api.cpp
@@ -1001,22 +1001,22 @@ void C_ClientCommand(edict_t *pEntity)
 
 			// Print version
 			
-			sprintf(buf, "%s %s\n", Plugin_info.name, Plugin_info.version);
+			ke::SafeSprintf(buf, sizeof(buf), "%s %s\n", Plugin_info.name, Plugin_info.version);
 			CLIENT_PRINT(pEntity, print_console, buf);
-			len = sprintf(buf, "Authors: \n         David \"BAILOPAN\" Anderson, Pavol \"PM OnoTo\" Marko, Felix \"SniperBeamer\" Geyer\n");
-			len += sprintf(&buf[len], "         Jonny \"Got His Gun\" Bergstrom, Lukasz \"SidLuke\" Wlasinski\n");
+			len = ke::SafeSprintf(buf, sizeof(buf), "Authors: \n         David \"BAILOPAN\" Anderson, Pavol \"PM OnoTo\" Marko, Felix \"SniperBeamer\" Geyer\n");
+			len += ke::SafeSprintf(&buf[len], sizeof(buf)-len, "         Jonny \"Got His Gun\" Bergstrom, Lukasz \"SidLuke\" Wlasinski\n");
 			CLIENT_PRINT(pEntity, print_console, buf);
-			len = sprintf(buf, "         Christian \"Basic-Master\" Hammacher, Borja \"faluco\" Ferrer\n");
-			len += sprintf(&buf[len], "         Scott \"DS\" Ehlert\n");
-			len += sprintf(&buf[len], "Compiled: %s\nURL:http://www.amxmodx.org/\n", __DATE__ ", " __TIME__);
+			len = ke::SafeSprintf(buf, sizeof(buf), "         Christian \"Basic-Master\" Hammacher, Borja \"faluco\" Ferrer\n");
+			len += ke::SafeSprintf(&buf[len], sizeof(buf)-len, "         Scott \"DS\" Ehlert\n");
+			len += ke::SafeSprintf(&buf[len], sizeof(buf)-len, "Compiled: %s\nURL:http://www.amxmodx.org/\n", __DATE__ ", " __TIME__);
 			CLIENT_PRINT(pEntity, print_console, buf);
 #ifdef JIT
-			sprintf(buf, "Core mode: JIT\n");
+			ke::SafeSprintf(buf, sizeof(buf), "Core mode: JIT\n");
 #else
 #ifdef ASM32
-			sprintf(buf, "Core mode: ASM\n");
+			ke::SafeSprintf(buf, sizeof(buf), "Core mode: ASM\n");
 #else
-			sprintf(buf, "Core mode: Normal\n");
+			ke::SafeSprintf(buf, sizeof(buf), "Core mode: Normal\n");
 #endif
 #endif
 			CLIENT_PRINT(pEntity, print_console, buf);

--- a/amxmodx/meta_api.cpp
+++ b/amxmodx/meta_api.cpp
@@ -963,12 +963,12 @@ void C_ClientCommand(edict_t *pEntity)
 
 		if (cmd && stricmp(cmd, "amxx") == 0)
 		{
-		    int argc = CMD_ARGC();
-		    if(argc > 1 && stricmp(arg, "plugins") == 0)
-		    {
+			int argc = CMD_ARGC();
+			if(argc > 1 && stricmp(arg, "plugins") == 0)
+			{
 				if(!g_plugins.getPluginsNum())
 				{
-					CLIENT_PRINT(pEntity, print_console, "[AMXX] No plugins found.");
+					CLIENT_PRINT(pEntity, print_console, "[AMXX] No plugins found.\n");
 					RETURN_META(MRES_SUPERCEDE);
 				}
 
@@ -992,13 +992,44 @@ void C_ClientCommand(edict_t *pEntity)
 					
 						len += ke::SafeSprintf(&buf[len], sizeof(buf)-len, " %s\n", (*a).getName());
 						CLIENT_PRINT(pEntity, print_console, buf);
-
-				        ++a;
 					}
+					++a;
 				}
 				RETURN_META(MRES_SUPERCEDE);
 			}
+			else if(argc > 1 && stricmp(arg, "modules") == 0)
+			{
+				if(!g_modules.size())
+				{
+					CLIENT_PRINT(pEntity, print_console, "[AMXX] No modules found.\n");
+					RETURN_META(MRES_SUPERCEDE);
+				}
 
+				CList<CModule, const char *>::iterator a = g_modules.begin();
+				size_t i = 0;
+
+				while(a)
+				{
+					if((*a).getStatusValue() == MODULE_LOADED)
+					{
+						len = ke::SafeSprintf(buf, sizeof(buf), "[%d] \"%s\"", ++i, (*a).getName());
+
+						if(*(*a).getVersion())
+						{
+							len += ke::SafeSprintf(&buf[len], sizeof(buf)-len, " (%s)", (*a).getVersion());
+						}
+						if(*(*a).getAuthor())
+						{
+							len += ke::SafeSprintf(&buf[len], sizeof(buf)-len, " by %s", (*a).getAuthor());
+						}
+
+						len += ke::SafeSprintf(&buf[len], sizeof(buf)-len, "\n");
+						CLIENT_PRINT(pEntity, print_console, buf);
+					}
+					++a;
+				}
+				RETURN_META(MRES_SUPERCEDE);
+			}
 			// Print version
 			
 			ke::SafeSprintf(buf, sizeof(buf), "%s %s\n", Plugin_info.name, Plugin_info.version);

--- a/amxmodx/meta_api.cpp
+++ b/amxmodx/meta_api.cpp
@@ -1010,14 +1010,14 @@ void C_ClientCommand(edict_t *pEntity)
 			len += ke::SafeSprintf(&buf[len], sizeof(buf)-len, "         Scott \"DS\" Ehlert\n");
 			len += ke::SafeSprintf(&buf[len], sizeof(buf)-len, "Compiled: %s\nURL:http://www.amxmodx.org/\n", __DATE__ ", " __TIME__);
 			CLIENT_PRINT(pEntity, print_console, buf);
-#ifdef JIT
-			ke::SafeSprintf(buf, sizeof(buf), "Core mode: JIT\n");
-#else
-#ifdef ASM32
-			ke::SafeSprintf(buf, sizeof(buf), "Core mode: ASM\n");
+#if defined JIT && !defined ASM32
+			ke::SafeSprintf(buf, sizeof(buf), "Core mode: JIT Only\n");
+#elif !defined JIT && defined ASM32
+			ke::SafeSprintf(buf, sizeof(buf), "Core mode: ASM32 Only\n");
+#elif defined JIT && defined ASM32
+			ke::SafeSprintf(buf, sizeof(buf), "Core mode: JIT+ASM32\n");
 #else
 			ke::SafeSprintf(buf, sizeof(buf), "Core mode: Normal\n");
-#endif
 #endif
 			CLIENT_PRINT(pEntity, print_console, buf);
 			RETURN_META(MRES_SUPERCEDE);


### PR DESCRIPTION
The idea was stolen from SM. SM allows us (as a player) to check what plugins and extensions are running on a server. I think it would be nice to have similar feature in amxx. Also added missing core mode "JIT+ASM32". 