### PR TITLE
Fix issue where native functions returning an array would not compile

### DIFF
--- a/compiler/libpc300/sc.h
+++ b/compiler/libpc300/sc.h
@@ -127,7 +127,7 @@ typedef struct s_symbol {
   cell codeaddr;        /* address (in the code segment) where the symbol declaration starts */
   char vclass;          /* sLOCAL if "addr" refers to a local symbol */
   char ident;           /* see below for possible values */
-  char usage;           /* see below for possible values */
+  short usage;          /* see below for possible values */
   char flags;          /* see below for possible values */
   int compound;         /* compound level (braces nesting level) */
   int tag;              /* tagname id */
@@ -217,6 +217,7 @@ typedef struct s_symbol {
 #define uSTOCK    0x40
 #define uENUMFIELD 0x40
 #define uMISSING  0x80
+#define uVISITED  0x100 /* temporary flag, to mark fields as "visited" in recursive loops */
 /* uRETNONE is not stored in the "usage" field of a symbol. It is
  * used during parsing a function, to detect a mix of "return;" and
  * "return value;" in a few special cases.

--- a/compiler/libpc300/sc1.c
+++ b/compiler/libpc300/sc1.c
@@ -3244,7 +3244,7 @@ static void funcstub(int native)
   /* attach the array to the function symbol */
   if (numdim>0) {
     assert(sym!=NULL);
-    sub=addvariable(symbolname,0,iARRAY,sGLOBAL,tag,dim,numdim,idxtag);
+    sub=addvariable(symbolname,0,iREFARRAY,sGLOBAL,tag,dim,numdim,idxtag);
     sub->parent=sym;
   } /* if */
 


### PR DESCRIPTION
Fix from Pawn upstream where it fails to compile in some situations: https://github.com/compuphase/pawn/commit/f134bda57493cbbb45200e8e5711e1b221946829

Slightly changed by adding `root=origRoot` so `delete_symbol` knows that we're passing `&glbtab` since `RemoveFromHashTable` is called as well there.