### PR TITLE
Add fmt() native to format and return a string inline 

### DIFF
--- a/amxmodx/string.cpp
+++ b/amxmodx/string.cpp
@@ -1409,6 +1409,20 @@ static cell AMX_NATIVE_CALL vformat(AMX *amx, cell *params)
 }
 
 
+#define MAX_FMT_LENGTH 256
+
+// native [MAX_FMT_LENGTH] fmt(const fmt[], any:...)
+static cell AMX_NATIVE_CALL fmt(AMX *amx, cell *params)
+{
+	int length;
+	const char *string = format_amxstring(amx, params, 1, length);
+
+	size_t num_params = *params / sizeof(cell);
+
+	set_amxstring_utf8_char(amx, params[num_params + 1], string, length, MAX_FMT_LENGTH - 1);
+
+	return 1;
+};
 
 
 AMX_NATIVE_INFO string_Natives[] =
@@ -1420,6 +1434,7 @@ AMX_NATIVE_INFO string_Natives[] =
 	{"copyc",			copyc},
 	{"equal",			equal},
 	{"equali",			equali},
+	{"fmt",				fmt},
 	{"format",			format},
 	{"formatex",		formatex},
 	{"format_args",		format_args},

--- a/plugins/include/string.inc
+++ b/plugins/include/string.inc
@@ -24,7 +24,12 @@
  * 			in the length.  This means that this is valid: 
  * 			copy(string, charsmax(string), ...)
  */
- 
+
+/**
+ * Buffer size used by fmt().
+ */
+#define MAX_FMT_LENGTH 256
+
 /**
  * Calculates the length of a string.
  *
@@ -166,6 +171,23 @@ native format(output[], len, const format[], any:...);
  * @return				Number of cells written.
  */
 native formatex(output[], len, const format[], any:...);
+
+/**
+ * Formats and returns a string according to the AMX Mod X format rules
+ * (see documentation).
+ *
+ * @note Example: menu_additem(menu, fmt("My first %s", "item")).
+ * @note This should only be used for simple inline formatting like in the above example.
+ *       Avoid using this function to store strings into variables as an additional
+ *       copying step is required.
+ * @note The buffer size is defined by MAX_FMT_LENGTH.
+ *
+ * @param format        Formatting rules.
+ * @param ...           Variable number of format parameters.
+ *
+ * @return              Formatted string
+ */
+native [MAX_FMT_LENGTH]fmt(const format[], any:...);
 
 /**
  * Formats a string according to the AMX Mod X format rules (see documentation).


### PR DESCRIPTION
Motivation is we have a bunch of natives, like new menu API, which is not really multilingual friendly, Instead of creating alternative native or new whole API with formatting syntax, we introduce `fmt()` native which can format and return a string inline. 

That would encourage the use of multilingual where it's usually things are not translated and would improve slightly code readability/usability. 

This is not in any ways a replacement for `format/ex` and should be used only in native for fast and unique formatting. The buffer is set to 256 for sanity, and it should be largely enough for most of the situations.
