### PR TITLE
Values by reference in forwards

### DIFF
--- a/amxmodx/CForward.h
+++ b/amxmodx/CForward.h
@@ -46,6 +46,8 @@ enum ForwardParam
 	FP_STRING,						// string
 	FP_STRINGEX,					// string; will be updated to the last function's value
 	FP_ARRAY,						// array; use the return value of prepareArray.
+	FP_CELL_BYREF,                  // cell; pass by reference
+	FP_FLOAT_BYREF,                 // float; pass by reference
 };
 
 // for prepareArray

--- a/amxmodx/amxmodx.cpp
+++ b/amxmodx/amxmodx.cpp
@@ -4118,9 +4118,13 @@ static cell AMX_NATIVE_CALL ExecuteForward(AMX *amx, cell *params)
 		LogError(amx, AMX_ERR_NATIVE, "Expected %d parameters, got %d", g_forwards.getParamsNum(id), count-2);
 		return 0;
 	}
+
+	ForwardParam param_type;
+
 	for (cell i=3; i<=count; i++)
 	{
-		if (g_forwards.getParamType(id, i-3) == FP_STRING)
+		param_type = g_forwards.getParamType(id, i-3);
+		if (param_type == FP_STRING)
 		{
 			char *tmp = get_amxstring(amx, params[i], 0, len);
 			cell num = len / sizeof(cell) + 1;
@@ -4131,7 +4135,14 @@ static cell AMX_NATIVE_CALL ExecuteForward(AMX *amx, cell *params)
 			}
 			strcpy((char *)allots[i-3].phys_addr, tmp);
 			ps[i-3] = (cell)allots[i-3].phys_addr;
-		} else {
+		}
+		else if (param_type == FP_CELL_BYREF)
+		{
+			cell *temp = get_amxaddr(amx, params[i]);
+			ps[i-3] = reinterpret_cast<cell>(temp);
+		}
+		else
+		{
 			ps[i-3] = *get_amxaddr(amx, params[i]);
 		}
 	}

--- a/plugins/include/amxconst.inc
+++ b/plugins/include/amxconst.inc
@@ -403,6 +403,7 @@ enum
 #define FP_FLOAT        1
 #define FP_STRING       2
 #define FP_ARRAY        4
+#define FP_VAL_BYREF    5   //cell & float are handled in the same way
 
 /**
  * @endsection

--- a/plugins/testsuite/fwdreftest1.sma
+++ b/plugins/testsuite/fwdreftest1.sma
@@ -1,0 +1,61 @@
+// vim: set ts=4 sw=4 tw=99 noet:
+//
+// AMX Mod X, based on AMX Mod by Aleksander Naszko ("OLO").
+// Copyright (C) The AMX Mod X Development Team.
+//
+// This software is licensed under the GNU General Public License, version 3 or higher.
+// Additional exceptions apply. For full license details, see LICENSE.txt or visit:
+//     https://alliedmods.net/amxmodx-license
+
+#include <amxmodx>
+
+new g_hMultiForward;
+new g_hOneForward;
+
+public plugin_init()
+{
+	register_plugin("Forward Test (Reference) (1)", "1.0", "Ni3znajomy");
+
+	g_hMultiForward = CreateMultiForward("multi_forward_reference", ET_IGNORE, FP_VAL_BYREF, FP_VAL_BYREF);
+	g_hOneForward = CreateOneForward(find_plugin_byfile("fwdreftest2.amxx"), "one_forward_reference", FP_VAL_BYREF, FP_VAL_BYREF);
+
+	register_srvcmd("fwdref_multi_test", "cmdForwardRefMultiTest");
+	register_srvcmd("fwdref_one_test", "cmdForwardRefOneTest");
+}
+
+public cmdForwardRefMultiTest()
+{
+	new sTestValue[10];
+
+	read_argv(1, sTestValue, charsmax(sTestValue));
+	new iTestValue1 = str_to_num(sTestValue);
+	
+	read_argv(2, sTestValue, charsmax(sTestValue));
+	new Float:fTestValue2 = str_to_float(sTestValue);
+
+	server_print("PLUGIN1: MULTI FORWARD START: val1 = %i | val2 = %f", iTestValue1, fTestValue2);
+	new dump;
+	ExecuteForward(g_hMultiForward, dump, iTestValue1, fTestValue2);
+	server_print("PLUGIN1: MULTI FORWARD END: val1 = %i | val2 = %f", iTestValue1, fTestValue2);
+}
+
+public cmdForwardRefOneTest()
+{
+	new sTestValue[10];
+
+	read_argv(1, sTestValue, charsmax(sTestValue));
+	new iTestValue1 = str_to_num(sTestValue);
+	
+	read_argv(2, sTestValue, charsmax(sTestValue));
+	new Float:fTestValue2 = str_to_float(sTestValue);
+
+	server_print("PLUGIN1: ONE FORWARD START: val1 = %i | val2 = %f", iTestValue1, fTestValue2);
+	new dump;
+	ExecuteForward(g_hOneForward, dump, iTestValue1, fTestValue2);
+	server_print("PLUGIN1: ONE FORWARD END: val1 = %i | val2 = %f", iTestValue1, fTestValue2);
+}
+
+
+
+
+

--- a/plugins/testsuite/fwdreftest2.sma
+++ b/plugins/testsuite/fwdreftest2.sma
@@ -1,0 +1,55 @@
+// vim: set ts=4 sw=4 tw=99 noet:
+//
+// AMX Mod X, based on AMX Mod by Aleksander Naszko ("OLO").
+// Copyright (C) The AMX Mod X Development Team.
+//
+// This software is licensed under the GNU General Public License, version 3 or higher.
+// Additional exceptions apply. For full license details, see LICENSE.txt or visit:
+//     https://alliedmods.net/amxmodx-license
+
+#include <amxmodx>
+
+new g_iTestValue1 = 0
+new Float:g_fTestValue2 = 0.0;
+
+public plugin_init()
+{
+	register_plugin("Forward Test (Reference) (2)", "1.0", "Ni3znajomy");
+
+	register_srvcmd("fwdref_set_test_values", "cmdSetTestValues");
+}
+
+public cmdSetTestValues()
+{
+	new sTestValue[10];
+
+	read_argv(1, sTestValue, charsmax(sTestValue));
+	g_iTestValue1 = str_to_num(sTestValue);
+	
+	read_argv(2, sTestValue, charsmax(sTestValue));
+	g_fTestValue2 = str_to_float(sTestValue);
+
+	server_print("PLUGIN2: TEST VALUES: val1 = %i | val2 = %f", g_iTestValue1, g_fTestValue2);
+}
+
+public multi_forward_reference(&val1, &Float:val2)
+{
+	server_print("PLUGIN2: MULTI FORWARD START: val1 = %i | val2 = %f", val1, val2);
+
+	val1 = g_iTestValue1;
+	val2 = g_fTestValue2;
+
+	server_print("PLUGIN2: MULTI FORWARD END: val1 = %i | val2 = %f", val1, val2);
+}
+
+public one_forward_reference(&val1, &Float:val2)
+{
+	server_print("PLUGIN2: ONE FORWARD START: val1 = %i | val2 = %f", val1, val2);
+
+	val1 = g_iTestValue1;
+	val2 = g_fTestValue2;
+
+	server_print("PLUGIN2: ONE FORWARD END: val1 = %i | val2 = %f", val1, val2);
+}
+
+

--- a/public/sdk/amxxmodule.h
+++ b/public/sdk/amxxmodule.h
@@ -2087,6 +2087,8 @@ enum ForwardParam
 	FP_STRING,						// string
 	FP_STRINGEX,					// string; will be updated to the last function's value
 	FP_ARRAY,						// array; use the return value of prepareArray.
+	FP_CELL_BYREF,                  // cell; pass by reference
+	FP_FLOAT_BYREF,                 // float; pass by reference
 };
 
 enum PlayerProp


### PR DESCRIPTION
This PR allow us to pass a value to forwards by reference. (In AMXX and its modules we pass pointer)

We have new param types:
For AMXX Core and its modules: ```FP_CELL_BYREF``` and ```FP_FLOAT_BYREF```
For AMXX Plugins: ```FP_VAL_BYREF```

```FP_VAL_BYREF``` is the synonym of ```FP_CELL_BYREF``` because int and floats values are handled in the same way in plugins. It may be confusing for people when they notice there's only ```FP_CELL_BYREF``` and there isn't ```FP_FLOAT_BYREF```, so I came with some generic name to refer both int and floats.

I've also done 2 test plugins to test this functionality. Some feedback would be nice. :smiley: 