### PR TITLE
Enable detours in ServerActivate to avoid sig conflict with third-party AMXX modules

### DIFF
--- a/amxmodx/meta_api.cpp
+++ b/amxmodx/meta_api.cpp
@@ -619,6 +619,11 @@ void C_ServerActivate(edict_t *pEdictList, int edictCount, int clientMax)
 		}
 	}
 
+	if (DropClientDetour)
+	{
+		DropClientDetour->EnableDetour();
+	}
+
 	RETURN_META(MRES_IGNORED);
 }
 
@@ -687,6 +692,11 @@ void C_ServerDeactivate()
 		}
 	}
 
+	if (DropClientDetour)
+	{
+		DropClientDetour->DisableDetour();
+	}
+
 	g_players_num	= 0;
 	executeForwards(FF_PluginEnd);
 
@@ -703,7 +713,7 @@ void C_ServerDeactivate_Post()
 		RETURN_META(MRES_IGNORED);
 
 	modules_callPluginsUnloading();
-	
+
 	detachReloadModules();
 
 	CoreCfg.Clear();
@@ -1581,7 +1591,6 @@ C_DLLEXPORT	int	Meta_Attach(PLUG_LOADTIME now, META_FUNCTIONS *pFunctionTable, m
 	if (CommonConfig && CommonConfig->GetMemSig("SV_DropClient", &address) && address)
 	{
 		DropClientDetour = DETOUR_CREATE_STATIC_FIXED(SV_DropClient, address);
-		DropClientDetour->EnableDetour();
 	}
 	else
 	{

--- a/modules/cstrike/cstrike/CstrikeMain.cpp
+++ b/modules/cstrike/cstrike/CstrikeMain.cpp
@@ -67,13 +67,19 @@ void OnPluginsLoaded()
 	ForwardInternalCommand = MF_RegisterForward("CS_InternalCommand", ET_STOP, FP_CELL, FP_STRING, FP_DONE);
 	ForwardOnBuy           = MF_RegisterForward("CS_OnBuy"          , ET_STOP, FP_CELL, FP_CELL, FP_DONE);
 	ForwardOnBuyAttempt    = MF_RegisterForward("CS_OnBuyAttempt"   , ET_STOP, FP_CELL, FP_CELL, FP_DONE);
+}
 
-	if (!ClientCommandDetour) // All CS_* forwards requires ClientCommand. Unlikely to fail.
+void OnServerActivate(edict_t *pEdictList, int edictCount, int clientMax)
+{
+	// Used to catch WeaponList message at map change.
+	EnableMessageHooks();
+
+	if (!ClientCommandDetour) // All CS_* forwards requires ClientCommand. Unlikely to fail. 
 	{
 		ToggleDetour_ClientCommands(false);
 		ToggleDetour_BuyCommands(false);
 
-		return;
+		RETURN_META(MRES_IGNORED);
 	}
 
 	auto haveBotDetours = UseBotArgs && BotArgs;
@@ -85,12 +91,6 @@ void OnPluginsLoaded()
 
 	ToggleDetour_ClientCommands(HasInternalCommandForward || HasOnBuyAttemptForward || HasOnBuyForward);
 	ToggleDetour_BuyCommands(HasOnBuyForward);
-}
-
-void OnServerActivate(edict_t *pEdictList, int edictCount, int clientMax)
-{
-	// Used to catch WeaponList message at map change.
-	EnableMessageHooks();
 
 	RETURN_META(MRES_IGNORED);
 }
@@ -98,6 +98,19 @@ void OnServerActivate(edict_t *pEdictList, int edictCount, int clientMax)
 void OnServerActivate_Post(edict_t *pEdictList, int edictCount, int clientMax)
 {
 	DisableMessageHooks();
+
+	RETURN_META(MRES_IGNORED);
+}
+
+void OnServerDeactivate()
+{
+	if (!ClientCommandDetour)
+	{
+		RETURN_META(MRES_IGNORED);
+	}
+
+	ToggleDetour_ClientCommands(false);
+	ToggleDetour_BuyCommands(false);
 
 	RETURN_META(MRES_IGNORED);
 }

--- a/modules/cstrike/cstrike/moduleconfig.h
+++ b/modules/cstrike/cstrike/moduleconfig.h
@@ -123,8 +123,8 @@
 // #define FN_ClientPutInServer			ClientPutInServer			/* pfnClientPutInServer()		(wd) Client is entering the game */
 // #define FN_ClientCommand				ClientCommand				/* pfnClientCommand()			(wd) Player has sent a command (typed or from a bind) */
 // #define FN_ClientUserInfoChanged		ClientUserInfoChanged		/* pfnClientUserInfoChanged()	(wd) Client has updated their setinfo structure */
-#define FN_ServerActivate				OnServerActivate				/* pfnServerActivate()			(wd) Server is starting a new map */
-// #define FN_ServerDeactivate			ServerDeactivate			/* pfnServerDeactivate()		(wd) Server is leaving the map (shutdown or changelevel); SDK2 */
+#define FN_ServerActivate				OnServerActivate			/* pfnServerActivate()			(wd) Server is starting a new map */
+#define FN_ServerDeactivate				OnServerDeactivate			/* pfnServerDeactivate()		(wd) Server is leaving the map (shutdown or changelevel); SDK2 */
 // #define FN_PlayerPreThink			PlayerPreThink				/* pfnPlayerPreThink() */
 // #define FN_PlayerPostThink			PlayerPostThink				/* pfnPlayerPostThink() */
 // #define FN_StartFrame				StartFrame					/* pfnStartFrame() */


### PR DESCRIPTION
This gives a chance for third-party modules which use `OnPluginsLoaded` to sigscan game library , before AMXX patches memory (when detour is enabled).

Requested by someone, somewhere.