### PR TITLE
Fix typo in find_ent_in_sphere()

### DIFF
--- a/modules/engine/entity.cpp
+++ b/modules/engine/entity.cpp
@@ -1354,7 +1354,7 @@ static cell AMX_NATIVE_CALL find_ent_in_sphere(AMX *amx, cell *params)
 
 	if (!FNullEnt(pEnt = FIND_ENTITY_IN_SPHERE(pEnt, origin, radius)))
 	{
-		return TypeConversion.cbase_to_id(pEnt);
+		return TypeConversion.edict_to_id(pEnt);
 	}
 
 	return 0;


### PR DESCRIPTION
Reported by Sylvert0. Related to #346.

Not sure why compiler ignored this.