### PR TITLE
Fix ancient register_menuid bug, using strstr instead of strcmp

### DIFF
--- a/amxmodx/CMenu.cpp
+++ b/amxmodx/CMenu.cpp
@@ -34,7 +34,7 @@ int MenuMngr::findMenuId(const char* name, AMX* amx)
 {
 	for (MenuIdEle* b = headid; b; b = b->next)
 	{
-		if ((!amx || !b->amx || amx == b->amx) && strstr(name,b->name.chars()))
+		if ((!amx || !b->amx || amx == b->amx) && !strcmp(name, b->name.chars()))
 			return b->id;
 	}
 	


### PR DESCRIPTION
If you registered a menu whose title was a superset of an already
registered menu, it wouldn't register a new handler but use the
handler of the subset title menu

Test plugin
```C
#include <amxmodx>
#include <amxmisc>

public plugin_init()
{
	register_menu("Test menu", 1, "test_menu");
	register_menu("Test menu advanced", 1, "test_menu_advanced");
	
	register_clcmd("say /testmenu", "show_test_menu");
	register_clcmd("say /testmenuadvanced", "show_test_menu_advanced");
}

public show_test_menu(id)
{
	show_menu(id, 1, "Test menu, press 1", -1, "Test menu");
	client_print(id, print_chat, "Showing Test menu");
}

public show_test_menu_advanced(id)
{
	show_menu(id, 1, "Test menu advanced, press 1", -1, "Test menu advanced");
	client_print(id, print_chat, "Showing Test menu advanced");
}

public test_menu(id, key)
{
	client_print(id, print_chat, "Test menu handler");
	
	return PLUGIN_HANDLED;
}

public test_menu_advanced(id, key)
{
	client_print(id, print_chat, "Test menu advanced handler");
	
	return PLUGIN_HANDLED;
}
```

(By the way amxmodx won't compile with the latest AMTL)