### PR TITLE
Improve client_print_color by inserting default color code at the start of string

### DIFF
--- a/amxmodx/amxmodx.cpp
+++ b/amxmodx/amxmodx.cpp
@@ -337,6 +337,12 @@ static cell AMX_NATIVE_CALL client_print_color(AMX *amx, cell *params) /* 3 para
 				g_langMngr.SetDefLang(i);
 				msg = format_amxstring(amx, params, 3, len);
 
+				if (*msg > 4) // Insert default color code at the start if not present, otherwise message will not be colored.
+				{
+					memmove(msg + 1, msg, ke::Min(len++, 191));
+					*msg = 1;
+				}
+
 				if (len > 190)	// Server crashes after byte 190. (190 + \n = 191)
 				{
 					len = 190;
@@ -368,6 +374,12 @@ static cell AMX_NATIVE_CALL client_print_color(AMX *amx, cell *params) /* 3 para
 			g_langMngr.SetDefLang(index);
 
 			msg = format_amxstring(amx, params, 3, len);
+
+			if (*msg > 4) // Insert default color code at the start if not present, otherwise message will not be colored.
+			{
+				memmove(msg + 1, msg, ke::Min(len++, 191));
+				*msg = 1;
+			}
 
 			if (len > 190)	// Server crashes after byte 190. (190 + \n = 191)
 			{


### PR DESCRIPTION
Originally reported by @9iky6 in #321.

To display colored message, `SayText` requires that at first index a color code is present.
Native will now automatically insert the default one if not present. For the sake of convenience.