### PR TITLE
Fix typos in entity_intersects() and get_global_edict2() natives

### DIFF
--- a/modules/engine/entity.cpp
+++ b/modules/engine/entity.cpp
@@ -1568,10 +1568,10 @@ static cell AMX_NATIVE_CALL entity_intersects(AMX *amx, cell *params) // bool:en
 		pevOther->absmax.y < pevEntity->absmin.y ||
 		pevOther->absmax.z < pevEntity->absmin.z)
 	{
-		return 1;
+		return 0;
 	}
 
-	return 0;
+	return 1;
 }
 
 AMX_NATIVE_INFO ent_NewNatives[] =

--- a/modules/engine/globals.cpp
+++ b/modules/engine/globals.cpp
@@ -170,12 +170,7 @@ static cell AMX_NATIVE_CALL get_global_edict2(AMX *amx, cell *params)
 			return -1;
 	}
 
-	if (!FNullEnt(pReturnEntity))
-	{
-		return TypeConversion.edict_to_id(pReturnEntity);
-	}
-
-	return -1;
+	return TypeConversion.edict_to_id(pReturnEntity);
 }
 
 static cell AMX_NATIVE_CALL get_global_edict(AMX *amx, cell *params) // globals_get_edict(variable); = 1 param


### PR DESCRIPTION
* `entity_intersects`: Return value is reversed. Two years later no one reported the issue \o/. Related  to #70.
* `get_global_edict2`: By using `FNullEnt` this ignores worldspawn edict, which should be allowed here. `edict_to_id` returns  -1 if pointer is null. Related  to #250.