### PR TITLE
Fix UTIL_ReplaceAll not properly tracking length.

### DIFF
--- a/amxmodx/util.cpp
+++ b/amxmodx/util.cpp
@@ -459,11 +459,14 @@ unsigned int UTIL_ReplaceAll(char *subject, size_t maxlength, const char *search
 	size_t searchLen = strlen(search);
 	size_t replaceLen = strlen(replace);
 
-	char *ptr = subject;
+	char *newptr, *ptr = subject;
 	unsigned int total = 0;
-	while ((ptr = UTIL_ReplaceEx(ptr, maxlength, search, searchLen, replace, replaceLen, caseSensitive)) != NULL)
+	while ((newptr = UTIL_ReplaceEx(ptr, maxlength, search, searchLen, replace, replaceLen, caseSensitive)) != NULL)
 	{
 		total++;
+		maxlength -= newptr - ptr;
+		ptr = newptr;
+
 		if (*ptr == '\0')
 		{
 			break;


### PR DESCRIPTION
Same as https://github.com/alliedmodders/sourcemod/pull/518

> UTIL_ReplaceEx returns a pointer to the character after the newly-replaced stuff. While maxlength is the size of the original buffer, the remaining space left needs to get reduced by how far forward we jumped after a replace happens.

Unlike SM, it doesn't impact the native (`replace_string`) which uses this function due output is copied again with proper max length, but still fixing this function is welcomed.

