### PR TITLE
Fix recursion issue with show_menu and newmenus

### DIFF
--- a/amxmodx/amxmodx.cpp
+++ b/amxmodx/amxmodx.cpp
@@ -1251,8 +1251,11 @@ static cell AMX_NATIVE_CALL show_menu(AMX *amx, cell *params) /* 3 param */
 				pPlayer->menu = 0;
 
 				// Fire newmenu callback so closing it can be handled by the plugin
-				if (Menu *pMenu = get_menu_by_id(pPlayer->newmenu))
-					pMenu->Close(pPlayer->index);
+				if (!CloseNewMenus(pPlayer))
+				{
+					LogError(amx, AMX_ERR_NATIVE, "Plugin called menu_display when item=MENU_EXIT");
+					return 0;
+				}
 
 				UTIL_FakeClientCommand(pPlayer->pEdict, "menuselect", "10", 0);
 			}
@@ -1274,8 +1277,11 @@ static cell AMX_NATIVE_CALL show_menu(AMX *amx, cell *params) /* 3 param */
 			pPlayer->menu = 0;
 
 			// Fire newmenu callback so closing it can be handled by the plugin
-			if (Menu *pMenu = get_menu_by_id(pPlayer->newmenu))
-				pMenu->Close(pPlayer->index);
+			if (!CloseNewMenus(pPlayer))
+			{
+				LogError(amx, AMX_ERR_NATIVE, "Plugin called menu_display when item=MENU_EXIT");
+				return 0;
+			}
 
 			UTIL_FakeClientCommand(pPlayer->pEdict, "menuselect", "10", 0);
 		}

--- a/amxmodx/newmenus.h
+++ b/amxmodx/newmenus.h
@@ -129,6 +129,7 @@ public:
 
 void ClearMenus();
 Menu *get_menu_by_id(int id);
+bool CloseNewMenus(CPlayer *pPlayer);
 
 extern ke::Vector<Menu *> g_NewMenus;
 extern AMX_NATIVE_INFO g_NewMenuNatives[];


### PR DESCRIPTION
Reported by Depresie here: https://forums.alliedmods.net/showthread.php?t=277625.

Side-effect of #140 bugfix. Now that `show_menu` closes previous newmenu, it doesn't consider that calling callback could display another newmenus. This patch applies the same infinite loop protection than `menu_display`.