### PR TITLE
Add cs_get_item_alias(), improve cs_get_item_id() & cleanup alias datas

### DIFF
--- a/gamedata/modules.games/game.cstrike.txt
+++ b/gamedata/modules.games/game.cstrike.txt
@@ -144,12 +144,17 @@
 	{
 		"ItemInfos"
 		{
-			"CommonAlias"
+			"BuyAliases"
 			{
+				//
+				// Weapon
+				//
+
 				"p228"
 				{
 					"itemid"     "1"  // CSW/I_P228
 					"classid"    "2"  // CS_WEAPONCLASS_PISTOL
+					"altname"    "228compact"
 				}
 				"scout"
 				{
@@ -160,6 +165,7 @@
 				{
 					"itemid"     "5"  // CSW/I_XM1014
 					"classid"    "5"  // CS_WEAPONCLASS_SHOTGUN
+					"altname"    "autoshotgun"
 				}
 				"mac10"
 				{
@@ -170,244 +176,123 @@
 				{
 					"itemid"     "8"  // CSW/I_AUG
 					"classid"    "7"  // CS_WEAPONCLASS_RIFLE
+					"altname"    "bullpup"
 				}
 				"elites"
 				{
-					"itemid"    "10"  // CSW/I_ELITE
+					"itemid"     "10" // CSW/I_ELITE
 					"classid"    "2"  // CS_WEAPONCLASS_PISTOL
 				}
 				"fn57"
 				{
-					"itemid"    "11"  // CSW/I_FIVESEVEN
+					"itemid"     "11" // CSW/I_FIVESEVEN
 					"classid"    "2"  // CS_WEAPONCLASS_PISTOL
+					"altname"    "fiveseven"
 				}
 				"ump45"
 				{
-					"itemid"    "12"  // CSW/I_UMP45
+					"itemid"     "12" // CSW/I_UMP45
 					"classid"    "4"  // CS_WEAPONCLASS_SUBMACHINEGUN
 				}
 				"sg550"
 				{
-					"itemid"    "13"  // CSW/I_SG550
+					"itemid"     "13" // CSW/I_SG550
 					"classid"    "8"  // CS_WEAPONCLASS_SNIPERRIFLE
+					"altname"    "krieg550"
 				}
 				"galil"
 				{
-					"itemid"    "14"  // CSW/I_GALIL
+					"itemid"     "14" // CSW/I_GALIL
 					"classid"    "7"  // CS_WEAPONCLASS_RIFLE
+					"altname"    "defender"
 				}
 				"famas"
 				{
-					"itemid"    "15"  // CSW/I_FAMAS
+					"itemid"     "15" // CSW/I_FAMAS
 					"classid"    "7"  // CS_WEAPONCLASS_RIFLE
+					"altname"    "clarion"
 				}
 				"usp"
 				{
-					"itemid"    "16"  // CSW/I_USP
+					"itemid"     "16" // CSW/I_USP
 					"classid"    "2"  // CS_WEAPONCLASS_PISTOL
+					"altname"    "km45"
 				}
 				"glock"
 				{
-					"itemid"    "17"  // CSW/I_GLOCK18
+					"itemid"     "17" // CSW/I_GLOCK18
 					"classid"    "2"  // CS_WEAPONCLASS_PISTOL
+					"altname"    "9x19mm"
 				}
 				"awp"
 				{
-					"itemid"    "18"  // CSW/I_AWP
+					"itemid"     "18" // CSW/I_AWP
 					"classid"    "8"  // CS_WEAPONCLASS_SNIPERRIFLE
+					"altname"    "magnum"
 				}
 				"mp5"
 				{
-					"itemid"    "19"  // CSW/I_MP5NAVY
+					"itemid"     "19" // CSW/I_MP5NAVY
 					"classid"    "4"  // CS_WEAPONCLASS_SUBMACHINEGUN
+					"altname"    "smg"
 				}
 				"m249"
 				{
-					"itemid"    "20"  // CSW/I_M249
+					"itemid"     "20" // CSW/I_M249
 					"classid"    "6"  // CS_WEAPONCLASS_MACHINEGUN
 				}
 				"m3"
 				{
-					"itemid"    "21"  // CSW/I_M3
+					"itemid"     "21" // CSW/I_M3
 					"classid"    "5"  // CS_WEAPONCLASS_SHOTGUN
+					"altname"    "12gauge"
 				}
 				"m4a1"
 				{
-					"itemid"    "22"  // CSW/I_M4A1
+					"itemid"     "22" // CSW/I_M4A1
 					"classid"    "7"  // CS_WEAPONCLASS_RIFLE
 				}
 				"tmp"
 				{
-					"itemid"    "23"  // CSW/I_TMP
+					"itemid"     "23" // CSW/I_TMP
 					"classid"    "4"  // CS_WEAPONCLASS_SUBMACHINEGUN
+					"altname"    "mp"
 				}
 				"g3sg1"
 				{
-					"itemid"    "24"  // CSW/I_G3SG1
+					"itemid"     "24" // CSW/I_G3SG1
 					"classid"    "8"  // CS_WEAPONCLASS_SNIPERRIFLE
+					"altname"    "d3au1"
 				}
 				"deagle"
 				{
-					"itemid"    "26"  // CSW/I_DEAGLE
+					"itemid"     "26" // CSW/I_DEAGLE
 					"classid"    "2"  // CS_WEAPONCLASS_PISTOL
+					"altname"    "nighthawk"
 				}
 				"sg552"
 				{
-					"itemid"    "27"  // CSW/I_SG552
+					"itemid"     "27" // CSW/I_SG552
 					"classid"    "7"  // CS_WEAPONCLASS_RIFLE
+					"altname"    "krieg552"
 				}
 				"ak47"
 				{
-					"itemid"    "28"  // CSW/I_AK47
+					"itemid"     "28" // CSW/I_AK47
 					"classid"    "7"  // CS_WEAPONCLASS_RIFLE
+					"altname"    "cv47"
 				}
 				"p90"
 				{
-					"itemid"    "30"  // CSW/I_P90
+					"itemid"     "30" // CSW/I_P90
 					"classid"    "4"  // CS_WEAPONCLASS_SUBMACHINEGUN
+					"altname"    "c90"
 				}
-				"fiveseven"
-				{
-					"itemid"    "11"  // CSW/I_FIVESEVEN
-					"classid"    "2"  // CS_WEAPONCLASS_PISTOL
-				}
-			}
 
-			"WeaponAlias"
-			{
-				"grenade"
-				{
-					"itemid"     "4"  // CSW/I_HEGRENADE
-					"classid"    "3"  // CS_WEAPONCLASS_GRENADE
-				}
-				"hegrenade"
-				{
-					"itemid"     "4"  // CSW/I_HEGRENADE
-					"classid"    "3"  // CS_WEAPONCLASS_GRENADE
-				}
-				"c4"
-				{
-					"itemid"     "6"  // CSW/I_C4
-					"classid"    "3"  // CS_WEAPONCLASS_GRENADE
-				}
-				"elite"
-				{
-					"itemid"    "10"  // CSW/I_ELITE
-					"classid"    "2"  // CS_WEAPONCLASS_PISTOL
-				}
-				"glock18"
-				{
-					"itemid"    "17"  // CSW/I_GLOCK18
-					"classid"    "2"  // CS_WEAPONCLASS_PISTOL
-				}
-				"mp5navy"
-				{
-					"itemid"    "19"  // CSW/I_MP5NAVY
-					"classid"    "4"  // CS_WEAPONCLASS_SUBMACHINEGUN
-				}
-				"knife"
-				{
-					"itemid"    "29"  // CSW/I_KNIFE
-					"classid"    "1"  // CS_WEAPONCLASS_KNIFE
-				}
-			}
+				//
+				// Equipment
+				//
 
-			"BuyAlias"
-			{
-				"228compact"
-				{
-					"itemid"     "1"  // CSW/I_P228
-					"classid"    "2"  // CS_WEAPONCLASS_PISTOL
-				}
-				"autoshotgun"
-				 {
-					"itemid"     "5"  // CSW/I_XM1014
-					"classid"    "5"  // CS_WEAPONCLASS_SHOTGUN
-				}
-				"bullpup"
-				{
-					"itemid"     "8"  // CSW/I_AUG
-					"classid"    "7"  // CS_WEAPONCLASS_RIFLE
-				}
-				"sg550"
-				{
-					"itemid"    "13"  // CSW/I_SG550
-					"classid"    "7"  // CS_WEAPONCLASS_RIFLE
-				}
-				"krieg550"
-				{
-					"itemid"    "13"  // CSW/I_SG550
-					"classid"    "7"  // CS_WEAPONCLASS_RIFLE
-				}
-				"defender"
-				{
-					"itemid"    "14"  // CSW/I_GALIL
-					"classid"    "7"  // CS_WEAPONCLASS_RIFLE
-				}
-				"clarion"
-				{
-					"itemid"    "15"  // CSW/I_FAMAS
-					"classid"    "7"  // CS_WEAPONCLASS_RIFLE
-				}
-				"km45"
-				{
-					"itemid"    "16"  // CSW/I_USP
-					"classid"    "2"  // CS_WEAPONCLASS_PISTOL
-				}
-				"9x19mm"
-				{
-					"itemid"    "17"  // CSW/I_GLOCK18
-					"classid"    "2"  // CS_WEAPONCLASS_PISTOL
-				}
-				"magnum"
-				{
-					"itemid"    "18"  // CSW/I_AWP
-					"classid"    "8"  // CS_WEAPONCLASS_SNIPERRIFLE
-				}
-				"smg"
-				{
-					"itemid"    "19"  // CSW/I_MP5NAVY
-					"classid"    "4"  // CS_WEAPONCLASS_SUBMACHINEGUN
-				}
-				"12gauge"
-				 {
-					"itemid"    "21"  // CSW/I_M3
-					"classid"    "5"  // CS_WEAPONCLASS_SHOTGUN
-				}
-				"mp"
-				{
-					"itemid"    "23"  // CSW/I_TMP
-					"classid"    "4"  // CS_WEAPONCLASS_SUBMACHINEGUN
-				}
-				"d3au1"
-				{
-					"itemid"    "24"  // CSW/I_G3SG1
-					"classid"    "8"  // CS_WEAPONCLASS_SNIPERRIFLE
-				}
-				"nighthawk"
-				{
-					"itemid"    "26"  // CSW/I_DEAGLE
-					"classid"    "2"  // CS_WEAPONCLASS_PISTOL
-				}
-				"krieg552"
-				{
-					"itemid"    "27"  // CSW/I_SG552
-					"classid"    "7"  // CS_WEAPONCLASS_RIFLE
-				}
-				"cv47"
-				{
-					"itemid"    "28"  // CSW/I_AK47
-					"classid"    "7"  // CS_WEAPONCLASS_RIFLE
-				}
-				"c90"
-				{
-					"itemid"    "30"  // CSW/I_P90
-					"classid"    "4"  // CS_WEAPONCLASS_SUBMACHINEGUN
-				}
-			}
-
-			"BuyEquipAlias"
-			{
 				"hegren"
 				{
 					"itemid"     "4"  // CSW/I_HEGRENADE
@@ -455,25 +340,20 @@
 					"classid"    "2"   // CS_WEAPONCLASS_PISTOL
 					"classname"  "weapon_shield"
 				}
-			}
 
-			"BuyAmmoAlias"
-			{
+				//
+				// Ammunition
+				//
+
 				"primammo"
 				{
 					"itemid"    "36"  // CSI_PRIAMMO
+					"altname"   "buyammo1"
 				}
 				"secammo"
 				{
 					"itemid"    "37"  // CSI_SECAMMO
-				}
-				"buyammo1"
-				{
-					"itemid"    "36"  // CSI_PRIAMMO
-				}
-				"buyammo2"
-				{
-					"itemid"    "37"  // CSI_SECAMMO
+					"altname"   "buyammo2"
 				}
 			}
 		}

--- a/modules/cstrike/cstrike/CstrikeDatas.h
+++ b/modules/cstrike/cstrike/CstrikeDatas.h
@@ -19,6 +19,7 @@
  */
 #define CSI_NONE                CSW_NONE
 #define CSI_P228                CSW_P228
+#define CSI_GLOCK               CSW_GLOCK // Unused by game
 #define CSI_SCOUT               CSW_SCOUT
 #define CSI_HEGRENADE           CSW_HEGRENADE
 #define CSI_XM1014              CSW_XM1014
@@ -73,6 +74,7 @@
  */
 #define CSW_NONE                        0
 #define CSW_P228						1
+#define CSW_GLOCK						2 // Unused by game
 #define CSW_SCOUT						3
 #define CSW_HEGRENADE					4
 #define CSW_XM1014						5

--- a/modules/cstrike/cstrike/CstrikeHacks.cpp
+++ b/modules/cstrike/cstrike/CstrikeHacks.cpp
@@ -162,7 +162,7 @@ DETOUR_DECL_STATIC1(C_ClientCommand, void, edict_t*, pEdict) // void ClientComma
 
 					UTIL_StringToLower(command, commandLowered, sizeof(commandLowered));
 
-					if (ItemsManager.GetAliasInfosFromBuy(commandLowered, &info))
+					if (ItemsManager.GetAliasInfos(commandLowered, &info))
 					{
 						CurrentItemId = info.itemid;
 					}

--- a/modules/cstrike/cstrike/CstrikeItemsInfos.h
+++ b/modules/cstrike/cstrike/CstrikeItemsInfos.h
@@ -31,11 +31,14 @@ struct AliasInfo
 	{
 		itemid  = CSI_NONE;
 		classid = CS_WEAPONCLASS_NONE;
+		classname = nullptr;
+		alt_alias = nullptr;
 	}
 
 	int itemid;
 	int classid;
 	ke::AString classname;
+	ke::AString alt_alias;
 };
 
 enum class Equipments
@@ -73,8 +76,8 @@ class CsItemInfo : public ITextListener_SMC
 	public:
 
 		bool GetAliasInfos(const char *alias, AliasInfo *info);
-		bool GetAliasInfosFromBuy(const char *alias, AliasInfo *info);
 		bool GetAliasInfosFromName(const char *classname, AliasInfo *info);
+		bool GetAliasFromId(size_t id, ke::AString &name, ke::AString &altname);
 
 		CsWeaponClassType WeaponIdToClass(int id);
 
@@ -84,17 +87,16 @@ class CsItemInfo : public ITextListener_SMC
 
 		typedef StringHashMap<AliasInfo> AliasMap;
 
-		AliasMap     m_CommonAliasesList;
-		AliasMap     m_WeaponAliasesList;
 		AliasMap     m_BuyAliasesList;
+		AliasMap     m_BuyAliasesAltList;
 
 		CsWeaponClassType m_WeaponIdToClass[CSI_MAX_COUNT];
 
 	private: // Config parsing
 
 		int          m_ParseState;
-		AliasMap*    m_List;
 		ke::AString  m_Alias;
+		ke::AString  m_AliasAlt;
 		AliasInfo    m_AliasInfo;
 		bool         m_ListsRetrievedFromConfig;
 		int          m_EquipmentsPrice[static_cast<size_t>(Equipments::Count)];

--- a/modules/cstrike/cstrike/CstrikeNatives.cpp
+++ b/modules/cstrike/cstrike/CstrikeNatives.cpp
@@ -1809,6 +1809,40 @@ static cell AMX_NATIVE_CALL cs_get_item_id(AMX* amx, cell* params)
 	return CSI_NONE;
 }
 
+// native bool:cs_get_item_alias(itemid, name[], name_maxlen, altname[] = "", altname_maxlen = 0); 
+static cell AMX_NATIVE_CALL cs_get_item_alias(AMX* amx, cell* params)
+{
+	if (ItemsManager.HasConfigError())
+	{
+		MF_LogError(amx, AMX_ERR_NATIVE, "Native cs_get_item_alias() is disabled because of corrupted or missing gamedata");
+		return 0;
+	}
+
+	auto itemid = params[1];
+
+	if (itemid == CSI_SHIELDGUN)
+	{
+		itemid = CSI_SHIELD;
+	}
+	else if (itemid == CSI_GLOCK)
+	{
+		itemid = CSI_GLOCK18;
+	}
+	else if (itemid <= CSI_NONE || itemid >= CSI_MAX_COUNT)
+	{
+		MF_LogError(amx, AMX_ERR_NATIVE, "Invalid item id: %d", itemid);
+		return FALSE;
+	}
+
+	ke::AString name, altname;
+	auto result = ItemsManager.GetAliasFromId(itemid, name, altname);
+
+	MF_SetAmxString(amx, params[2], name.chars(), params[3]);
+	MF_SetAmxString(amx, params[4], altname.chars(), params[5]);
+
+	return result ? TRUE : FALSE;
+}
+
 // native bool:cs_get_translated_item_alias(const alias[], itemname[], maxlength);
 static cell AMX_NATIVE_CALL cs_get_translated_item_alias(AMX* amx, cell* params)
 {
@@ -2005,6 +2039,7 @@ AMX_NATIVE_INFO CstrikeNatives[] =
 	{"cs_find_ent_by_class",		cs_find_ent_by_class},
 	{"cs_find_ent_by_owner",        cs_find_ent_by_owner},
 	{"cs_get_item_id",		        cs_get_item_id},
+	{"cs_get_item_alias",			cs_get_item_alias},
 	{"cs_get_translated_item_alias",cs_get_translated_item_alias},
 	{"cs_get_weapon_info",          cs_get_weapon_info},
 	{"cs_get_user_weapon_entity",   cs_get_user_weapon_entity},

--- a/plugins/include/cstrike.inc
+++ b/plugins/include/cstrike.inc
@@ -361,7 +361,7 @@ native cs_set_user_plant(index, plant = 1, showbombicon = 1);
  * @param index         Client index
  * @param team          Team id
  * @param model         Internal model id, if CS_DONTCHANGE the game will choose the model
- 			or if CS_NORESET the game will not update it.
+ *                      or if CS_NORESET the game will not update it.
  * @param send_teaminfo If true, a TeamInfo message will be sent
  *
  * @noreturn
@@ -1059,6 +1059,19 @@ native cs_find_ent_by_owner(start_index, const classname[], owner);
  * @return              Item id (CSI_* constants)
  */
 native any:cs_get_item_id(const name[], &CsWeaponClassType:classid = CS_WEAPONCLASS_NONE);
+
+/**
+ * Returns the alias name associated with an item index.
+ *
+ * @param itemid          Item id (CSI_* constants)
+ * @param name            Buffer to store alias name to
+ * @param name_maxlen     Maximum buffer size
+ * @param altname         Optional buffer to store if available alternative alias name to
+ * @param altname_maxlen  Maximum buffer size
+ *
+ * @return                True if alias is found, false otherwise
+ */
+native bool:cs_get_item_alias(itemid, name[], name_maxlen, altname[] = "", altname_maxlen = 0);
 
 /**
  * Returns an item name associated with a command alias.

--- a/plugins/include/cstrike_const.inc
+++ b/plugins/include/cstrike_const.inc
@@ -21,6 +21,7 @@
  */
 #define CSW_NONE            0
 #define CSW_P228            1
+#define CSW_GLOCK           2  // Unused by game, See CSW_GLOCK18.
 #define CSW_SCOUT           3
 #define CSW_HEGRENADE       4
 #define CSW_XM1014          5
@@ -147,6 +148,7 @@ enum
  */
 #define CSI_NONE                CSW_NONE
 #define CSI_P228                CSW_P228
+#define CSI_GLOCK               CSW_GLOCK  // Unused by game, See CSI_GLOCK18.
 #define CSI_SCOUT               CSW_SCOUT
 #define CSI_HEGRENADE           CSW_HEGRENADE
 #define CSI_XM1014              CSW_XM1014


### PR DESCRIPTION
- Added `cs_get_item_alias `native to lookup an alias (and if it exists its alternative name) associated with an item id.
- Cleaned up alias infos in gamedata file. There is now just one list and to avoid duplicating data, the alternative alias name has been moved into the associated alias. The `WeaponAlias` list has been removed because this is not used by game.
- Internally there is two aliases lists now: the default and the alternatives ones. The later is separated to keep the default list with unique item id.
- `cs_get_item_id` has been improved to make sure that a name is well tested with/out `item_` and `weapon_` prefixes.