### PR TITLE
Update hashers

### DIFF
--- a/third_party/hashing/hashers/crc32.cpp
+++ b/third_party/hashing/hashers/crc32.cpp
@@ -1,6 +1,6 @@
 // //////////////////////////////////////////////////////////
 // crc32.cpp
-// Copyright (c) 2014 Stephan Brumme. All rights reserved.
+// Copyright (c) 2014,2015 Stephan Brumme. All rights reserved.
 // see http://create.stephan-brumme.com/disclaimer.html
 //
 
@@ -374,7 +374,7 @@ void CRC32::add(const void* data, size_t numBytes)
 }
 
 
-/// return latest hash as 16 hex characters
+/// return latest hash as 8 hex characters
 const char* CRC32::getHash()
 {
   // convert hash to string
@@ -390,12 +390,21 @@ const char* CRC32::getHash()
   hashBuffer[5] = dec2hex[(m_hash >>  8) & 15];
   hashBuffer[6] = dec2hex[(m_hash >>  4) & 15];
   hashBuffer[7] = dec2hex[ m_hash        & 15];
-
   // zero-terminated string
   hashBuffer[8] = 0;
 
   // convert to std::string
-  return (const char *)hashBuffer;
+  return const_cast<const char *>(hashBuffer);
+}
+
+
+/// return latest hash as bytes
+void CRC32::getHash(unsigned char buffer[CRC32::HashBytes])
+{
+  buffer[0] = (m_hash >> 24) & 0xFF;
+  buffer[1] = (m_hash >> 16) & 0xFF;
+  buffer[2] = (m_hash >>  8) & 0xFF;
+  buffer[3] =  m_hash        & 0xFF;
 }
 
 

--- a/third_party/hashing/hashers/crc32.h
+++ b/third_party/hashing/hashers/crc32.h
@@ -1,6 +1,6 @@
 // //////////////////////////////////////////////////////////
 // crc32.h
-// Copyright (c) 2014 Stephan Brumme. All rights reserved.
+// Copyright (c) 2014,2015 Stephan Brumme. All rights reserved.
 // see http://create.stephan-brumme.com/disclaimer.html
 //
 
@@ -20,10 +20,18 @@
     while (more data available)
       crc32.add(pointer to fresh data, number of new bytes);
     std::string myHash3 = crc32.getHash();
+
+    Note:
+    You can find code for the faster Slicing-by-16 algorithm on my website, too:
+    http://create.stephan-brumme.com/crc32/
+    Its unrolled version is about twice as fast but its look-up table doubled in size as well.
   */
 class CRC32 //: public Hash
 {
 public:
+  /// hash is 4 bytes long
+  enum { HashBytes = 4 };
+
   /// same as reset()
   CRC32();
 
@@ -35,8 +43,10 @@ public:
   /// add arbitrary number of bytes
   void add(const void* data, size_t numBytes);
 
-  /// return latest hash as 16 hex characters
+  /// return latest hash as 8 hex characters
   const char* getHash();
+  /// return latest hash as bytes
+  void        getHash(unsigned char buffer[HashBytes]);
 
   /// restart
   void reset();

--- a/third_party/hashing/hashers/keccak.cpp
+++ b/third_party/hashing/hashers/keccak.cpp
@@ -1,6 +1,6 @@
 // //////////////////////////////////////////////////////////
 // keccak.cpp
-// Copyright (c) 2014 Stephan Brumme. All rights reserved.
+// Copyright (c) 2014,2015 Stephan Brumme. All rights reserved.
 // see http://create.stephan-brumme.com/disclaimer.html
 //
 
@@ -18,10 +18,10 @@ Keccak::Keccak(Bits bits)
 /// same as reset()
 void Keccak::changeBits(Bits bits)
 {
-	m_blockSize = (200 - 2 * (bits / 8));
-	m_bits = bits;
+  m_blockSize = (200 - 2 * (bits / 8));
+  m_bits = bits;
 
-	reset();
+  reset();
 }
 
 /// restart
@@ -225,11 +225,11 @@ void Keccak::processBuffer()
   // add a "1" byte
   m_buffer[offset++] = 1;
   // fill with zeros
-  while (offset < blockSize - 1)
+  while (offset < blockSize)
     m_buffer[offset++] = 0;
 
   // and add a single set bit
-  m_buffer[blockSize - 1] = 0x80;
+  m_buffer[blockSize - 1] |= 0x80;
 
   processBlock(m_buffer);
 }
@@ -257,8 +257,21 @@ const char* Keccak::getHash()
       result[written++] = dec2hex[oneByte >> 4];
       result[written++] = dec2hex[oneByte & 15];
     }
+
+  // Keccak224's last entry in m_hash provides only 32 bits instead of 64 bits
+  unsigned int remainder = m_bits - hashLength * 64;
+  unsigned int processed = 0;
+  while (processed < remainder)
+  {
+    // convert a byte to hex
+    unsigned char oneByte = (unsigned char) (m_hash[hashLength] >> processed);
+    result[written++] = dec2hex[oneByte >> 4];
+    result[written++] = dec2hex[oneByte & 15];
+
+    processed += 8;
+  }
   result[written] = 0;
-  return (const char *)result;
+  return const_cast<const char *>(result);
 }
 
 

--- a/third_party/hashing/hashers/keccak.h
+++ b/third_party/hashing/hashers/keccak.h
@@ -1,6 +1,6 @@
 // //////////////////////////////////////////////////////////
 // keccak.h
-// Copyright (c) 2014 Stephan Brumme. All rights reserved.
+// Copyright (c) 2014,2015 Stephan Brumme. All rights reserved.
 // see http://create.stephan-brumme.com/disclaimer.html
 //
 

--- a/third_party/hashing/hashers/md5.h
+++ b/third_party/hashing/hashers/md5.h
@@ -24,6 +24,9 @@
 class MD5 //: public Hash
 {
 public:
+  /// split into 64 byte blocks (=> 512 bits), hash is 16 bytes long
+  enum { BlockSize = 512 / 8, HashBytes = 16 };
+
   /// same as reset()
   MD5();
 
@@ -35,8 +38,10 @@ public:
   /// add arbitrary number of bytes
   void add(const void* data, size_t numBytes);
 
-  /// return latest hash as 16 hex characters
+  /// return latest hash as 32 hex characters
   const char* getHash();
+  /// return latest hash as bytes
+  void        getHash(unsigned char buffer[HashBytes]);
 
   /// restart
   void reset();
@@ -47,15 +52,14 @@ private:
   /// process everything left in the internal buffer
   void processBuffer();
 
-  /// split into 64 byte blocks (=> 512 bits)
-  enum { BlockSize = 512 / 8 };
-
   /// size of processed data in bytes
   uint64_t m_numBytes;
   /// valid bytes in m_buffer
   size_t   m_bufferSize;
   /// bytes not processed yet
   uint8_t  m_buffer[BlockSize];
+
+  enum { HashValues = HashBytes / 4 };
   /// hash, stored as integers
-  uint32_t m_hash[4];
+  uint32_t m_hash[HashValues];
 };

--- a/third_party/hashing/hashers/sha1.cpp
+++ b/third_party/hashing/hashers/sha1.cpp
@@ -1,6 +1,6 @@
 // //////////////////////////////////////////////////////////
 // sha1.cpp
-// Copyright (c) 2014 Stephan Brumme. All rights reserved.
+// Copyright (c) 2014,2015 Stephan Brumme. All rights reserved.
 // see http://create.stephan-brumme.com/disclaimer.html
 //
 
@@ -239,14 +239,14 @@ void SHA1::processBuffer()
     addLength = extra + paddedLength - BlockSize;
 
   // must be big endian
-  *addLength++ = (msgBits >> 56) & 0xFF;
-  *addLength++ = (msgBits >> 48) & 0xFF;
-  *addLength++ = (msgBits >> 40) & 0xFF;
-  *addLength++ = (msgBits >> 32) & 0xFF;
-  *addLength++ = (msgBits >> 24) & 0xFF;
-  *addLength++ = (msgBits >> 16) & 0xFF;
-  *addLength++ = (msgBits >>  8) & 0xFF;
-  *addLength   =  msgBits        & 0xFF;
+  *addLength++ = (unsigned char)((msgBits >> 56) & 0xFF);
+  *addLength++ = (unsigned char)((msgBits >> 48) & 0xFF);
+  *addLength++ = (unsigned char)((msgBits >> 40) & 0xFF);
+  *addLength++ = (unsigned char)((msgBits >> 32) & 0xFF);
+  *addLength++ = (unsigned char)((msgBits >> 24) & 0xFF);
+  *addLength++ = (unsigned char)((msgBits >> 16) & 0xFF);
+  *addLength++ = (unsigned char)((msgBits >>  8) & 0xFF);
+  *addLength   = (unsigned char)( msgBits        & 0xFF);
 
   // process blocks
   processBlock(m_buffer);
@@ -256,12 +256,30 @@ void SHA1::processBuffer()
 }
 
 
-/// return latest hash as 16 hex characters
+/// return latest hash as 40 hex characters
 const char* SHA1::getHash()
 {
-  // convert hash to string
-  static const char dec2hex[16+1] = "0123456789abcdef";
+  // compute hash (as raw bytes)
+  unsigned char rawHash[HashBytes];
+  getHash(rawHash);
 
+  // convert to hex string
+  static char result[40+1];
+  size_t written = 0;
+  for (int i = 0; i < HashBytes; i++)
+  {
+    static const char dec2hex[16+1] = "0123456789abcdef";
+    result[written++] = dec2hex[(rawHash[i] >> 4) & 15];
+    result[written++] = dec2hex[ rawHash[i]       & 15];
+  }
+  result[written] = 0;
+  return const_cast<const char *>(result);
+}
+
+
+/// return latest hash as bytes
+void SHA1::getHash(unsigned char buffer[SHA1::HashBytes])
+{
   // save old hash if buffer is partially filled
   uint32_t oldHash[HashValues];
   for (int i = 0; i < HashValues; i++)
@@ -270,28 +288,17 @@ const char* SHA1::getHash()
   // process remaining bytes
   processBuffer();
 
-  // create hash string
-  static char hashBuffer[HashValues*8+1];
-  size_t offset = 0;
+  unsigned char* current = buffer;
   for (int i = 0; i < HashValues; i++)
   {
-    hashBuffer[offset++] = dec2hex[(m_hash[i] >> 28) & 15];
-    hashBuffer[offset++] = dec2hex[(m_hash[i] >> 24) & 15];
-    hashBuffer[offset++] = dec2hex[(m_hash[i] >> 20) & 15];
-    hashBuffer[offset++] = dec2hex[(m_hash[i] >> 16) & 15];
-    hashBuffer[offset++] = dec2hex[(m_hash[i] >> 12) & 15];
-    hashBuffer[offset++] = dec2hex[(m_hash[i] >>  8) & 15];
-    hashBuffer[offset++] = dec2hex[(m_hash[i] >>  4) & 15];
-    hashBuffer[offset++] = dec2hex[ m_hash[i]        & 15];
+    *current++ = (m_hash[i] >> 24) & 0xFF;
+    *current++ = (m_hash[i] >> 16) & 0xFF;
+    *current++ = (m_hash[i] >>  8) & 0xFF;
+    *current++ =  m_hash[i]        & 0xFF;
 
     // restore old hash
     m_hash[i] = oldHash[i];
   }
-  // zero-terminated string
-  hashBuffer[offset] = 0;
-
-  // convert to std::string
-  return (const char *)hashBuffer;
 }
 
 

--- a/third_party/hashing/hashers/sha1.h
+++ b/third_party/hashing/hashers/sha1.h
@@ -1,6 +1,6 @@
 // //////////////////////////////////////////////////////////
 // sha1.h
-// Copyright (c) 2014 Stephan Brumme. All rights reserved.
+// Copyright (c) 2014,2015 Stephan Brumme. All rights reserved.
 // see http://create.stephan-brumme.com/disclaimer.html
 //
 
@@ -24,6 +24,9 @@
 class SHA1 //: public Hash
 {
 public:
+  /// split into 64 byte blocks (=> 512 bits), hash is 20 bytes long
+  enum { BlockSize = 512 / 8, HashBytes = 20 };
+
   /// same as reset()
   SHA1();
 
@@ -35,8 +38,10 @@ public:
   /// add arbitrary number of bytes
   void add(const void* data, size_t numBytes);
 
-  /// return latest hash as 16 hex characters
+  /// return latest hash as 40 hex characters
   const char* getHash();
+  /// return latest hash as bytes
+  void        getHash(unsigned char buffer[HashBytes]);
 
   /// restart
   void reset();
@@ -47,15 +52,14 @@ private:
   /// process everything left in the internal buffer
   void processBuffer();
 
-  /// split into 64 byte blocks (=> 512 bits)
-  enum { BlockSize = 512 / 8, HashValues = 5 };
-
   /// size of processed data in bytes
   uint64_t m_numBytes;
   /// valid bytes in m_buffer
   size_t   m_bufferSize;
   /// bytes not processed yet
   uint8_t  m_buffer[BlockSize];
+
+  enum { HashValues = HashBytes / 4 };
   /// hash, stored as integers
   uint32_t m_hash[HashValues];
 };

--- a/third_party/hashing/hashers/sha256.h
+++ b/third_party/hashing/hashers/sha256.h
@@ -1,6 +1,6 @@
 // //////////////////////////////////////////////////////////
 // sha256.h
-// Copyright (c) 2014 Stephan Brumme. All rights reserved.
+// Copyright (c) 2014,2015 Stephan Brumme. All rights reserved.
 // see http://create.stephan-brumme.com/disclaimer.html
 //
 
@@ -24,6 +24,9 @@
 class SHA256 //: public Hash
 {
 public:
+  /// split into 64 byte blocks (=> 512 bits), hash is 32 bytes long
+  enum { BlockSize = 512 / 8, HashBytes = 32 };
+
   /// same as reset()
   SHA256();
 
@@ -35,8 +38,10 @@ public:
   /// add arbitrary number of bytes
   void add(const void* data, size_t numBytes);
 
-  /// return latest hash as 16 hex characters
+  /// return latest hash as 64 hex characters
   const char* getHash();
+  /// return latest hash as bytes
+  void        getHash(unsigned char buffer[HashBytes]);
 
   /// restart
   void reset();
@@ -47,15 +52,14 @@ private:
   /// process everything left in the internal buffer
   void processBuffer();
 
-  /// split into 64 byte blocks (=> 512 bits)
-  enum { BlockSize = 512 / 8, HashValues = 8 };
-
   /// size of processed data in bytes
   uint64_t m_numBytes;
   /// valid bytes in m_buffer
   size_t   m_bufferSize;
   /// bytes not processed yet
   uint8_t  m_buffer[BlockSize];
+
+  enum { HashValues = HashBytes / 4 };
   /// hash, stored as integers
-  uint32_t m_hash[8];
+  uint32_t m_hash[HashValues];
 };

--- a/third_party/hashing/hashers/sha3.h
+++ b/third_party/hashing/hashers/sha3.h
@@ -1,6 +1,6 @@
 // //////////////////////////////////////////////////////////
 // sha3.h
-// Copyright (c) 2014 Stephan Brumme. All rights reserved.
+// Copyright (c) 2014,2015 Stephan Brumme. All rights reserved.
 // see http://create.stephan-brumme.com/disclaimer.html
 //
 


### PR DESCRIPTION
PR updates [Portable C++ Hashing Library](http://create.stephan-brumme.com/hash-library) to version 7 (from 5?).
Current version of library has a bug that causes returning incomplete hash for SHA3 & Keccak 224 bits.
This update fixes it.