### PR TITLE
Remove inline comment support in multilingual INI parser (bug 6476)

### DIFF
--- a/amxmodx/CLang.cpp
+++ b/amxmodx/CLang.cpp
@@ -490,7 +490,7 @@ int CLangMngr::MergeDefinitionFile(const char *file)
 	Data.currentFile = file;
 
 	unsigned int line, col;
-	bool result = textparsers->ParseFile_INI(file, static_cast<ITextListener_INI*>(this), &line, &col);
+	bool result = textparsers->ParseFile_INI(file, static_cast<ITextListener_INI*>(this), &line, &col, false);
 
 	if (!result)
 	{

--- a/amxmodx/CTextParsers.cpp
+++ b/amxmodx/CTextParsers.cpp
@@ -778,7 +778,7 @@ failed:
 * INI parser
 */
 
-bool TextParsers::ParseFile_INI(const char *file, ITextListener_INI *ini_listener, unsigned int *line, unsigned int *col)
+bool TextParsers::ParseFile_INI(const char *file, ITextListener_INI *ini_listener, unsigned int *line, unsigned int *col, bool inline_comment)
 {
 	FILE *fp = fopen(file, "rt");
 	unsigned int curline = 0;
@@ -842,46 +842,49 @@ bool TextParsers::ParseFile_INI(const char *file, ITextListener_INI *ini_listene
 			continue;
 		}
 
-		/* Now search for comment characters */
-		in_quote = false;
-		save_ptr = ptr;
-		for (size_t i = 0; i<len; i++, ptr++)
+		if (inline_comment)
 		{
-			if (!in_quote)
+			/* Now search for comment characters */
+			in_quote = false;
+			save_ptr = ptr;
+			for (size_t i = 0; i<len; i++, ptr++)
 			{
-				switch (*ptr)
+				if (!in_quote)
 				{
-					case '"':
+					switch (*ptr)
 					{
-						in_quote = true;
-						break;
-					}
-					case ';':
-					{
-						/* Stop the loop */
-						len = i;
+						case '"':
+						{
+							in_quote = true;
+							break;
+						}
+						case ';':
+						{
+							/* Stop the loop */
+							len = i;
 
-						/* Terminate the string here */
-						*ptr = '\0';
-						break;
+							/* Terminate the string here */
+							*ptr = '\0';
+							break;
+						}
+					}
+				}
+				else 
+				{
+					if (*ptr == '"')
+					{
+						in_quote = false;
 					}
 				}
 			}
-			else 
+
+			if (!len)
 			{
-				if (*ptr == '"')
-				{
-					in_quote = false;
-				}
+				continue;
 			}
-		}
 
-		if (!len)
-		{
-			continue;
+			ptr = save_ptr;
 		}
-
-		ptr = save_ptr;
 
 		/* Lastly, strip ending whitespace off */
 		for (size_t i = len - 1; i<len; i--)

--- a/amxmodx/CTextParsers.h
+++ b/amxmodx/CTextParsers.h
@@ -52,7 +52,8 @@ public:
 	bool ParseFile_INI(const char *file,
 		ITextListener_INI *ini_listener,
 		unsigned int *line,
-		unsigned int *col);
+		unsigned int *col,
+		bool inline_comment);
 
 	SMCError ParseFile_SMC(const char *file,
 		ITextListener_SMC *smc_listener,

--- a/public/ITextParsers.h
+++ b/public/ITextParsers.h
@@ -351,12 +351,14 @@
 		 * @param ini_listener	Event handler for reading file.
 		 * @param line			If non-NULL, will contain last line parsed (0 if file could not be opened).
 		 * @param col			If non-NULL, will contain last column parsed (undefined if file could not be opened).
+		 * @param inline_comment Whether inline comment is allowed.
 		 * @return				True if parsing succeeded, false if file couldn't be opened or there was a syntax error.
 		 */
 		virtual bool ParseFile_INI(const char *file,
 									ITextListener_INI *ini_listener,
 									unsigned int *line,
-									unsigned int *col) =0;
+									unsigned int *col,
+									bool inline_comment = true) =0;
 
 		/**
 		 * @brief Parses an SMC-format text file.


### PR DESCRIPTION
Multilingual system uses INI parser since #260. Originally, only comment on a new line was supported.

If you do for example `KEY = ; VALUE`, the current parser will throw an Invalid multi-lingual line error.
It's possible to use `KEY = "; VALUE"`, but changing an old behavior for existing plugin is not welcomed.

For backward compatibility patch removes inline comment support for ML files only. Comment on new line is still working.