### PR TITLE
Fixed entity param changing in hamsandwich

### DIFF
--- a/modules/hamsandwich/DataHandler.h
+++ b/modules/hamsandwich/DataHandler.h
@@ -92,7 +92,7 @@ public:
 	Data(int type, void *ptr) : m_data(ptr), m_index(NULL), m_type(type)
 	{ /* nothing */ };
 
-	Data(int type, void *ptr, int *cptr) : m_data(ptr), m_index(NULL), m_type(type)
+	Data(int type, void *ptr, int *cptr) : m_data(ptr), m_index(cptr), m_type(type)
 	{ /* nothing */ };
 
 	~Data()


### PR DESCRIPTION
So, we want to change the param which contains entity index in pre hook:
```C++
#include <amxmodx>
#include <hamsandwich>

public plugin_init() {
	RegisterHam(Ham_TakeDamage, "player", "PlayerTakingDamage", .Post = false);
	RegisterHam(Ham_TakeDamage, "player", "PlayerTakenDamage", .Post = true);
}

public PlayerTakingDamage(this, inflictor, attacker, Float:damage, damageType) {
	server_print("PlayerTakingDamage: inflictor=%d, attacker=%d", inflictor, attacker);
	SetHamParamEntity(2, attacker);
}

public PlayerTakenDamage(this, inflictor, attacker, Float:damage, damageType) {
	server_print("PlayerTakenDamage: inflictor=%d, attacker=%d", inflictor, attacker);
}
```
We expect to get something like this:
```
PlayerTakingDamage: inflictor=116, attacker=1
PlayerTakenDamage: inflictor=1, attacker=1
```
But we get:
```
PlayerTakingDamage: inflictor=116, attacker=1
PlayerTakenDamage: inflictor=116, attacker=1
```
This PR fixes this problem. I think this is just a copy-paste typo.