### PR TITLE
Move Cvar_DirectSet to gamedata

### DIFF
--- a/amxmodx/CvarManager.h
+++ b/amxmodx/CvarManager.h
@@ -14,6 +14,7 @@
 #include <amtl/am-vector.h>
 #include <amtl/am-inlinelist.h>
 #include <sm_namehashset.h>
+#include "CGameConfigs.h"
 
 class CDetour;
 

--- a/amxmodx/meta_api.cpp
+++ b/amxmodx/meta_api.cpp
@@ -1572,9 +1572,9 @@ C_DLLEXPORT	int	Meta_Attach(PLUG_LOADTIME now, META_FUNCTIONS *pFunctionTable, m
 
 	FlagMan.SetFile("cmdaccess.ini");
 
-	g_CvarManager.CreateCvarHook();
-
 	ConfigManager.OnAmxxStartup();
+
+	g_CvarManager.CreateCvarHook();
 
 	void *address = nullptr;
 

--- a/gamedata/common.games/functions.engine.txt
+++ b/gamedata/common.games/functions.engine.txt
@@ -22,6 +22,13 @@
 				"linux"     "@SV_DropClient"
 				"mac"       "@SV_DropClient"
 			}
+			"Cvar_DirectSet" // void Cvar_DirectSet(struct cvar_s *var, char *value);
+			{
+				"library"   "engine"
+				"windows"   "\x55\x8B\x2A\x81\x2A\x2A\x2A\x2A\x2A\x56\x8B\x2A\x2A\x57\x8B\x2A\x2A\x85"
+				"linux"     "@Cvar_DirectSet"
+				"mac"       "@Cvar_DirectSet"
+			}
 		}
 	}
 }


### PR DESCRIPTION
Binding/Hooking cvars don't work on ReHLDS server without modification AMXX code. I think the best option is to move Cvar_DirectSet to gamedata files for easier configuration. I'm not sure about windows signature but when I was testing it, it worked as it should. I'll appreciate if anyone checks it just for sanity. Tested on Linux & Windows.