### PR TITLE
Fix CS_OnBuy* not triggered from alias containing uppercase letters

### DIFF
--- a/modules/cstrike/cstrike/CstrikeHacks.cpp
+++ b/modules/cstrike/cstrike/CstrikeHacks.cpp
@@ -158,8 +158,11 @@ DETOUR_DECL_STATIC1(C_ClientCommand, void, edict_t*, pEdict) // void ClientComma
 				if (get_pdata<CUnifiedSignals>(pEdict, SignalsDesc.fieldOffset).GetState() & SIGNAL_BUY) // Are we inside the buy zone?
 				{
 					AliasInfo info;
+					char commandLowered[32];
 
-					if (ItemsManager.GetAliasInfosFromBuy(command, &info))
+					UTIL_StringToLower(command, commandLowered, sizeof(commandLowered));
+
+					if (ItemsManager.GetAliasInfosFromBuy(commandLowered, &info))
 					{
 						CurrentItemId = info.itemid;
 					}

--- a/modules/cstrike/cstrike/CstrikeUtils.cpp
+++ b/modules/cstrike/cstrike/CstrikeUtils.cpp
@@ -12,6 +12,7 @@
 //
 
 #include "amxxmodule.h"
+#include <amtl/am-algorithm.h>
 
 extern int MessageIdTextMsg;
 
@@ -46,4 +47,23 @@ bool UTIL_CheckForPublic(const char *publicname)
 	}
 
 	return false;
+}
+
+void UTIL_StringToLower(const char *str, char *buffer, size_t maxlength)
+{
+	auto length = ke::Min(strlen(str), maxlength - 1);
+
+	for (size_t i = 0; i < length; ++i)
+	{
+		if (str[i] >= 'A' && str[i] <= 'Z')
+		{
+			buffer[i] = tolower(str[i]);
+		}
+		else
+		{
+			buffer[i] = str[i];
+		}
+	}
+
+	buffer[length] = '\0';
 }

--- a/modules/cstrike/cstrike/CstrikeUtils.h
+++ b/modules/cstrike/cstrike/CstrikeUtils.h
@@ -21,6 +21,7 @@ extern HLTypeConversion TypeConversion;
 bool UTIL_IsPlayer(edict_t *pPlayer);
 void UTIL_TextMsg_Generic(edict_t* pPlayer, const char* message);
 bool UTIL_CheckForPublic(const char *publicname);
+void UTIL_StringToLower(const char *str, char *buffer, size_t maxlength);
 
 #define GETINFOKEYBUFFER	(*g_engfuncs.pfnGetInfoKeyBuffer)
 #define	SETCLIENTKEYVALUE	(*g_engfuncs.pfnSetClientKeyValue)


### PR DESCRIPTION
Reported by GoRiLliAz (a.k.a the Bug Finder).

It's actually my fault, code was removed in #183 because function was not checking character validity, and I thought actually this was needed, thus removing all. But it's required as input from console is unchanged and uppercase letters are allowed by game.

Arbitrary buffer max length of 32 which should be largely enough to contain an alias name.