### PR TITLE
Revert access check for say command

### DIFF
--- a/plugins/adminchat.sma
+++ b/plugins/adminchat.sma
@@ -69,9 +69,9 @@ public plugin_cfg()
 	}
 }
 
-public cmdSayChat(id, level)
+public cmdSayChat(id)
 {
-	if (!access(id, level))
+	if (!access(id, g_AdminChatFlag))
 	{
 		return PLUGIN_CONTINUE
 	}


### PR DESCRIPTION
Server owners reported that admins without ADMIN_PASSWORD flag can use "say @" command. I proposed them to revert access check back to 1.8.2 code. Works fine, but its not a solution of problem. We need to fix flag manager.