### PR TITLE
Fakemeta: fixed bug with recursive pre hooks (one returned supercede …

### DIFF
--- a/modules/fakemeta/forward.cpp
+++ b/modules/fakemeta/forward.cpp
@@ -24,7 +24,6 @@ float mlFloatResult;
 const char *mStringResult;
 const char *mlStringResult;
 int retType = 0;
-int lastFmRes = FMRES_IGNORED;
 KVD_Wrapper g_kvd_hook;
 clientdata_t *g_cd_hook;
 entity_state_t *g_es_hook;
@@ -55,7 +54,6 @@ void clfm()
 	mlCellResult = 0;
 	mStringResult = "";
 	mlStringResult = "";
-	lastFmRes = FMRES_IGNORED;
 	mFloatResult = 0.0;
 	mlFloatResult = 0.0;
 }

--- a/modules/fakemeta/forward.h
+++ b/modules/fakemeta/forward.h
@@ -193,7 +193,6 @@ extern const char *mStringResult;
 extern cell mlCellResult;
 extern float mlFloatResult;
 extern const char *mlStringResult;
-extern int lastFmRes;
 extern int retType;
 
 #endif //_INCLUDE_FORWARD_H

--- a/modules/fakemeta/forwardmacros.h
+++ b/modules/fakemeta/forwardmacros.h
@@ -751,14 +751,12 @@
 #define SIMPLE_VOID_HOOK_INT_INT_CONSTVECT_EDICT(call) \
 	void call (int v, int vb, const float *vec, edict_t *e) \
 	{ \
-		if (vec) { \
-			PREPARE_VECTOR(vec); \
-			FM_ENG_HANDLE(FM_##call, (Engine[FM_##call].at(i),  (cell)v, (cell)vb, p_vec, (cell)ENTINDEX(e))); \
-		} else { \
-			const float b[3]={0.0,0.0,0.0}; \
-			PREPARE_VECTOR(b); \
-			FM_ENG_HANDLE(FM_##call, (Engine[FM_##call].at(i),  (cell)v, (cell)vb, p_b, (cell)ENTINDEX(e))); \
+		const float b[3]={0.0,0.0,0.0}; \
+		if (vec == nullptr) { \
+			vec = b; \
 		} \
+		PREPARE_VECTOR(vec); \
+		FM_ENG_HANDLE(FM_##call, (Engine[FM_##call].at(i),  (cell)v, (cell)vb, p_vec, (cell)ENTINDEX(e))); \
 		RETURN_META(mswi(lastFmRes)); \
 	} \
 	void call##_post (int v, int vb, const float *vec, edict_t *e) \
@@ -924,6 +922,7 @@
 	register unsigned int i = 0; \
 	clfm(); \
 	int fmres = FMRES_IGNORED; \
+	int lastFmRes = FMRES_IGNORED; \
 	for (i=0; i<Engine[pfnCall].length(); i++) \
 	{ \
 		fmres = MF_ExecuteForward pfnArgs; \
@@ -941,6 +940,7 @@
 	register unsigned int i = 0; \
 	clfm(); \
 	int fmres = FMRES_IGNORED; \
+	int lastFmRes = FMRES_IGNORED; \
 	for (i=0; i<EnginePost[pfnCall].length(); i++) \
 	{ \
 		fmres = MF_ExecuteForward pfnArgs; \


### PR DESCRIPTION
…can supercede several hooks)

Bug demonstration:
```
#include <amxmodx>
#include <fakemeta>

public plugin_init() {
	register_forward(FM_ClientDisconnect, "OnClientDisconnect_PreHook", false);
	register_forward(FM_SetModel, "OnSetModel_PreHook", false);
}

public OnSetModel_PreHook(entityIndex, const modelName[]) {
	engfunc(EngFunc_SetModel, entityIndex, modelName);
	return FMRES_SUPERCEDE;
}

public OnClientDisconnect_PreHook(playerIndex) {
	new armouryEntity = engfunc(EngFunc_CreateNamedEntity, engfunc(EngFunc_AllocString, "armoury_entity"));
	
	dllfunc(DLLFunc_Spawn, armouryEntity); // CArmoury::Spawn calls SetModel
	
	return FMRES_IGNORED; // but supercedes and gamedll doesn't print about disconnect WTF?!?!?!
}
```