### PR TITLE
Filter evil characters in name and message (bug 5912, bug 6301)

### DIFF
--- a/amxmodx/amxmodx.h
+++ b/amxmodx/amxmodx.h
@@ -142,6 +142,7 @@ unsigned int UTIL_ReplaceAll(char *subject, size_t maxlength, const char *search
 char *UTIL_ReplaceEx(char *subject, size_t maxLen, const char *search, size_t searchLen, const char *replace, size_t replaceLen, bool caseSensitive);
 void UTIL_TrimLeft(char *buffer);
 void UTIL_TrimRight(char *buffer);
+size_t UTIL_FilterEvilCharacters(const char *in, char *out, size_t out_maxlen, bool name_only);
 
 #define GET_PLAYER_POINTER(e)   (&g_players[ENTINDEX(e)])
 //#define GET_PLAYER_POINTER(e)   (&g_players[(((int)e-g_edict_point)/sizeof(edict_t))])

--- a/amxmodx/meta_api.cpp
+++ b/amxmodx/meta_api.cpp
@@ -149,6 +149,7 @@ int FF_ClientConnectEx = -1;
 
 IFileSystem* g_FileSystem;
 HLTypeConversion TypeConversion;
+server_static_t *ServerStatic;
 
 bool ColoredMenus(const char *ModName)
 {
@@ -929,6 +930,27 @@ void C_ClientPutInServer_Post(edict_t *pEntity)
 	RETURN_META(MRES_IGNORED);
 }
 
+void C_ClientUserInfoChanged_Pre(edict_t *pEntity, char *infobuffer)
+{
+	if (ServerStatic)
+	{
+		auto clientIndex = TypeConversion.edict_to_id(pEntity);
+
+		const char *oldName = ServerStatic->clients[clientIndex - 1].name;
+		const char *newName = INFOKEY_VALUE(infobuffer, "name");
+
+		if (oldName[0] == '\0' || strcmp(newName, oldName) != 0)
+		{
+			char safeNewName[MAX_NAME];
+			UTIL_FilterEvilCharacters(newName, safeNewName, sizeof(safeNewName), true);
+
+			SET_CLIENT_KEYVALUE(clientIndex, infobuffer, "name", safeNewName);
+		}
+	}
+
+	RETURN_META(MRES_IGNORED);
+}
+
 void C_ClientUserInfoChanged_Post(edict_t *pEntity, char *infobuffer)
 {
 	CPlayer *pPlayer = GET_PLAYER_POINTER(pEntity);
@@ -1006,6 +1028,19 @@ void C_ClientCommand(edict_t *pEntity)
 #endif
 			CLIENT_PRINT(pEntity, print_console, buf);
 			RETURN_META(MRES_SUPERCEDE);
+		}
+	}
+
+	if (!strcmp(cmd, "say") || !strcmp(cmd, "say_team"))
+	{
+		auto args = CMD_ARGS();
+
+		if (args && *args)
+		{
+			char safeMessage[128];
+			auto length = UTIL_FilterEvilCharacters(args, safeMessage, sizeof(safeMessage), false);
+
+			memcpy(const_cast<char*>(args), safeMessage, length + 1);
 		}
 	}
 
@@ -1586,15 +1621,37 @@ C_DLLEXPORT	int	Meta_Attach(PLUG_LOADTIME now, META_FUNCTIONS *pFunctionTable, m
 
 	g_CvarManager.CreateCvarHook();
 
-	void *address = nullptr;
+	if (CommonConfig)
+	{
+		void *address = nullptr;
 
-	if (CommonConfig && CommonConfig->GetMemSig("SV_DropClient", &address) && address)
-	{
-		DropClientDetour = DETOUR_CREATE_STATIC_FIXED(SV_DropClient, address);
-	}
-	else
-	{
-		AMXXLOG_Log("client_disconnected forward has been disabled - check your gamedata files.");
+#if defined(KE_WINDOWS)
+		TypeDescription typeDesc;
+
+		if (CommonConfig->GetOffset("svs", &typeDesc))
+		{
+			auto base = *reinterpret_cast<uintptr_t*>(reinterpret_cast<byte*>(g_engfuncs.pfnGetCurrentPlayer) + typeDesc.fieldOffset);
+			ServerStatic = reinterpret_cast<decltype(ServerStatic)>(base - 4);
+		}
+#else
+		if (CommonConfig->GetMemSig("svs", &address))
+		{
+			ServerStatic = reinterpret_cast<decltype(ServerStatic)>(address);
+		}
+#endif
+		else
+		{
+			AMXXLOG_Log("svs global variable is not available - check your gamedata files.");
+		}
+
+		if (CommonConfig->GetMemSig("SV_DropClient", &address) && address)
+		{
+			DropClientDetour = DETOUR_CREATE_STATIC_FIXED(SV_DropClient, address);
+		}
+		else
+		{
+			AMXXLOG_Log("client_disconnected forward has been disabled - check your gamedata files.");
+		}
 	}
 
 	GET_IFACE<IFileSystem>("filesystem_stdio", g_FileSystem, FILESYSTEM_INTERFACE_VERSION);
@@ -1739,6 +1796,7 @@ C_DLLEXPORT	int	GetEntityAPI2(DLL_FUNCTIONS *pFunctionTable, int *interfaceVersi
 	gFunctionTable.pfnInconsistentFile = C_InconsistentFile;
 	gFunctionTable.pfnServerActivate = C_ServerActivate;
 	gFunctionTable.pfnClientConnect = C_ClientConnect;
+	gFunctionTable.pfnClientUserInfoChanged = C_ClientUserInfoChanged_Pre;
 
 	memcpy(pFunctionTable, &gFunctionTable, sizeof(DLL_FUNCTIONS));
 


### PR DESCRIPTION

This fixes a known exploit around localized string and var arg, like `#Spec_Help_Text`, `+forward` or `%s` , which can cause bugs with multiple occurrences, at worst crashing a client.

While it should not crash on the client (typically an overflow with localized strings), unfortunately, this is happening because AMXX sends a message as it is directly and people are enough cunning to use such string in their name as well.

The concerned messages are: `TextMsg`, `SayText` and `ShowMenu`.

This means that any plugin which displays a menu with player's name (like slap menu) or rewrites the chat output (like adminchat with `say_team @`), at best you get an unwanted translated message, at worst it crashes the client who receives the message.

Ideally, the name should be filtered in the engine, and anything typed in `say/_team` in the mod, but since AMXX is equally responsible, it makes sense we do this filtering.

-- 

This patch filters the following characters in those specific events:
 - When at player changes name
  - By filtering name, this should cover most of the situations since name is often inserted in message
 - When a player says something via `say` and `say_team`
  - By filtering when a command is issued, it should cover `read_args` which is used by the plugin to retrieve the whole input buffer from chat before being passed in natives using `TextMsg`, `SayText`  such as  `client_print/_color` or manually via `write_string`.

Character           | Description                                     | Message
----------------------|-----------------------------------------------|-----------------------------|
 `+` `<key>`        | Key binds. Translated to `[key] `.  |  `ShowMenu`
 `&` `<value>`     | Hotkeys in VGUI. Unsure.             | `ShowMenu` ?
 `#` `<value>`     | Localized string                             | `ShowMenu`, `SayText`, `TextMsg`
 `%` `s`                | Format specifier                            | `SayText`, ``TextMsg`

Some notes ^:
 - I'm not totally sure about `&`. It seems engine already filters it by replacing by spaces, but for safety I keep it
 - `%` should be filtered by the mod if you opt for the beta, but for safety I keep it.
 - Only `#` and `%` are concerned in messages

-- 

I would like some feedbacks.
 - Characters are replaced with similar Unicode (code written by @WPMGPRoSToTeMa ). What do you think about it? Is a config should be added allow admin to choose whether they want to replace evil characters with a specific one instead of Unicode?
 - Any usage I could have forgotten?