### PR TITLE
Add a param to register_*cmd() and get_*cmd() to indiquate info is a multilingual key + modify plugin

### DIFF
--- a/amxmodx/CCmd.cpp
+++ b/amxmodx/CCmd.cpp
@@ -30,7 +30,7 @@ CmdMngr::CmdMngr()
 }
 
 CmdMngr::Command::Command(CPluginMngr::CPlugin* pplugin, const char* pcmd, const char* pinfo, int pflags, 
-							int pfunc, bool pviewable, CmdMngr* pparent) : commandline(pcmd), info(pinfo)
+							int pfunc, bool pviewable, bool pinfo_ml, CmdMngr* pparent) : commandline(pcmd), info(pinfo)
 {
 	char szCmd[64], szArg[64];
 	*szCmd = 0; *szArg = 0;
@@ -43,6 +43,7 @@ CmdMngr::Command::Command(CPluginMngr::CPlugin* pplugin, const char* pcmd, const
 	prefix = 0;
 	function = pfunc;
 	listable = pviewable;
+	info_ml = pinfo_ml;
 	parent = pparent;
 	id = --uniqueid;
 }
@@ -52,9 +53,9 @@ CmdMngr::Command::~Command()
 	++uniqueid;
 }
 
-CmdMngr::Command* CmdMngr::registerCommand(CPluginMngr::CPlugin* plugin, int func, char* cmd, char* info, int level, bool listable)
+CmdMngr::Command* CmdMngr::registerCommand(CPluginMngr::CPlugin* plugin, int func, const char* cmd, const char* info, int level, bool listable, bool info_ml)
 {
-	Command* b = new Command(plugin, cmd, info, level, func, listable, this);
+	Command* b = new Command(plugin, cmd, info, level, func, listable, info_ml, this);
 	if (b == 0) return 0;
 	setCmdLink(&sortedlists[0], b);
 	

--- a/amxmodx/CCmd.h
+++ b/amxmodx/CCmd.h
@@ -38,6 +38,7 @@ public:
 		ke::AString commandline;
 		ke::AString info;
 		
+		bool info_ml;
 		bool listable;
 		int function;
 		int flags;
@@ -46,7 +47,7 @@ public:
 		int prefix;
 		static int uniqueid;
 		
-		Command(CPluginMngr::CPlugin* pplugin, const char* pcmd, const char* pinfo, int pflags, int pfunc, bool pviewable, CmdMngr* pparent);
+		Command(CPluginMngr::CPlugin* pplugin, const char* pcmd, const char* pinfo, int pflags, int pfunc, bool pviewable, bool pinfo_ml, CmdMngr* pparent);
 		~Command();
 	public:
 		inline const char* getCommand() { return command.chars(); }
@@ -59,6 +60,7 @@ public:
 		inline bool gotAccess(int f) const { return (!flags || ((flags & f) != 0)); }
 		inline CPluginMngr::CPlugin* getPlugin() { return plugin; }
 		inline bool isViewable() const { return listable; }
+		inline bool isInfoML() const { return info_ml; }
 		inline int getFlags() const { return flags; }
 		inline long int getId() const { return (long int)id; }
 		
@@ -106,7 +108,7 @@ public:
 
 	void registerPrefix(const char* nn);
 	
-	Command* registerCommand(CPluginMngr::CPlugin* plugin, int func, char* cmd, char* info, int level, bool listable);
+	Command* registerCommand(CPluginMngr::CPlugin* plugin, int func, const char* cmd, const char* info, int level, bool listable, bool info_ml);
 	Command* getCmd(long int id, int type, int access);
 	int getCmdNum(int type, int access);
 	

--- a/plugins/adminhelp.sma
+++ b/plugins/adminhelp.sma
@@ -78,7 +78,7 @@ public cmdHelp(id, level, cid)
 
 	console_print(id, "^n----- %L -----", id, "HELP_COMS")
 	
-	new info[128], cmd[32], eflags
+	new info[128], cmd[32], eflags, bool:is_info_ml
 	new end = start + lHelpAmount
 
 	if (end > clcmdsnum)
@@ -88,7 +88,13 @@ public cmdHelp(id, level, cid)
 
 	for (new i = start; i < end; i++)
 	{
-		get_concmd(i, cmd, charsmax(cmd), eflags, info, charsmax(info), flags, id)
+		get_concmd(i, cmd, charsmax(cmd), eflags, info, charsmax(info), flags, id, is_info_ml)
+
+		if (is_info_ml)
+		{
+			LookupLangKey(info, charsmax(info), info, id);
+		}
+
 		console_print(id, "%3d: %s %s", i + 1, cmd, info)
 	}
 	

--- a/plugins/include/amxmisc.inc
+++ b/plugins/include/amxmisc.inc
@@ -78,8 +78,14 @@ stock cmd_access(id, level, cid, num, bool:accesssilent = false)
 	}
 	if (read_argc() < num)
 	{
-		new hcmd[32], hinfo[128], hflag;
-		get_concmd(cid, hcmd, charsmax(hcmd), hflag, hinfo, charsmax(hinfo), level);
+		new hcmd[32], hinfo[128], hflag, bool:info_ml;
+		get_concmd(cid, hcmd, charsmax(hcmd), hflag, hinfo, charsmax(hinfo), level, info_ml);
+
+		if (info_ml)
+		{
+			LookupLangKey(hinfo, charsmax(hinfo), hinfo, id);
+		}
+
 		console_print(id, "%L:  %s %s", id, "USAGE", hcmd, hinfo);
 		return 0;
 	}

--- a/plugins/include/amxmodx.inc
+++ b/plugins/include/amxmodx.inc
@@ -1749,12 +1749,13 @@ native remove_user_flags(index, flags = -1, id = 0);
  * @param info          Command description
  * @param FlagManager   0 opts out of flag manager, 1 opts in, -1 selects
  *                      automatically
+ * @param info_ml       If true, the parameter "info" will be looked up as multilingual key
  *
  * @return              Command id, 0 on failure
  * @error               If an invalid callback function is specified, an error
  *                      will be thrown.
  */
-native register_clcmd(const client_cmd[], const function[], flags = -1, const info[] = "", FlagManager = -1);
+native register_clcmd(const client_cmd[], const function[], flags = -1, const info[] = "", FlagManager = -1, bool:info_ml = false);
 
 /**
  * Registers a callback to be called when the client or server executes a
@@ -1774,12 +1775,13 @@ native register_clcmd(const client_cmd[], const function[], flags = -1, const in
  * @param info          Command description
  * @param FlagManager   0 opts out of flag manager, 1 opts in, -1 selects
  *                      automatically
+ * @param info_ml       If true, the parameter "info" will be looked up as multilingual key
  *
  * @return              Command id, 0 on failure
  * @error               If an invalid callback function is specified, an error
  *                      will be thrown.
  */
-native register_concmd(const cmd[], const function[], flags = -1, const info[] = "", FlagManager = -1);
+native register_concmd(const cmd[], const function[], flags = -1, const info[] = "", FlagManager = -1, bool:info_ml = false);
 
 /**
  * Registers a callback to be called when the server executes a command from the
@@ -1792,12 +1794,13 @@ native register_concmd(const cmd[], const function[], flags = -1, const info[] =
  * @param function      Callback function
  * @param flags         Admin privilege flags required
  * @param info          Command description
+ * @param info_ml       If true, the parameter "info" will be looked up as multilingual key
  *
  * @return              Command id, 0 on failure
  * @error               If an invalid callback function is specified, an error
  *                      will be thrown.
  */
-native register_srvcmd(const server_cmd[], const function[], flags = -1, const info[] = "");
+native register_srvcmd(const server_cmd[], const function[], flags = -1, const info[] = "", bool:info_ml = false);
 
 /**
  * Retrieves information about a client command.
@@ -1813,10 +1816,11 @@ native register_srvcmd(const server_cmd[], const function[], flags = -1, const i
  * @param len2      Maximum description buffer size
  * @param flag      Only considers commands that can be accessed with
  *                  the specified privilege flags
+ * @param info_ml   Variable to store whether the parameter "info" is a multilingual key
  *
  * @return          1 on success, 0 if command was not found
  */
-native get_clcmd(index, command[], len1, &flags, info[], len2, flag);
+native get_clcmd(index, command[], len1, &flags, info[], len2, flag, &bool:info_ml = false);
 
 /**
  * Returns number of registered client commands.
@@ -1845,10 +1849,11 @@ native get_clcmdsnum(flag);
  * @param len2      Maximum description buffer size
  * @param flag      Only considers commands that can be accessed with
  *                  the specified privilege flags
+ * @param info_ml   Variable to store whether the parameter "info" is a multilingual key
  *
  * @return          1 on success, 0 if command was not found
  */
-native get_srvcmd(index, server_cmd[], len1, &flags, info[], len2, flag);
+native get_srvcmd(index, server_cmd[], len1, &flags, info[], len2, flag, &bool:info_ml = false);
 
 /**
  * Returns number of registered server commands.
@@ -1880,10 +1885,11 @@ native get_srvcmdsnum(flag);
  * @param id        If set to 0 only server commands will be considered,
  *                  positive will only consider client commands, otherwise
  *                  all console commands will be considered
+ * @param info_ml   Variable to store whether the parameter "info" is a multilingual key
  *
  * @return          1 on success, 0 if command was not found
  */
-native get_concmd(index, cmd[], len1, &flags, info[], len2, flag, id = -1);
+native get_concmd(index, cmd[], len1, &flags, info[], len2, flag, id = -1, &bool:info_ml = false);
 
 /**
  * Returns the parent plugin id of a console command.


### PR DESCRIPTION
Small QoL. Motivation is to encourage the translation of plugin commands and to help admin/user to read such infos in their defined language. There is no reason to not translate them to the end-users.

Changes have been reflected on `cmd_access()` function and `amx_help` command. Not sure if I've forgotten others usage?