### PR TITLE
add levenshtein distance

### DIFF
--- a/amxmodx/string.cpp
+++ b/amxmodx/string.cpp
@@ -1424,6 +1424,52 @@ static cell AMX_NATIVE_CALL fmt(AMX *amx, cell *params)
 	return 1;
 };
 
+/**
+ *
+ */
+static cell AMX_NATIVE_CALL levenshtein(AMX *amx, cell *params)
+{
+	int a_len, b_len, i, j, prev, tmp;
+	const char *a = get_amxstring(amx, params[1], 0, a_len);
+	const char *b = get_amxstring(amx, params[2], 1, b_len);
+
+	if (a_len == 0) {
+		return b_len;
+	}
+
+	if (b_len == 0) {
+		return a_len;
+	}
+
+	int column[a_len + 1];
+
+#define MIN2(a, b) (a) > (b) ? (b) : (a)
+#define MIN3(a, b, c) MIN2(c, MIN2(a, b))
+
+	for (i = 1; i < a_len + 1; ++i) {
+		column[i] = i;
+	}
+
+	for (j = 1; j < b_len + 1; ++j) {
+		column[0] = j;
+		prev = j - 1;
+		for (i = 1; i < a_len + 1; ++i) {
+			tmp = column[i];
+			column[i] = MIN3(
+				column[i] + 1,
+				column[i - 1] + 1,
+				prev + (a[i - 1] == b[j - 1] ? 0 : 1)
+			);
+			prev = tmp;
+		}
+	}
+
+#undef MIN3
+#undef MIN2
+
+	return column[a_len];
+}
+
 
 AMX_NATIVE_INFO string_Natives[] =
 {
@@ -1474,5 +1520,6 @@ AMX_NATIVE_INFO string_Natives[] =
 	{"str_to_float",	str_to_float},
 	{"float_to_str",	float_to_str},
 	{"vformat",			vformat},
+	{"levenshtein",		levenshtein},
 	{NULL,				NULL}
 };

--- a/plugins/include/string.inc
+++ b/plugins/include/string.inc
@@ -818,6 +818,14 @@ stock argbreak(const text[], left[], leftlen, right[], rightlen)
 native split_string(const source[], const split[], part[], partLen);
 
 /**
+ * @param str1		String being evaluated for Levenshtein distance
+ * @param str2		String being evaluated for Levenshtein distance
+ *
+ * @return			Levenshtein distance
+ */
+native levenshtein(const str1[], const str2[]);
+
+/**
  * It is basically strbreak but you have a delimiter that is more than one character in length. By Suicid3.
  *
  * @param szInput		Source input string.

--- a/plugins/testsuite/fuzzy_search_test.sma
+++ b/plugins/testsuite/fuzzy_search_test.sma
@@ -1,0 +1,52 @@
+// vim: set ts=4 sw=4 tw=99 noet:
+
+#include <amxmodx>
+
+public plugin_init()
+{
+	register_plugin("Fuzzy string search Test", "1.0", "")
+
+	register_srvcmd("test_lev", "Command_TestLevenshtein")
+}
+
+new TestCount = 0
+new FailCount = 0
+
+stock test_reset()
+{
+	TestCount = 0
+	FailCount = 0
+}
+
+stock test_result()
+{
+	if (FailCount == 0) {
+		server_print("All test passed");
+	} else {
+		server_print("%d failed", FailCount);
+	}
+}
+
+stock test(const test_name[], expected, const str1[], const str2[])
+{
+	new actual = levenshtein(str1, str2)
+	if (actual == expected) {
+		server_print("[%d](%s) PASS %d == %d", ++TestCount, test_name, actual, expected);
+	} else {
+		server_print("[%d](%s) FAIL %d == %d", ++TestCount, test_name, actual, expected);
+		FailCount++;
+	}
+}
+
+public Command_TestLevenshtein()
+{
+	test_reset()
+
+	test("equal strings", 0, "hello", "hello")
+	test("str1 empty", 4, "", "test")
+	test("str2 empty", 3, "tet", "")
+	test("d(debug, debugg)", 1, "debug", "debugg")
+	test("d(elephant, relevant)", 3, "elephant", "relevant")
+
+	test_result()
+}

--- a/support/PackageScript
+++ b/support/PackageScript
@@ -267,6 +267,7 @@ scripting_files = [
   'testsuite/textparse_test.sma',
   'testsuite/textparse_test.cfg',
   'testsuite/textparse_test.ini',
+  'testsuite/fuzzy_search_test.sma',
   'include/amxconst.inc',
   'include/amxmisc.inc',
   'include/amxmodx.inc',


### PR DESCRIPTION
The games are place where developer has deal with natural language. It would be nice to have tools for processing it. In this PR was implemented algorithm `Levenshtein distance`
 with memory usage `O(min(n, m)`) and time complexy `O(mn)`. 
There is list of tools which i am going to implement (If natural language processing tools are welcomed):
* `Soundex`
* `Metaphone`
* Improve Levenshtein distance (`Damerau–Levenshtein distance`)
* `Prefix tree (trie)`
