### PR TITLE
Allow null invoker to be passed in EngFunc_PlayBackEvent (bug 6467)

### DIFF
--- a/modules/fakemeta/engfunc.cpp
+++ b/modules/fakemeta/engfunc.cpp
@@ -899,7 +899,11 @@ static cell AMX_NATIVE_CALL engfunc(AMX *amx, cell *params)
 		iparam1 = cRet[0];
 		cRet = MF_GetAmxAddr(amx,params[3]);
 		index = cRet[0];
-		CHECK_ENTITY(index);
+		if (index != -1)
+		{
+			CHECK_ENTITY(index);
+			pRet = TypeConversion.id_to_edict(index);
+		}
 		cRet = MF_GetAmxAddr(amx,params[4]);
 		iparam2 = cRet[0];
 		cRet = MF_GetAmxAddr(amx,params[5]);
@@ -924,7 +928,7 @@ static cell AMX_NATIVE_CALL engfunc(AMX *amx, cell *params)
 		iparam5 = cRet[0];
 		cRet = MF_GetAmxAddr(amx,params[13]);
 		iparam6 = cRet[0];
-		(*g_engfuncs.pfnPlaybackEvent)(iparam1,TypeConversion.id_to_edict(index),iparam2,fparam1,Vec1,Vec2,fparam2,fparam3,iparam3,iparam4,iparam5,iparam6);
+		(*g_engfuncs.pfnPlaybackEvent)(iparam1,pRet,iparam2,fparam1,Vec1,Vec2,fparam2,fparam3,iparam3,iparam4,iparam5,iparam6);
 		return 1;
 
 		//pfnCheckVisibility

--- a/modules/fakemeta/forwardmacros.h
+++ b/modules/fakemeta/forwardmacros.h
@@ -814,14 +814,14 @@
 	{ \
 		PREPARE_VECTOR(vec); \
 		PREPARE_VECTOR(vecb); \
-		FM_ENG_HANDLE(FM_##call, (Engine[FM_##call].at(i),  (cell)v, (cell)ENTINDEX((edict_t*)e), (cell)eb, f, p_vec, p_vecb, fb, fc, (cell)vb, (cell)vc, (cell)vd, (cell)ve)); \
+		FM_ENG_HANDLE(FM_##call, (Engine[FM_##call].at(i),  (cell)v, e ? (cell)ENTINDEX((edict_t*)e) : -1, (cell)eb, f, p_vec, p_vecb, fb, fc, (cell)vb, (cell)vc, (cell)vd, (cell)ve)); \
 		RETURN_META(mswi(lastFmRes)); \
 	} \
 	void call##_post (int v, const edict_t *e, unsigned short eb, float f, float *vec, float *vecb, float fb, float fc, int vb, int vc, int vd, int ve) \
 	{ \
 		PREPARE_VECTOR(vec); \
 		PREPARE_VECTOR(vecb); \
-		FM_ENG_HANDLE_POST(FM_##call, (EnginePost[FM_##call].at(i), (cell)v, (cell)ENTINDEX((edict_t*)e),(cell)eb, f, p_vec, p_vecb, fb, fc, (cell)vb, (cell)vc, (cell)vd, (cell)ve)); \
+		FM_ENG_HANDLE_POST(FM_##call, (EnginePost[FM_##call].at(i), (cell)v, e ? (cell)ENTINDEX((edict_t*)e) : -1, (cell)eb, f, p_vec, p_vecb, fb, fc, (cell)vb, (cell)vc, (cell)vd, (cell)ve)); \
 		RETURN_META(MRES_IGNORED); \
 	} 
 


### PR DESCRIPTION
This allows passing `-1` (you can use `FM_NULLENT`) in `EngFunc_PlayBackEvent` for invoker to tell the module to pass a `NULL` invoker edict. This is allowed by the engine to use a specific origin rather than the invoker's origin.

This fix the forward as well to return -1 instead of 0 if invoker edict is null. Should be safe change.