### PR TITLE
Extend "read_argv" native

### DIFF
--- a/amxmodx/amxmodx.cpp
+++ b/amxmodx/amxmodx.cpp
@@ -2435,7 +2435,19 @@ static cell AMX_NATIVE_CALL read_argv(AMX *amx, cell *params) /* 3 param */
 	int argc = params[1];
 
 	const char *value = g_fakecmd.notify ? (argc >= 0 && argc < 3 ? g_fakecmd.argv[argc] : "") : CMD_ARGV(argc);
-	return set_amxstring_utf8(amx, params[2], value, strlen(value), params[3]);
+
+	switch (*params / sizeof(cell))
+	{
+		case 1:
+			return atoi(value);
+		case 3:
+			return set_amxstring_utf8(amx, params[2], value, strlen(value), *get_amxaddr(amx, params[3]));
+		default:
+			cell *fCell = get_amxaddr(amx, params[2]);
+			REAL fparam = static_cast<REAL>(atof(value));
+			*fCell = amx_ftoc(fparam);
+			return static_cast<int>(fparam);
+	}
 }
 
 static cell AMX_NATIVE_CALL read_args(AMX *amx, cell *params) /* 2 param */

--- a/plugins/include/amxmodx.inc
+++ b/plugins/include/amxmodx.inc
@@ -1327,14 +1327,29 @@ native get_players(players[MAX_PLAYERS], &num, const flags[] = "", const team[] 
  * Retrieves argument of client command.
  *
  * @note Should only be used inside of the client_command() forward.
+ * @note Usage examples:
+ *       value = read_argv(1);
+ *       read_argv(2, floatvalue);
+ *       written = read_argv(3, buffer, buffersize);
  *
  * @param id        Argument index starting from 1, 0 returns the command itself
- * @param output    Buffer to copy command argument to
- * @param len       Maximum buffer size
+ * @param ...       Changes the native's behavior depending on how many
+ *                  additional parameters are provided:
+ *                     0 - Return the argument integer value directly
+ *                     1 - Store the argument float value in the variable passed
+ *                         as the second parameter
+ *                     2 - Copy the argument string value to the buffer provided
+ *                         in the second parameter, using the third as the
+ *                         maximum buffer size
  *
- * @return          Number of cells written to buffer
+ * @return          Changes depending on how many additional parameters are
+ *                  provided:
+ *                     0 - Returns the argument integer value
+ *                     1 - Returns the argument float value, converted
+ *                         (truncated) to an integer
+ *                     2 - Returns the number of cells written to the buffer
  */
-native read_argv(id, output[], len);
+native read_argv(id, any:...);
 
 /**
  * Retrieves full client command string.


### PR DESCRIPTION
~~This PR introduces a new native ```read_argv2```.~~
This PR extends ```read_argv``` native. It works like ```read_data``` native. We can get integer/float value directly instead writing it to an array then executing ```str_to_num``` or ```str_to_float``` natives.