### PR TITLE
Update GameConfig

### DIFF
--- a/amxmodx/CGameConfigs.cpp
+++ b/amxmodx/CGameConfigs.cpp
@@ -651,7 +651,15 @@ bool CGameConfig::Reparse(char *error, size_t maxlength)
 		if (g_LibSys.PathExists(path))
 		{
 			g_LibSys.PathFormat(path, sizeof(path), "custom/%s.txt", m_File);
-			return EnterFile(path, error, maxlength);
+
+			auto success = EnterFile(path, error, maxlength);
+
+			if (success)
+			{
+				AMXXLOG_Log("[AMXX] Parsed custom gamedata override file: %s", path);
+			}
+
+			return success;
 		}
 		return true;
 	}
@@ -717,6 +725,8 @@ bool CGameConfig::Reparse(char *error, size_t maxlength)
 			g_LibSys.CloseDirectory(customDir);
 			return false;
 		}
+
+		AMXXLOG_Log("[AMXX] Parsed custom gamedata override file: %s", path);
 
 		customDir->NextEntry();
 	}

--- a/amxmodx/CGameConfigs.cpp
+++ b/amxmodx/CGameConfigs.cpp
@@ -637,7 +637,6 @@ bool CGameConfig::Reparse(char *error, size_t maxlength)
 
 	if (!g_LibSys.PathExists(path))
 	{
-#if 0
 		// Single config file without master
 		g_LibSys.PathFormat(path, sizeof(path), "%s.txt", m_File);
 
@@ -645,7 +644,7 @@ bool CGameConfig::Reparse(char *error, size_t maxlength)
 		{
 			return false;
 		}
-#endif
+
 		// Allow customizations of default gamedata files
 		build_pathname_r(path, sizeof(path), "%s/gamedata/custom/%s.txt", dataDir, m_File);
 

--- a/amxmodx/gameconfigs.cpp
+++ b/amxmodx/gameconfigs.cpp
@@ -24,6 +24,7 @@ static cell AMX_NATIVE_CALL LoadGameConfigFile(AMX *amx, cell *params)
 
 	if (!ConfigManager.LoadGameConfigFile(filename, &config, error, sizeof(error)))
 	{
+		ConfigManager.CloseGameConfigFile(config);
 		LogError(amx, AMX_ERR_NATIVE, "Unable to open %s: %s", filename, error);
 		return 0;
 	}
@@ -31,7 +32,7 @@ static cell AMX_NATIVE_CALL LoadGameConfigFile(AMX *amx, cell *params)
 	int handle = GameConfigHandle.create();
 
 	auto configHandle = GameConfigHandle.lookup(handle);
-	
+
 	if (!configHandle)
 	{
 		return 0;


### PR DESCRIPTION
* Allows single config file without master. Really for convenience. Master has been introduced for better maintainability overall (AMBuild, Updater, etc), but for simple config this is not really useful. I think it's fine to have this choice depending the associated config(s) to a plugin. To be discussed. 
* Fixes `LoadGameConfigFile` native which will return a valid handle if native is called two times ormore with an invalid path. It's because path is always saved in cache. A possible solution is to close gameconfig right away. Internal design is kind of weird.
* Prints a message to console when there is a gamedata file loaded from the `custom` folder to act as a reminder that original value is overwritten. Should we save in amxx log instead?