### PR TITLE
Add extra parameters to cs_get_user_weapon native

### DIFF
--- a/modules/cstrike/cstrike/CstrikeNatives.cpp
+++ b/modules/cstrike/cstrike/CstrikeNatives.cpp
@@ -1946,11 +1946,14 @@ static cell AMX_NATIVE_CALL cs_get_user_weapon_entity(AMX *amx, cell *params)
 	return (weaponEntIndex != -1) ? weaponEntIndex : 0;
 }
 
-// native cs_get_user_weapon(playerIndex);
+// native cs_get_user_weapon(playerIndex, &clip = 0, &ammo = 0);
 static cell AMX_NATIVE_CALL cs_get_user_weapon(AMX *amx, cell *params)
 {
 	GET_OFFSET("CBasePlayer", m_pActiveItem);
+	GET_OFFSET("CBasePlayer", m_rgAmmo);
 	GET_OFFSET("CBasePlayerItem", m_iId);
+	GET_OFFSET("CBasePlayerWeapon", m_iClip);
+	GET_OFFSET("CBasePlayerWeapon", m_iPrimaryAmmoType);
 
 	int playerIndex = params[1];
 
@@ -1961,6 +1964,21 @@ static cell AMX_NATIVE_CALL cs_get_user_weapon(AMX *amx, cell *params)
 
 	if (!FNullEnt(pWeapon))
 	{
+		cell *cpTemp = MF_GetAmxAddr(amx, params[2]);
+		*cpTemp = get_pdata<int>(pWeapon, m_iClip);
+
+		cpTemp = MF_GetAmxAddr(amx, params[3]);
+		int iAmmoType = get_pdata<int>(pWeapon, m_iPrimaryAmmoType);
+
+		if(iAmmoType <= 0)
+		{
+			*cpTemp = 0;
+		}
+		else
+		{
+			*cpTemp = get_pdata<int>(pPlayer, m_rgAmmo, iAmmoType);
+		}
+
 		return get_pdata<int>(pWeapon, m_iId);
 	}
 

--- a/plugins/include/cstrike.inc
+++ b/plugins/include/cstrike.inc
@@ -1117,13 +1117,15 @@ native cs_get_user_weapon_entity(playerIndex);
  * @note More reliable than get_user_weapon.
  *
  * @param playerIndex   Player index
+ * @param clip          Optional variable to store clip ammo to
+ * @param ammo          Optional variable to store backpack ammo to
  *
  * @return              Weapon index on success or 0 if there is no active weapon
  * @error               If the client index is not within the range of 1 to
  *                      maxClients, or the client is not connected, an error will be
  *                      thrown.
  */
-native cs_get_user_weapon(playerIndex);
+native cs_get_user_weapon(playerIndex, &clip = 0, &ammo = 0);
 
 /**
  * Returns a weapon class id associated with a weapon id.


### PR DESCRIPTION
Related to #330.

```get_user_weapon``` native has optional 2 parameters (clip & ammo), so I think ```cs_get_user_weapon``` native should have them too.