### PR TITLE
cmd_targetex

### DIFF
--- a/plugins/admincmd.sma
+++ b/plugins/admincmd.sma
@@ -185,38 +185,70 @@ public cmdKick(id, level, cid)
 	if (!cmd_access(id, level, cid, 2))
 		return PLUGIN_HANDLED
 
-	new arg[32]
+	new arg[32], players[MAX_PLAYERS], lang[32];
 	read_argv(1, arg, charsmax(arg))
-	new player = cmd_target(id, arg, CMDTARGET_OBEY_IMMUNITY | CMDTARGET_ALLOW_SELF)
+	new plnum = cmd_targetex(id, arg, CMDTARGET_OBEY_IMMUNITY | CMDTARGET_ALLOW_SELF | CMDTARGET_SAFETY, players, lang, charsmax(lang))
 	
-	if (!player)
+	if (!plnum)
 		return PLUGIN_HANDLED
 	
-	new authid[32], authid2[32], name2[MAX_NAME_LENGTH], name[MAX_NAME_LENGTH], userid2, reason[32]
+	if (plnum == 1)
+	{
+		new authid[32], authid2[32], name2[MAX_NAME_LENGTH], name[MAX_NAME_LENGTH], userid2, reason[32]
 	
-	get_user_authid(id, authid, charsmax(authid))
-	get_user_authid(player, authid2, charsmax(authid2))
-	get_user_name(player, name2, charsmax(name2))
-	get_user_name(id, name, charsmax(name))
-	userid2 = get_user_userid(player)
-	read_argv(2, reason, charsmax(reason))
-	remove_quotes(reason)
-	
-	log_amx("Kick: ^"%s<%d><%s><>^" kick ^"%s<%d><%s><>^" (reason ^"%s^")", name, get_user_userid(id), authid, name2, userid2, authid2, reason)
+		get_user_authid(id, authid, charsmax(authid))
+		get_user_authid(players[0], authid2, charsmax(authid2))
+		get_user_name(players[0], name2, charsmax(name2))
+		get_user_name(id, name, charsmax(name))
+		userid2 = get_user_userid(players[0])
+		read_argv(2, reason, charsmax(reason))
+		remove_quotes(reason)
+		
+		log_amx("Kick: ^"%s<%d><%s><>^" kick ^"%s<%d><%s><>^" (reason ^"%s^")", name, get_user_userid(id), authid, name2, userid2, authid2, reason)
 
-	show_activity_key("ADMIN_KICK_1", "ADMIN_KICK_2", name, name2);
+		show_activity_key("ADMIN_KICK_1", "ADMIN_KICK_2", name, name2);
 
-	if (is_user_bot(player))
-		server_cmd("kick #%d", userid2)
+		if (is_user_bot(players[0]))
+			server_cmd("kick #%d", userid2)
+		else
+		{
+			if (reason[0])
+				server_cmd("kick #%d ^"%s^"", userid2, reason)
+			else
+				server_cmd("kick #%d", userid2)
+		}
+		
+		console_print(id, "[AMXX] Client ^"%s^" kicked", name2)
+	}
 	else
 	{
-		if (reason[0])
-			server_cmd("kick #%d ^"%s^"", userid2, reason)
-		else
-			server_cmd("kick #%d", userid2)
+		new authid[32], name[MAX_NAME_LENGTH], reason[32];
+		get_user_authid(id, authid, charsmax(authid));
+		get_user_name(id, name, charsmax(name));
+		read_argv(2, reason, charsmax(reason));
+		remove_quotes(reason);
+		
+		log_amx("Cmd: ^"%s<%d><%s><>^" kick %l (reason ^"%s^")", name, get_user_userid(id), authid, lang, reason);
+		
+		show_activity_key("ADMIN_KICK_1", "ADMIN_KICK_2", name, lang);
+		
+		new userid2;
+		for (new i = 0; i < plnum; ++i)
+		{
+			userid2 = get_user_userid(players[i]);
+			if (is_user_bot(players[i]))
+				server_cmd("kick #%d", userid2)
+			else
+			{
+				if (reason[0])
+					server_cmd("kick #%d ^"%s^"", userid2, reason)
+				else
+					server_cmd("kick #%d", userid2)
+			}
+		}
+		
+		console_print(id, "[AMXX] %l", "CLIENTS_KICKED", lang);
 	}
-	
-	console_print(id, "[AMXX] Client ^"%s^" kicked", name2)
 	
 	return PLUGIN_HANDLED
 }
@@ -396,15 +428,15 @@ public cmdBan(id, level, cid)
 	if (!cmd_access(id, level, cid, 3))
 		return PLUGIN_HANDLED
 
-	new target[32], minutes[8], reason[64]
+	new target[32], minutes[8], reason[64], players[MAX_PLAYERS];
 	
-	read_argv(1, target, charsmax(target))
-	read_argv(2, minutes, charsmax(minutes))
-	read_argv(3, reason, charsmax(reason))
+	read_argv(1, target, charsmax(target));
+	read_argv(2, minutes, charsmax(minutes));
+	read_argv(3, reason, charsmax(reason));
 	
-	new player = cmd_target(id, target, CMDTARGET_OBEY_IMMUNITY | CMDTARGET_NO_BOTS | CMDTARGET_ALLOW_SELF)
+	new plnum = cmd_targetex(id, target, CMDTARGET_OBEY_IMMUNITY | CMDTARGET_NO_BOTS | CMDTARGET_ALLOW_SELF | CMDTARGET_NO_MULTIPLE_TARGETS, players);
 	
-	if (!player)
+	if (!plnum)
 		return PLUGIN_HANDLED
 
 	new nNum = str_to_num(minutes)
@@ -420,11 +452,11 @@ public cmdBan(id, level, cid)
 	}
 
 	new authid[32], name2[MAX_NAME_LENGTH], authid2[32], name[MAX_NAME_LENGTH]
-	new userid2 = get_user_userid(player)
+	new userid2 = get_user_userid(players[0])
 
-	get_user_authid(player, authid2, charsmax(authid2))
+	get_user_authid(players[0], authid2, charsmax(authid2))
 	get_user_authid(id, authid, charsmax(authid))
-	get_user_name(player, name2, charsmax(name2))
+	get_user_name(players[0], name2, charsmax(name2))
 	get_user_name(id, name, charsmax(name))
 	
 	log_amx("Ban: ^"%s<%d><%s><>^" ban and kick ^"%s<%d><%s><>^" (minutes ^"%s^") (reason ^"%s^")", name, get_user_userid(id), authid, name2, userid2, authid2, minutes, reason)
@@ -433,11 +465,11 @@ public cmdBan(id, level, cid)
 	
 	new temp[64], banned[16]
 	if (nNum)
-		formatex(temp, charsmax(temp), "%L", player, "FOR_MIN", minutes)
+		formatex(temp, charsmax(temp), "%L", players[0], "FOR_MIN", minutes)
 	else
-		formatex(temp, charsmax(temp), "%L", player, "PERM")
+		formatex(temp, charsmax(temp), "%L", players[0], "PERM")
 
-	formatex(banned, charsmax(banned), "%L", player, "BANNED")
+	formatex(banned, charsmax(banned), "%L", players[0], "BANNED")
 
 	if (reason[0])
 		server_cmd("kick #%d ^"%s (%s %s)^";wait;banid %s %s;wait;writeid", userid2, reason, banned, temp, minutes, authid2)
@@ -449,11 +481,11 @@ public cmdBan(id, level, cid)
 
 	new msg[256];
 	new len;
-	new players[MAX_PLAYERS], pnum, plr
-	get_players(players, pnum, "ch")
+	new plrs[MAX_PLAYERS], pnum, plr
+	get_players(plrs, pnum, "ch")
 	for (new i; i<pnum; i++)
 	{
-		plr = players[i]
+		plr = plrs[i]
 
 		len = formatex(msg, charsmax(msg), "%L", plr, "BAN");
 		len += formatex(msg[len], charsmax(msg) - len, " %s ", name2);
@@ -482,15 +514,15 @@ public cmdBanIP(id, level, cid)
 	if (!cmd_access(id, level, cid, 3))
 		return PLUGIN_HANDLED
 	
-	new target[32], minutes[8], reason[64]
+	new target[32], minutes[8], reason[64], players[MAX_PLAYERS];
 	
-	read_argv(1, target, charsmax(target))
-	read_argv(2, minutes, charsmax(minutes))
-	read_argv(3, reason, charsmax(reason))
+	read_argv(1, target, charsmax(target));
+	read_argv(2, minutes, charsmax(minutes));
+	read_argv(3, reason, charsmax(reason));
 	
-	new player = cmd_target(id, target, CMDTARGET_OBEY_IMMUNITY | CMDTARGET_NO_BOTS | CMDTARGET_ALLOW_SELF)
+	new plnum = cmd_targetex(id, target, CMDTARGET_OBEY_IMMUNITY | CMDTARGET_NO_BOTS | CMDTARGET_ALLOW_SELF | CMDTARGET_NO_MULTIPLE_TARGETS, players);
 	
-	if (!player)
+	if (!plnum)
 		return PLUGIN_HANDLED
 
 	new nNum = str_to_num(minutes)
@@ -506,11 +538,11 @@ public cmdBanIP(id, level, cid)
 	}
 	
 	new authid[32], name2[MAX_NAME_LENGTH], authid2[32], name[MAX_NAME_LENGTH]
-	new userid2 = get_user_userid(player)
+	new userid2 = get_user_userid(players[0])
 	
-	get_user_authid(player, authid2, charsmax(authid2))
+	get_user_authid(players[0], authid2, charsmax(authid2))
 	get_user_authid(id, authid, charsmax(authid))
-	get_user_name(player, name2, charsmax(name2))
+	get_user_name(players[0], name2, charsmax(name2))
 	get_user_name(id, name, charsmax(name))
 	
 	log_amx("Ban: ^"%s<%d><%s><>^" ban and kick ^"%s<%d><%s><>^" (minutes ^"%s^") (reason ^"%s^")", name, get_user_userid(id), authid, name2, userid2, authid2, minutes, reason)
@@ -519,13 +551,13 @@ public cmdBanIP(id, level, cid)
 
 	new temp[64], banned[16]
 	if (nNum)
-		formatex(temp, charsmax(temp), "%L", player, "FOR_MIN", minutes)
+		formatex(temp, charsmax(temp), "%L", players[0], "FOR_MIN", minutes)
 	else
-		formatex(temp, charsmax(temp), "%L", player, "PERM")
-	format(banned, 15, "%L", player, "BANNED")
+		formatex(temp, charsmax(temp), "%L", players[0], "PERM")
+	format(banned, 15, "%L", players[0], "BANNED")
 
 	new address[32]
-	get_user_ip(player, address, charsmax(address), 1)
+	get_user_ip(players[0], address, charsmax(address), 1)
 
 	if (reason[0])
 		server_cmd("kick #%d ^"%s (%s %s)^";wait;addip ^"%s^" ^"%s^";wait;writeip", userid2, reason, banned, temp, minutes, address)
@@ -536,11 +568,11 @@ public cmdBanIP(id, level, cid)
 
 	new msg[256];
 	new len;
-	new players[MAX_PLAYERS], pnum, plr
-	get_players(players, pnum, "ch")
+	new plrs[MAX_PLAYERS], pnum, plr
+	get_players(plrs, pnum, "ch")
 	for (new i; i<pnum; i++)
 	{
-		plr = players[i]
+		plr = plrs[i]
 
 		len = formatex(msg, charsmax(msg), "%L", plr, "BAN");
 		len += formatex(msg[len], charsmax(msg) - len, " %s ", name2);
@@ -569,30 +601,46 @@ public cmdSlay(id, level, cid)
 	if (!cmd_access(id, level, cid, 2))
 		return PLUGIN_HANDLED
 	
-	new arg[32]
+	new arg[32], players[MAX_PLAYERS], lang[32];
+	read_argv(1, arg, charsmax(arg));
+	new plnum = cmd_targetex(id, arg, CMDTARGET_OBEY_IMMUNITY | CMDTARGET_ALLOW_SELF | CMDTARGET_ONLY_ALIVE, players, lang, charsmax(lang));
 	
-	read_argv(1, arg, charsmax(arg))
-	
-	new player = cmd_target(id, arg, CMDTARGET_OBEY_IMMUNITY | CMDTARGET_ALLOW_SELF | CMDTARGET_ONLY_ALIVE)
-	
-	if (!player)
+	if (!plnum)
 		return PLUGIN_HANDLED
-	
-	user_kill(player)
-	
-	new authid[32], name2[MAX_NAME_LENGTH], authid2[32], name[MAX_NAME_LENGTH]
-	
-	get_user_authid(id, authid, charsmax(authid))
-	get_user_name(id, name, charsmax(name))
-	get_user_authid(player, authid2, charsmax(authid2))
-	get_user_name(player, name2, charsmax(name2))
-	
-	log_amx("Cmd: ^"%s<%d><%s><>^" slay ^"%s<%d><%s><>^"", name, get_user_userid(id), authid, name2, get_user_userid(player), authid2)
+	if (plnum == 1)
+	{
+		user_kill(players[0])
+		
+		new authid[32], name2[MAX_NAME_LENGTH], authid2[32], name[MAX_NAME_LENGTH]
+		
+		get_user_authid(id, authid, charsmax(authid))
+		get_user_name(id, name, charsmax(name))
+		get_user_authid(players[0], authid2, charsmax(authid2))
+		get_user_name(players[0], name2, charsmax(name2))
+		
+		log_amx("Cmd: ^"%s<%d><%s><>^" slay ^"%s<%d><%s><>^"", name, get_user_userid(id), authid, name2, get_user_userid(players[0]), authid2)
 
-	show_activity_key("ADMIN_SLAY_1", "ADMIN_SLAY_2", name, name2);
+		show_activity_key("ADMIN_SLAY_1", "ADMIN_SLAY_2", name, name2);
 
-	console_print(id, "[AMXX] %L", id, "CLIENT_SLAYED", name2)
-	
+		console_print(id, "[AMXX] %L", id, "CLIENT_SLAYED", name2)
+	}
+	else
+	{
+		for (new i = 0; i < plnum; ++i)
+		{
+			user_kill(players[i]);
+		}
+		
+		new authid[32], name[MAX_NAME_LENGTH];
+		get_user_authid(id, authid, charsmax(authid));
+		get_user_name(id, name, charsmax(name));
+		
+		log_amx("Cmd: ^"%s<%d><%s><>^" slay %l", name, get_user_userid(id), authid, lang);
+		
+		show_activity_key("ADMIN_SLAY_1", "ADMIN_SLAY_2", name, lang);
+		
+		console_print(id, "[AMXX] %l", "CLIENTS_SLAYED", lang);
+	}
 	return PLUGIN_HANDLED
 }
 
@@ -601,32 +649,51 @@ public cmdSlap(id, level, cid)
 	if (!cmd_access(id, level, cid, 2))
 		return PLUGIN_HANDLED
 
-	new arg[32]
+	new arg[32], players[MAX_PLAYERS], lang[32];
+	read_argv(1, arg, charsmax(arg));
+	new plnum = cmd_targetex(id, arg, CMDTARGET_OBEY_IMMUNITY | CMDTARGET_ALLOW_SELF | CMDTARGET_ONLY_ALIVE, players, lang, charsmax(lang));
 	
-	read_argv(1, arg, charsmax(arg))
-	new player = cmd_target(id, arg, CMDTARGET_OBEY_IMMUNITY | CMDTARGET_ALLOW_SELF | CMDTARGET_ONLY_ALIVE)
-	
-	if (!player)
+	if (!plnum)
 		return PLUGIN_HANDLED
 
-	new spower[32], authid[32], name2[MAX_NAME_LENGTH], authid2[32], name[MAX_NAME_LENGTH]
+	new spower[32];
+	read_argv(2, spower, charsmax(spower));
+	new damage = clamp(str_to_num(spower), 0);
 	
-	read_argv(2, spower, charsmax(spower))
+	if (plnum == 1)
+	{
+		new authid[32], name2[MAX_NAME_LENGTH], authid2[32], name[MAX_NAME_LENGTH]
 	
-	new damage = clamp( str_to_num(spower), 0)
+		user_slap(players[0], damage)
 	
-	user_slap(player, damage)
+		get_user_authid(id, authid, charsmax(authid))
+		get_user_name(id, name, charsmax(name))
+		get_user_authid(players[0], authid2, charsmax(authid2))
+		get_user_name(players[0], name2, charsmax(name2))
 	
-	get_user_authid(id, authid, charsmax(authid))
-	get_user_name(id, name, charsmax(name))
-	get_user_authid(player, authid2, charsmax(authid2))
-	get_user_name(player, name2, charsmax(name2))
-	
-	log_amx("Cmd: ^"%s<%d><%s><>^" slap with %d damage ^"%s<%d><%s><>^"", name, get_user_userid(id), authid, damage, name2, get_user_userid(player), authid2)
+		log_amx("Cmd: ^"%s<%d><%s><>^" slap with %d damage ^"%s<%d><%s><>^"", name, get_user_userid(id), authid, damage, name2, get_user_userid(players[0]), authid2)
 
-	show_activity_key("ADMIN_SLAP_1", "ADMIN_SLAP_2", name, name2, damage);
+		show_activity_key("ADMIN_SLAP_1", "ADMIN_SLAP_2", name, name2, damage);
 
-	console_print(id, "[AMXX] %L", id, "CLIENT_SLAPED", name2, damage)
+		console_print(id, "[AMXX] %L", id, "CLIENT_SLAPED", name2, damage)
+	}
+	else
+	{
+		for (new i = 0; i < plnum; ++i)
+		{
+			user_slap(players[i], damage);
+		}
+		
+		new authid[32], name[MAX_NAME_LENGTH];
+		get_user_authid(id, authid, charsmax(authid));
+		get_user_name(id, name, charsmax(name));
+		
+		log_amx("Cmd: ^"%s<%d><%s><>^" slap with %d damage %l", name, get_user_userid(id), authid, damage, lang);
+		
+		show_activity_key("ADMIN_SLAP_1", "ADMIN_SLAP_2", name, lang, damage);
+		
+		console_print(id, "[AMXX] %l", "CLIENTS_SLAPED", lang, damage);
+	}
 	
 	return PLUGIN_HANDLED
 }
@@ -1274,24 +1341,24 @@ public cmdNick(id, level, cid)
 	if (!cmd_access(id, level, cid, 3))
 		return PLUGIN_HANDLED
 
-	new arg1[32], arg2[32], authid[32], name[32], authid2[32], name2[32]
+	new arg1[32], arg2[32], authid[32], name[32], authid2[32], name2[32], players[MAX_PLAYERS];
 
-	read_argv(1, arg1, charsmax(arg1))
-	read_argv(2, arg2, charsmax(arg2))
+	read_argv(1, arg1, charsmax(arg1));
+	read_argv(2, arg2, charsmax(arg2));
 
-	new player = cmd_target(id, arg1, CMDTARGET_OBEY_IMMUNITY | CMDTARGET_ALLOW_SELF)
+	new plnum = cmd_targetex(id, arg1, CMDTARGET_OBEY_IMMUNITY | CMDTARGET_ALLOW_SELF | CMDTARGET_NO_MULTIPLE_TARGETS, players);
 	
-	if (!player)
+	if (!plnum)
 		return PLUGIN_HANDLED
 
 	get_user_authid(id, authid, charsmax(authid))
 	get_user_name(id, name, charsmax(name))
-	get_user_authid(player, authid2, charsmax(authid2))
-	get_user_name(player, name2, charsmax(name2))
+	get_user_authid(players[0], authid2, charsmax(authid2))
+	get_user_name(players[0], name2, charsmax(name2))
 
-	set_user_info(player, "name", arg2)
+	set_user_info(players[0], "name", arg2)
 
-	log_amx("Cmd: ^"%s<%d><%s><>^" change nick to ^"%s^" ^"%s<%d><%s><>^"", name, get_user_userid(id), authid, arg2, name2, get_user_userid(player), authid2)
+	log_amx("Cmd: ^"%s<%d><%s><>^" change nick to ^"%s^" ^"%s<%d><%s><>^"", name, get_user_userid(id), authid, arg2, name2, get_user_userid(players[0]), authid2)
 
 	show_activity_key("ADMIN_NICK_1", "ADMIN_NICK_2", name, name2, arg2);
 

--- a/plugins/include/amxmisc.inc
+++ b/plugins/include/amxmisc.inc
@@ -12,6 +12,10 @@
 #endif
 #define _amxmisc_included
 
+#if !defined _fakemeta_included
+	#include <fakemeta>
+#endif
+
 #if !defined _amxmodx_included
 	#include <amxmodx>
 #endif
@@ -112,10 +116,13 @@ stock access(id, level)
 /**
  * cmd_target flags
  */
-#define CMDTARGET_OBEY_IMMUNITY (1<<0) // Obey immunity
-#define CMDTARGET_ALLOW_SELF    (1<<1) // Allow self targeting
-#define CMDTARGET_ONLY_ALIVE    (1<<2) // Target must be alive
-#define CMDTARGET_NO_BOTS       (1<<3) // Target can't be a bot
+#define CMDTARGET_OBEY_IMMUNITY       (1<<0) // Obey immunity
+#define CMDTARGET_ALLOW_SELF          (1<<1) // Allow self targeting
+#define CMDTARGET_ONLY_ALIVE          (1<<2) // Target must be alive
+#define CMDTARGET_NO_BOTS             (1<<3) // Target can't be a bot
+#define CMDTARGET_NO_SPEC             (1<<4) // Target can't be spectator
+#define CMDTARGET_SAFETY              (1<<5) // Allow only safety commands (@aim @bots @me @spec @spectating name)
+#define CMDTARGET_NO_MULTIPLE_TARGETS (1<<6) // Allow targeting only one target
 
 /**
  * Processes a generic target pattern and tries to match it to a client based
@@ -191,6 +198,333 @@ stock cmd_target(id, const arg[], flags = CMDTARGET_OBEY_IMMUNITY)
 	}
 
 	return player;
+}
+
+/**
+ * Same as above, but allow a more complex and flexible targeting system.
+ * cmd_target allows targeting a single client, if you want to target more use this function.
+ * Any special targeting type must be preceded by @, otherwise it will be treated as single-client and will call cmd_target. 
+ * New targeting types are: @all, @alive, @aim, @bots, @dead, @humans, @me, @!me, @ct, @t, @spec, @spectating. 
+ *
+ * @all        : target all players from server. 
+ * @alive      : target all alive player from server.
+ * @aim        : target the player that the admin is currently looking at.
+ * @bots       : target only bots.
+ * @dead       : target only dead players. 
+ * @humans     : target only human players.
+ * @me         : target the admin that write the command. 
+ * @!me        : target everyone in the server except the admin that use the command. 
+ * @ct         : target anyone from CT team.
+ * @t          : target anyone from TERRORIST team.
+ * @spec       : target anyone from SPECTATOR team.
+ * @spectating : target the player that the admin is currently spectating.
+ *
+ * @note Unlike cmd_target, here the pattern flags(CMDTARGET_*) are applied before any other check is performed.
+ * @note The array is filled only with fully valid players that passed all filterings. It works in get_players style.
+ * @note Work with clasic targeting ways: name/ip/authid/userid. This are checked after the special ones(@*).
+ * @note Some commands does not work on dead and/or spectator players(like amx_slay). In such case, a message is send to the admin.
+ * @note They are case-sensitive.
+ *
+ * @example new ArrayPlayers[MAX_PLAYERS], Num = cmd_target_ex(params), id; for(new i; i < Num; i++) { id = ArrayPlayers[i]; other_code_here }
+ * @example amx_slay @dead is not valid and will throw an error. amx_slay @alive is fully valid.
+ *
+ * @param id       	        	Client index of admin performing an action
+ * @param target    	        Target pattern
+ * @param cmd_flags             Filtering flags, see CMDTARGET_* constants above
+ * @param players_list          The array that will be filled with all players that match the patter specified 
+ * @param size                  The dimension of the array, you can use this to limit the number of players retured
+ *
+ * @return                      The number of players that are added into array. You need this to loop all players. It will return 0 in case no match is possible
+ */
+stock cmd_targetex(id, const target[], cmd_flags, players_list[MAX_PLAYERS], lang[] = "", len = -1)
+{
+	//server_print("cmd_targetex : intra in functie");
+	new players[32], flags[10], team[10], bool:parse_players, player, ignored_player, num;
+	if(target[0] == '@')	
+	{
+		//server_print("cmd_targetex : are @");
+		switch(target[1])
+		{
+			case 'a':
+			{
+				if(equal(target[1], "all"))
+				{
+					if(cmd_flags & CMDTARGET_NO_MULTIPLE_TARGETS)
+					{
+						console_print(id, "%l", "CANT_PERF_MULTIPLE");
+						return 0;
+					}
+					if(cmd_flags & CMDTARGET_SAFETY)
+					{
+						console_print(id, "%l", "CANT_PERF_SAFETY");
+						return 0;
+					}
+					if(cmd_flags & CMDTARGET_ONLY_ALIVE || cmd_flags & CMDTARGET_NO_SPEC)
+					{
+						copy(flags, charsmax(flags), "a")
+					}
+					
+					if( len > 0 )
+					{
+						copy(lang, len, "ALL");
+					}
+					
+					parse_players = true;
+				}
+				else if(equal(target[1], "alive"))
+				{
+					if(cmd_flags & CMDTARGET_NO_MULTIPLE_TARGETS)
+					{
+						console_print(id, "%l", "CANT_PERF_MULTIPLE");
+						return 0;
+					}
+					if(cmd_flags & CMDTARGET_SAFETY)
+					{
+						console_print(id, "%l", "CANT_PERF_SAFETY");
+						return 0;
+					}
+					parse_players = true;
+					copy(flags, charsmax(flags), "a");
+					
+					if( len > 0 )
+					{
+						copy(lang, len, "ALIVE");
+					}
+				}
+				else if(equal(target[1], "aim"))
+				{
+					new aim_target, body;
+					get_user_aiming(id, aim_target, body);
+					
+					if(1 <= aim_target <= MaxClients)
+					{
+						player = aim_target;
+					}
+				}
+			}
+			case 'b':
+			{
+				if(equal(target[1], "bots"))
+				{
+					if(cmd_flags & CMDTARGET_NO_MULTIPLE_TARGETS)
+					{
+						console_print(id, "%l", "CANT_PERF_MULTIPLE");
+						return 0;
+					}
+					parse_players = true;
+					copy(flags, charsmax(flags), "d");
+					if( len > 0 )
+					{
+						copy(lang, len, "BOTS");
+					}
+				}
+			}
+			case 'd':
+			{
+				if(!(cmd_flags & CMDTARGET_ONLY_ALIVE) && equal(target[1], "dead"))
+				{
+					if(cmd_flags & CMDTARGET_NO_MULTIPLE_TARGETS)
+					{
+						console_print(id, "%l", "CANT_PERF_MULTIPLE");
+						return 0;
+					}
+					if(cmd_flags & CMDTARGET_SAFETY)
+					{
+						console_print(id, "%l", "CANT_PERF_SAFETY");
+						return 0;
+					}
+					parse_players = true;
+					copy(flags, charsmax(flags), "b");
+					if( len > 0 )
+					{
+						copy(lang, len, "DEAD");
+					}
+				}
+			}
+			case 'h':
+			{
+				if(equal(target[1], "humans"))
+				{
+					if(cmd_flags & CMDTARGET_NO_MULTIPLE_TARGETS)
+					{
+						console_print(id, "%l", "CANT_PERF_MULTIPLE");
+						return 0;
+					}
+					if(cmd_flags & CMDTARGET_SAFETY)
+					{
+						console_print(id, "%l", "CANT_PERF_SAFETY");
+						return 0;
+					}
+					parse_players = true;
+					copy(flags, charsmax(flags), "c");
+					if( len > 0 )
+					{
+						copy(lang, len, "HUMANS");
+					}
+				}
+			}
+			case 'm':
+			{
+				if(equal(target[1], "me"))
+				{
+					player = id;
+				}
+			}
+			case '!':
+			{
+				if(equal(target[1], "!me"))
+				{
+					if(cmd_flags & CMDTARGET_NO_MULTIPLE_TARGETS)
+					{
+						console_print(id, "%l", "CANT_PERF_MULTIPLE");
+						return 0;
+					}
+					if(cmd_flags & CMDTARGET_SAFETY)
+					{
+						console_print(id, "%l", "CANT_PERF_SAFETY");
+						return 0;
+					}
+					parse_players = true;
+					ignored_player = id;
+					if( len > 0 )
+					{
+						copy(lang, len, "NOT_ME");
+					}
+				}
+			}
+			case 'c':
+			{
+				if(equal(target[1], "ct"))
+				{
+					if(cmd_flags & CMDTARGET_NO_MULTIPLE_TARGETS)
+					{
+						console_print(id, "%l", "CANT_PERF_MULTIPLE");
+						return 0;
+					}
+					if(cmd_flags & CMDTARGET_SAFETY)
+					{
+						console_print(id, "%l", "CANT_PERF_SAFETY");
+						return 0;
+					}
+					parse_players = true;
+					copy(flags, charsmax(flags), "e");
+					copy(team, charsmax(team), "CT");
+					if( len > 0 )
+					{
+						copy(lang, len, "CT_TEAM");
+					}
+				}
+			}
+			case 't':
+			{
+				if( equal(target[1], "t"))
+				{
+					if(cmd_flags & CMDTARGET_NO_MULTIPLE_TARGETS)
+					{
+						console_print(id, "%l", "CANT_PERF_MULTIPLE");
+						return 0;
+					}
+					if(cmd_flags & CMDTARGET_SAFETY)
+					{
+						console_print(id, "%l", "CANT_PERF_SAFETY");
+						return 0;
+					}
+					parse_players = true;
+					copy(flags, charsmax(flags), "e");
+					copy(team, charsmax(team), "TERRORIST");
+					if( len > 0 )
+					{
+						copy(lang, len, "T_TEAM");
+					}
+				}
+			}
+			case 's':
+			{
+				if(!(cmd_flags & CMDTARGET_NO_SPEC) && equal(target[1], "spec"))
+				{
+					if(cmd_flags & CMDTARGET_NO_MULTIPLE_TARGETS)
+					{
+						console_print(id, "%l", "CANT_PERF_MULTIPLE");
+						return 0;
+					}
+					parse_players = true;
+					copy(flags, charsmax(flags), "e");
+					copy(team, charsmax(team), "SPECTATOR");
+					if( len > 0 )
+					{
+						copy(lang, len, "SPECTATORS");
+					}
+				}
+				else if(equal(target[1], "spectating"))
+				{
+					new spectated_player = pev(id, pev_iuser2);
+					if(1 <= spectated_player <= MaxClients)
+					{
+						player = spectated_player;
+					}
+				} 
+			}
+		}
+	}
+	
+	if(parse_players)
+	{
+		//server_print("cmd_targetex : parseaza");
+		if(flags[0] != EOS)
+		{
+			if(team[0] != EOS)
+			{
+				get_players(players, num, flags, team);
+			}
+			else 
+			{
+				get_players(players, num, flags);
+			}
+		}
+		else 
+		{
+			get_players(players, num);
+		}
+		
+		new entry;
+		for(new i; i < num; i++)
+		{
+			player = players[i];
+
+			if(ignored_player != player)
+			{
+				if(cmd_flags & CMDTARGET_OBEY_IMMUNITY)
+				{
+					if((get_user_flags(player) & ADMIN_IMMUNITY) && ((cmd_flags & CMDTARGET_ALLOW_SELF) ? (id != player) : true))
+					{
+						continue;
+					}
+				}
+				
+				if(entry < charsmax(players_list))
+				{
+					players_list[entry++] = player;
+				}
+			}
+		}
+		return entry;
+	}
+	else 
+	{
+		//server_print("cmd_targetex : nu parseaza");
+		if(!player)
+		{
+			//server_print("cmd_targetex : cmd_target");
+			player = cmd_target(id, target, cmd_flags);
+			
+			if(!player)
+			{
+				return 0;
+			}
+		}
+		players_list[0] = player;
+		return 1;
+	}
 }
 
 /**

--- a/plugins/lang/admincmd.txt
+++ b/plugins/lang/admincmd.txt
@@ -1,6 +1,8 @@
 [en]
 ADMIN_KICK_1 = ADMIN: kick %s
 ADMIN_KICK_2 = ADMIN %s: kick %s
+CLIENT_KICKED = Client "%s" kicked
+CLIENTS_KICKED = %l kicked
 IP_REMOVED = Ip "%s" removed from ban list
 AUTHID_REMOVED = Authid "%s" removed from ban list
 ADMIN_UNBAN_1 = ADMIN: unban %s
@@ -14,10 +16,16 @@ PERM = permanently
 CLIENT_BANNED = Client "%s" banned
 ADMIN_SLAY_1 = ADMIN: slay %s
 ADMIN_SLAY_2 = ADMIN %s: slay %s
+ADMIN_SLAY_GROUP_1 = ADMIN : slay all %s
+ADMIN_SLAY_GROUP_2 = ADMIN %s: slay all %s
 CLIENT_SLAYED = Client "%s" slayed
+CLIENTS_SLAYED = %l slayed
 ADMIN_SLAP_1 = ADMIN: slap %s with %d damage
 ADMIN_SLAP_2 = ADMIN %s: slap %s with %d damage
+ADMIN_SLAP_GROUP_1 = ADMIN : slap all %s
+ADMIN_SLAP_GROUP_2 = ADMIN %s: slap all %s
 CLIENT_SLAPED = Client "%s" slaped with %d damage
+CLIENTS_SLAPED = %l slaped with %d damage
 MAP_NOT_FOUND = Map with that name not found or map is invalid
 ADMIN_MAP_1 = ADMIN: changelevel %s
 ADMIN_MAP_2 = ADMIN %s: changelevel %s

--- a/plugins/lang/common.txt
+++ b/plugins/lang/common.txt
@@ -17,8 +17,18 @@ CL_NOT_FOUND = Client with that name or userid not found
 CLIENT_IMM = Client "%s" has immunity
 CANT_PERF_DEAD = That action can't be performed on dead client "%s"
 CANT_PERF_BOT = That action can't be performed on bot "%s"
+CANT_PERF_SAFETY = That action can't be performed in safety conditions
+CANT_PERF_MULTIPLE = That action can't be performed on multiple targets
 ON = On
 OFF = Off
+ALL = all
+ALIVE = all alive
+BOTS = bots
+HUMANS = humans
+NOT_ME = all without him
+CT_TEAM = counter-terrorists team
+T_TEAM = terrorists team
+SPECTATORS = spectators
 
 [de]
 BACK = Zurueck


### PR DESCRIPTION
This is a feature stolen from SM, and it will introduce multi-targets commands.

There is a list of all new targeting types : @all        : target all players from server. 
@alive      : target all alive player from server.
@aim        : target the player that the admin is currently looking at.
@bots       : target only bots.
@dead       : target only dead players. 
@humans     : target only human players.
@me         : target the admin that write the command. 
@!me        : target everyone in the server except the admin that use the command. 
@ct         : target anyone from CT team.
@t          : target anyone from TERRORIST team.
@spec       : target anyone from SPECTATOR team.
@spectating : target the player that the admin is currently spectating.

AMXX is getting very old and we still don't have a multi targetting option... so there is my suggestion.
