### PR TITLE
Adding flag parameter to user_silentkill.

### DIFF
--- a/plugins/include/message_stocks.inc
+++ b/plugins/include/message_stocks.inc
@@ -29,7 +29,7 @@ stock dod_make_deathmsg(killer, victim, weaponNUM)
 }
 
 /* Kills a user without a message. */
-stock user_silentkill(index)
+stock user_silentkill(index, flag = 1)
 {
 	static msgid = 0;
 	new msgblock;
@@ -39,7 +39,7 @@ stock user_silentkill(index)
 	}
 	msgblock = get_msg_block(msgid);
 	set_msg_block(msgid, BLOCK_ONCE);	
-	user_kill(index, 1);
+	user_kill(index, flag);
 	set_msg_block(msgid, msgblock);
 
 	return 1;


### PR DESCRIPTION
The api says that the user_silentkill() "Kills a user without a message.",  that means it is just user_kill() without sending deathmsg.
But user_silentkill() automatically kills player without affecting the client's score (and that is not mentioned in api), so i'll add a second parameter to user_silnetkill() to let user to decide if he want to kill a player without or not affecting the table.
New parameter has the default value 1, so it won't break the compatibility.