### PR TITLE
Fix issues with some cstrike natives

### DIFF
--- a/modules/cstrike/cstrike/CstrikeItemsInfos.cpp
+++ b/modules/cstrike/cstrike/CstrikeItemsInfos.cpp
@@ -15,7 +15,7 @@
 #include "CstrikeHacks.h"
 
 CsItemInfo ItemsManager;
-char WeaponNameList[MAX_WEAPONS][64];
+ItemInfo WeaponsList[MAX_WEAPONS];
 
 #define PSTATE_ALIASES_TYPE       0
 #define PSTATE_ALIASES_ALIAS      1
@@ -202,7 +202,7 @@ bool CsItemInfo::GetAliasInfosFromName(const char *name, AliasInfo *info)
 
 	for (size_t id = 0; id < ARRAYSIZE(WeaponNameList); ++id)
 	{
-		const char *weapon = WeaponNameList[id];
+		const char *weapon = WeaponsList[id].name.chars();
 
 		if (weapon[prefix_weapon_length] == '_' && !strncmp(weapon, prefix_weapon, prefix_weapon_length))
 		{

--- a/modules/cstrike/cstrike/CstrikeItemsInfos.cpp
+++ b/modules/cstrike/cstrike/CstrikeItemsInfos.cpp
@@ -200,7 +200,7 @@ bool CsItemInfo::GetAliasInfosFromName(const char *name, AliasInfo *info)
 		name += prefix_item_length + 1;
 	}
 
-	for (size_t id = 0; id < ARRAYSIZE(WeaponNameList); ++id)
+	for (size_t id = 0; id < ARRAYSIZE(WeaponsList); ++id)
 	{
 		const char *weapon = WeaponsList[id].name.chars();
 

--- a/modules/cstrike/cstrike/CstrikeItemsInfos.h
+++ b/modules/cstrike/cstrike/CstrikeItemsInfos.h
@@ -20,6 +20,37 @@
 #include <amtl/am-string.h>
 #include <sm_stringhashmap.h>
 
+struct ItemInfo
+{
+	ItemInfo() : name("Empty"), ammoIndex1(-1), maxAmmo1(0), ammoIndex2(-1), maxAmmo2(0), slot(0), position(0), id(0), flags(0)
+	{}
+
+	ItemInfo &operator = (ItemInfo &other)
+	{
+		name       = other.name;
+		ammoIndex1 = other.ammoIndex1;
+		maxAmmo1   = other.maxAmmo1;
+		ammoIndex2 = other.ammoIndex2;
+		maxAmmo2   = other.maxAmmo2;
+		slot       = other.slot;
+		position   = other.position;
+		id         = other.id;
+		flags      = other.flags;
+
+		return *this;
+	}
+
+	ke::AString name;
+	int         ammoIndex1;
+	int         maxAmmo1;
+	int         ammoIndex2;
+	int         maxAmmo2;
+	int         slot;
+	int         position;
+	int         id;
+	int         flags;
+};
+
 struct AliasInfo
 {
 	AliasInfo()
@@ -102,7 +133,7 @@ class CsItemInfo : public ITextListener_SMC
 		int          m_EquipmentsPrice[static_cast<size_t>(Equipments::Count)];
 };
 
-extern char WeaponNameList[MAX_WEAPONS][64];
+extern ItemInfo WeaponsList[MAX_WEAPONS];
 extern CsItemInfo ItemsManager;
 
 #endif // _CSTRIKE_WEAPONS_INFOS_H_

--- a/modules/cstrike/cstrike/CstrikeNatives.cpp
+++ b/modules/cstrike/cstrike/CstrikeNatives.cpp
@@ -1889,40 +1889,41 @@ static cell AMX_NATIVE_CALL cs_get_weapon_info(AMX* amx, cell* params)
 	}
 
 	int weapon_id = params[1];
+	int info_type = params[2];
 
-	if (weapon_id <= CSW_NONE || weapon_id == CSW_C4 || weapon_id == CSW_KNIFE || weapon_id > CSW_LAST_WEAPON)
+	WeaponInfoStruct *info;
+
+	if (weapon_id <= CSW_NONE || weapon_id > CSW_LAST_WEAPON || !(info = GetWeaponInfo(weapon_id)))
 	{
 		MF_LogError(amx, AMX_ERR_NATIVE, "Invalid weapon id: %d", weapon_id);
 		return 0;
 	}
 
-	int info_type = params[2];
-
 	switch (info_type)
 	{
 		case CS_WEAPONINFO_COST:
 		{
-			return GetWeaponInfo(weapon_id)->cost;
+			return info->cost;
 		}
 		case CS_WEAPONINFO_CLIP_COST:
 		{
-			return GetWeaponInfo(weapon_id)->clipCost;
+			return info->clipCost;
 		}
 		case CS_WEAPONINFO_BUY_CLIP_SIZE:
 		{
-			return GetWeaponInfo(weapon_id)->buyClipSize;
+			return info->buyClipSize;
 		}
 		case CS_WEAPONINFO_GUN_CLIP_SIZE:
 		{
-			return GetWeaponInfo(weapon_id)->gunClipSize;
+			return info->gunClipSize;
 		}
 		case CS_WEAPONINFO_MAX_ROUNDS:
 		{
-			return GetWeaponInfo(weapon_id)->maxRounds;
+			return info->maxRounds;
 		}
 		case CS_WEAPONINFO_AMMO_TYPE:
 		{
-			return GetWeaponInfo(weapon_id)->ammoType;
+			return info->ammoType;
 		}
 	}
 

--- a/modules/cstrike/cstrike/CstrikeNatives.cpp
+++ b/modules/cstrike/cstrike/CstrikeNatives.cpp
@@ -115,7 +115,7 @@ static cell AMX_NATIVE_CALL cs_get_hostage_id(AMX *amx, cell *params)
 	int index = params[1];
 
 	CHECK_NONPLAYER(index);
-	edict_t *pHostage = INDEXENT(index);
+	edict_t *pHostage = TypeConversion.id_to_edict(index);
 
 	CHECK_HOSTAGE(pHostage);
 
@@ -131,7 +131,7 @@ static cell AMX_NATIVE_CALL cs_get_weapon_silenced(AMX *amx, cell *params)
 	int index = params[1];
 
 	CHECK_NONPLAYER(index);
-	edict_t *pWeapon = INDEXENT(index);
+	edict_t *pWeapon = TypeConversion.id_to_edict(index);
 
 	switch (get_pdata<int>(pWeapon, m_iId))
 	{
@@ -162,7 +162,7 @@ static cell AMX_NATIVE_CALL cs_get_weapon_id(AMX *amx, cell *params)
 	int index = params[1];
 
 	CHECK_NONPLAYER(index);
-	edict_t *pWeapon = INDEXENT(index);
+	edict_t *pWeapon = TypeConversion.id_to_edict(index);
 
 	return get_pdata<int>(pWeapon, m_iId);
 }
@@ -177,7 +177,7 @@ static cell AMX_NATIVE_CALL cs_set_weapon_silenced(AMX *amx, cell *params)
 	int silence  = params[2];
 
 	CHECK_NONPLAYER(index);
-	edict_t *pWeapon = INDEXENT(index);
+	edict_t *pWeapon = TypeConversion.id_to_edict(index);
 
 	int draw_animation = 1;
 
@@ -231,7 +231,7 @@ static cell AMX_NATIVE_CALL cs_set_weapon_silenced(AMX *amx, cell *params)
 
 		if (draw_animation > 0 && UTIL_IsPlayer(pPlayer))
 		{
-			int currentWeapon = *static_cast<int *>(MF_PlayerPropAddr(ENTINDEX(pPlayer), Player_CurrentWeapon));
+			int currentWeapon = *static_cast<int *>(MF_PlayerPropAddr(TypeConversion.edict_to_id(pPlayer), Player_CurrentWeapon));
 
 			if (currentWeapon != weaponType)
 			{
@@ -299,7 +299,7 @@ static cell AMX_NATIVE_CALL cs_get_weapon_burstmode(AMX *amx, cell *params)
 	int index = params[1];
 
 	CHECK_NONPLAYER(index);
-	edict_t *pWeapon = INDEXENT(index);
+	edict_t *pWeapon = TypeConversion.id_to_edict(index);
 
 	int flag = 0;
 
@@ -327,7 +327,7 @@ static cell AMX_NATIVE_CALL cs_set_weapon_burstmode(AMX *amx, cell *params)
 	int burst = params[2];
 
 	CHECK_NONPLAYER(index);
-	edict_t *pWeapon = INDEXENT(index);
+	edict_t *pWeapon = TypeConversion.id_to_edict(index);
 
 	int weaponState = get_pdata<int>(pWeapon, m_iWeaponState);
 	int weaponNewState = weaponState;
@@ -908,7 +908,7 @@ static cell AMX_NATIVE_CALL cs_get_hostage_follow(AMX *amx, cell *params)
 	int index = params[1];
 
 	CHECK_NONPLAYER(index);
-	edict_t* pHostage = INDEXENT(index);
+	edict_t* pHostage = TypeConversion.id_to_edict(index);
 
 	CHECK_HOSTAGE(pHostage);
 
@@ -932,7 +932,7 @@ static cell AMX_NATIVE_CALL cs_get_hostage_follow(AMX *amx, cell *params)
 		pEntity = get_pdata<EHANDLE>(pHostage, m_hTargetEnt).Get();
 	}
 
-	return pEntity ? ENTINDEX(pEntity) : 0;
+	return pEntity ? TypeConversion.edict_to_id(pEntity) : 0;
 }
 
 // native cs_set_hostage_foll(index, followedindex = 0);
@@ -945,7 +945,7 @@ static cell AMX_NATIVE_CALL cs_set_hostage_follow(AMX *amx, cell *params)
 	int target = params[2];
 
 	CHECK_NONPLAYER(index);
-	edict_t* pHostage = INDEXENT(index);
+	edict_t* pHostage = TypeConversion.id_to_edict(index);
 
 	if (target != 0)
 	{
@@ -996,7 +996,7 @@ static cell AMX_NATIVE_CALL cs_get_weapon_ammo(AMX *amx, cell *params)
 	int index = params[1];
 
 	CHECK_NONPLAYER(index);
-	edict_t *pWeapon = INDEXENT(index);
+	edict_t *pWeapon = TypeConversion.id_to_edict(index);
 
 	return get_pdata<int>(pWeapon, m_iClip);
 }
@@ -1010,7 +1010,7 @@ static cell AMX_NATIVE_CALL cs_set_weapon_ammo(AMX *amx, cell *params)
 	int ammo  = params[2];
 
 	CHECK_NONPLAYER(index);
-	edict_t *pWeapon = INDEXENT(index);
+	edict_t *pWeapon = TypeConversion.id_to_edict(index);
 
 	set_pdata<int>(pWeapon, m_iClip, ammo);
 
@@ -1185,7 +1185,7 @@ static cell AMX_NATIVE_CALL cs_get_armoury_type(AMX *amx, cell *params)
 	int index = params[1];
 
 	CHECK_NONPLAYER(index);
-	edict_t *pArmoury = INDEXENT(index);
+	edict_t *pArmoury = TypeConversion.id_to_edict(index);
 
 	if (strcmp(STRING(pArmoury->v.classname), "armoury_entity"))
 	{
@@ -1243,7 +1243,7 @@ static cell AMX_NATIVE_CALL cs_set_armoury_type(AMX *amx, cell *params)
 	int type  = params[2];
 
 	CHECK_NONPLAYER(index);
-	edict_t *pArmoury = INDEXENT(index);
+	edict_t *pArmoury = TypeConversion.id_to_edict(index);
 
 	if (strcmp(STRING(pArmoury->v.classname), "armoury_entity"))
 	{
@@ -1509,7 +1509,7 @@ static cell AMX_NATIVE_CALL cs_get_hostage_lastuse(AMX *amx, cell *params)
 	int index = params[1];
 
 	CHECK_NONPLAYER(index);
-	edict_t *pHostage = INDEXENT(index);
+	edict_t *pHostage = TypeConversion.id_to_edict(index);
 
 	CHECK_HOSTAGE(pHostage);
 
@@ -1535,7 +1535,7 @@ static cell AMX_NATIVE_CALL cs_set_hostage_lastuse(AMX *amx, cell *params)
 	int index = params[1];
 
 	CHECK_NONPLAYER(index);
-	edict_t *pHostage = INDEXENT(index);
+	edict_t *pHostage = TypeConversion.id_to_edict(index);
 
 	CHECK_HOSTAGE(pHostage);
  
@@ -1562,7 +1562,7 @@ static cell AMX_NATIVE_CALL cs_get_hostage_nextuse(AMX* amx, cell* params)
 	int index = params[1];
 
 	CHECK_NONPLAYER(index);
-	edict_t *pHostage = INDEXENT(index);
+	edict_t *pHostage = TypeConversion.id_to_edict(index);
 
 	CHECK_HOSTAGE(pHostage);
 
@@ -1577,7 +1577,7 @@ static cell AMX_NATIVE_CALL cs_set_hostage_nextuse(AMX* amx, cell* params)
 	int index = params[1];
 
 	CHECK_NONPLAYER(index);
-	edict_t *pHostage = INDEXENT(index);
+	edict_t *pHostage = TypeConversion.id_to_edict(index);
 
 	CHECK_HOSTAGE(pHostage);
 
@@ -1594,7 +1594,7 @@ static cell AMX_NATIVE_CALL cs_get_c4_explode_time(AMX* amx, cell* params)
 	int index = params[1];
 
 	CHECK_NONPLAYER(index);
-	edict_t *pC4 = INDEXENT(index);
+	edict_t *pC4 = TypeConversion.id_to_edict(index);
 
 	if (strcmp(STRING(pC4->v.classname), "grenade") != 0)
 	{
@@ -1613,7 +1613,7 @@ static cell AMX_NATIVE_CALL cs_set_c4_explode_time(AMX* amx, cell* params)
 	int index = params[1];
 
 	CHECK_NONPLAYER(index);
-	edict_t *pC4 = INDEXENT(index);
+	edict_t *pC4 = TypeConversion.id_to_edict(index);
 
 	if (strcmp(STRING(pC4->v.classname), "grenade") != 0)
 	{
@@ -1634,7 +1634,7 @@ static cell AMX_NATIVE_CALL cs_get_c4_defusing(AMX* amx, cell* params)
 	int index = params[1];
 
 	CHECK_NONPLAYER(index);
-	edict_t *pC4 = INDEXENT(index);
+	edict_t *pC4 = TypeConversion.id_to_edict(index);
 
 	if (strcmp(STRING(pC4->v.classname), "grenade") != 0)
 	{
@@ -1653,7 +1653,7 @@ static cell AMX_NATIVE_CALL cs_set_c4_defusing(AMX* amx, cell* params)
 	int index = params[1];
 
 	CHECK_NONPLAYER(index);
-	edict_t *pC4 = INDEXENT(index);
+	edict_t *pC4 = TypeConversion.id_to_edict(index);
 
 	if (strcmp(STRING(pC4->v.classname), "grenade") != 0)
 	{
@@ -1682,7 +1682,7 @@ static cell AMX_NATIVE_CALL cs_create_entity(AMX* amx, cell* params)
 
 	if (!FNullEnt(pEnt))
 	{
-		return ENTINDEX(pEnt);
+		return TypeConversion.edict_to_id(pEnt);
 	}
 
 	return 0;

--- a/modules/cstrike/cstrike/CstrikeNatives.cpp
+++ b/modules/cstrike/cstrike/CstrikeNatives.cpp
@@ -1874,7 +1874,7 @@ static cell AMX_NATIVE_CALL cs_get_translated_item_alias(AMX* amx, cell* params)
 		}
 	}
 
-	MF_SetAmxString(amx, params[2], alias, params[3]);
+	MF_SetAmxString(amx, params[2], name, params[3]);
 
 	return info.itemid != CSI_NONE;
 }

--- a/modules/cstrike/cstrike/CstrikePlayer.cpp
+++ b/modules/cstrike/cstrike/CstrikePlayer.cpp
@@ -18,7 +18,7 @@ ke::Vector<int> ModelsUpdateQueue;
 
 void ClientDisconnect(edict_t *pEntity)
 {
-	int index = ENTINDEX(pEntity);
+	int index = TypeConversion.edict_to_id(pEntity);
 
 	Players[index].ResetModel();
 	Players[index].ResetZoom();
@@ -30,7 +30,7 @@ void ClientUserInfoChanged(edict_t *pEntity, char *infobuffer)
 {
 	if (pEntity->pvPrivateData)
 	{
-		Players[ENTINDEX(pEntity)].UpdateModel(pEntity);
+		Players[TypeConversion.edict_to_id(pEntity)].UpdateModel(pEntity);
 	}
 
 	RETURN_META(MRES_IGNORED);

--- a/modules/cstrike/cstrike/CstrikePlayer.h
+++ b/modules/cstrike/cstrike/CstrikePlayer.h
@@ -70,7 +70,7 @@ class CPlayer
 			{
 				MDLL_ClientUserInfoChanged(pPlayer, GETINFOKEYBUFFER(pPlayer));
 
-				PostponeModelUpdate(ENTINDEX(pPlayer) - 1);
+				PostponeModelUpdate(TypeConversion.edict_to_id(pPlayer) - 1);
 			}
 		}
 
@@ -85,7 +85,7 @@ class CPlayer
 
 			if (strcmp(GETCLIENTKEYVALUE(infobuffer, "model"), m_Model) != 0)
 			{
-				int index = ENTINDEX(pPlayer);
+				int index = TypeConversion.edict_to_id(pPlayer);
 
 				SETCLIENTKEYVALUE(index, infobuffer, "model", m_Model);
 

--- a/modules/cstrike/cstrike/CstrikeUserMessages.cpp
+++ b/modules/cstrike/cstrike/CstrikeUserMessages.cpp
@@ -21,8 +21,8 @@
 bool ShouldBlock;
 bool ShouldBlockHLTV;
 bool ShouldDisableHooks;
-bool RetrieveWeaponName;
-ke::AString CurrentWeaponName;
+bool RetrieveWeaponList;
+ItemInfo CurrentWeaponList;
 int ArgPosition;
 
 int MessageIdArmorType;
@@ -132,7 +132,19 @@ void OnMessageBegin(int msg_dest, int msg_type, const float *pOrigin, edict_t *p
 		{
 			if (msg_type == MessageIdWeaponList)
 			{
-				RetrieveWeaponName = true;
+				//	MESSAGE_BEGIN(MSG_INIT, gmsgWeaponList);
+				//	  WRITE_STRING(pszName);
+				//	  WRITE_BYTE(CBasePlayer::GetAmmoIndex(II.pszAmmo1));
+				//	  WRITE_BYTE(II.iMaxAmmo1);
+				//	  WRITE_BYTE(CBasePlayer::GetAmmoIndex(II.pszAmmo2));
+				//	  WRITE_BYTE(II.iMaxAmmo2);
+				//	  WRITE_BYTE(II.iSlot);
+				//	  WRITE_BYTE(II.iPosition);
+				//	  WRITE_BYTE(II.iId);
+				//	  WRITE_BYTE(II.iFlags);
+				//	MESSAGE_END();
+				//
+				RetrieveWeaponList = true;
 			}
 		}
 	}
@@ -152,9 +164,19 @@ void OnWriteByte(int value)
 		RETURN_META(MRES_SUPERCEDE);
 	}
 
-	if (RetrieveWeaponName && ++ArgPosition == 7 && value >= 0 && value < MAX_WEAPONS)
+	if (RetrieveWeaponList)
 	{
-		strncopy(WeaponNameList[value], CurrentWeaponName.chars(), sizeof(WeaponNameList[value]));
+		switch (++ArgPosition)
+		{
+			case 1: CurrentWeaponList.ammoIndex1 = value;
+			case 2: CurrentWeaponList.maxAmmo1 = value;
+			case 3: CurrentWeaponList.ammoIndex2 = value;
+			case 4: CurrentWeaponList.maxAmmo2 = value;
+			case 5: CurrentWeaponList.slot = value;
+			case 6: CurrentWeaponList.position = value;
+			case 7: CurrentWeaponList.id = value;
+			case 8: CurrentWeaponList.flags = value;
+		}
 	}
 
 	RETURN_META(MRES_IGNORED);
@@ -167,9 +189,9 @@ void OnWriteString(const char *value)
 		RETURN_META(MRES_SUPERCEDE);
 	}
 
-	if (RetrieveWeaponName)
+	if (RetrieveWeaponList)
 	{
-		CurrentWeaponName = value;
+		CurrentWeaponList.name = value;
 	}
 
 	RETURN_META(MRES_IGNORED);
@@ -190,10 +212,12 @@ void OnMessageEnd(void)
 		RETURN_META(MRES_SUPERCEDE);
 	}
 
-	if (RetrieveWeaponName)
+	if (RetrieveWeaponList)
 	{
-		RetrieveWeaponName = false;
+		RetrieveWeaponList = false;
 		ArgPosition = 0;
+
+		WeaponsList[CurrentWeaponList.id] = CurrentWeaponList;
 	}
 
 	RETURN_META(MRES_IGNORED);

--- a/modules/cstrike/cstrike/CstrikeUserMessages.cpp
+++ b/modules/cstrike/cstrike/CstrikeUserMessages.cpp
@@ -87,7 +87,7 @@ void OnMessageBegin(int msg_dest, int msg_type, const float *pOrigin, edict_t *p
 		{
 			if (msg_type == MessageIdSetFOV)
 			{
-				int index = ENTINDEX(pEntity);
+				int index = TypeConversion.edict_to_id(pEntity);
 				int zoom = Players[index].GetZoom();
 
 				if (zoom)
@@ -107,7 +107,7 @@ void OnMessageBegin(int msg_dest, int msg_type, const float *pOrigin, edict_t *p
 			}
 			else if (msg_type == MessageIdResetHUD)
 			{
-				int index = ENTINDEX(pEntity);
+				int index = TypeConversion.edict_to_id(pEntity);
 
 				if (Players[index].GetZoom())
 				{

--- a/modules/cstrike/cstrike/CstrikeUtils.h
+++ b/modules/cstrike/cstrike/CstrikeUtils.h
@@ -33,7 +33,7 @@ void UTIL_StringToLower(const char *str, char *buffer, size_t maxlength);
 		MF_LogError(amx, AMX_ERR_NATIVE, "Entity out of range (%d)", x); \
 		return 0; \
 	} else { \
-		if (x != 0 && FNullEnt(INDEXENT(x))) { \
+		if (x != 0 && FNullEnt(TypeConversion.id_to_edict(x))) { \
 			MF_LogError(amx, AMX_ERR_NATIVE, "Invalid entity %d", x); \
 			return 0; \
 		} \
@@ -50,7 +50,7 @@ void UTIL_StringToLower(const char *str, char *buffer, size_t maxlength);
 				return 0; \
 			} \
 		} else { \
-			if (x != 0 && FNullEnt(INDEXENT(x))) { \
+			if (x != 0 && FNullEnt(TypeConversion.id_to_edict(x))) { \
 				MF_LogError(amx, AMX_ERR_NATIVE, "Invalid entity %d", x); \
 				return 0; \
 			} \
@@ -73,7 +73,7 @@ void UTIL_StringToLower(const char *str, char *buffer, size_t maxlength);
 		MF_LogError(amx, AMX_ERR_NATIVE, "Non-player entity %d out of range", x); \
 		return 0; \
 	} else { \
-		if (FNullEnt(INDEXENT(x))) { \
+		if (FNullEnt(TypeConversion.id_to_edict(x))) { \
 			MF_LogError(amx, AMX_ERR_NATIVE, "Invalid non-player entity %d", x); \
 			return 0; \
 		} \


### PR DESCRIPTION
- Fixed bcompat with `cs_s/get_user_backpackammo`. 
 - Reported by Depresie [here](https://forums.alliedmods.net/showthread.php?t=279551). 
 - Related to #255.
 - Currently, to set `m_rgAmmo`, it relies on `m_rgpPlayerItems` to find the associated item in order to retrieve the ammo index. But it supposes that item is still present in the player's inventory. If you delete your item and you call these natives, this won't work since the item has been already unlinked in `m_rgpPlayerItems`. It was a bad idea to use that. It was working before because it was hardcoded with offset. 
 - This patch retrieves ammo index from WeaponList, and actually simplify the native code a lot. Sanity check has been modified to be more generic.
- Fixed a silly typo in cs_get_translated_item_alias()
- Fixed incomplete sanity check in cs_get_weapon_info().