### PR TITLE
Fix typo in replace_stringex native

### DIFF
--- a/amxmodx/string.cpp
+++ b/amxmodx/string.cpp
@@ -348,12 +348,12 @@ static cell AMX_NATIVE_CALL replace_stringex(AMX *amx, cell *params)
 
 	char *ptr = UTIL_ReplaceEx(text, maxlength + 1, search, searchLen, replace, replaceLen, caseSensitive); // + EOS
 
-	if (ptr == NULL)
+	if (!ptr)
 	{
 		return -1;
 	}
 
-	set_amxstring(amx, params[1], ptr, maxlength);
+	set_amxstring(amx, params[1], text, maxlength);
 
 	return ptr - text;
 }


### PR DESCRIPTION
Reported by PartialCloning here : https://forums.alliedmods.net/showthread.php?t=276618.
Related to a86ca1491f97961cd58ac1492272130742bb5d5b.