### PR TITLE
Increased the cvar name size from 23 to 31.

### DIFF
--- a/amxmodx/CvarManager.cpp
+++ b/amxmodx/CvarManager.cpp
@@ -482,8 +482,8 @@ void CvarManager::OnConsoleCommand()
 	if (!indexToSearch)
 	{
 		print_srvconsole("\nManaged cvars:\n");
-		print_srvconsole("       %-24.23s %-24.23s %-18.17s %-8.7s %-8.7s %-8.7s\n", "NAME", "VALUE", "PLUGIN", "BOUND", "HOOKED", "BOUNDED");
-		print_srvconsole(" - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - \n");
+		print_srvconsole("       %-32.31s %-24.23s %-18.17s %-8.7s %-8.7s %-8.7s\n", "NAME", "VALUE", "PLUGIN", "BOUND", "HOOKED", "BOUNDED");
+		print_srvconsole(" - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - \n");
 	}
 
 	for (CvarsList::iterator iter = m_Cvars.begin(); iter != m_Cvars.end(); iter++)
@@ -497,7 +497,7 @@ void CvarManager::OnConsoleCommand()
 		{
 			if (!indexToSearch)
 			{
-				print_srvconsole(" [%3d] %-24.23s %-24.23s %-18.17s %-8.7s %-8.7s %-8.7s\n", ++index, ci->name.chars(), ci->var->string,
+				print_srvconsole(" [%3d] %-32.31s %-24.23s %-18.17s %-8.7s %-8.7s %-8.7s\n", ++index, ci->name.chars(), ci->var->string,
 								 ci->plugin.length() ? ci->plugin.chars() : "-",
 								 ci->binds.empty() ? "no" : "yes",
 								 ci->hooks.empty() ? "no" : "yes",


### PR DESCRIPTION
         [ 76] gal_game_crash_recreation        0
         [ 77] gal_srv_timelimit_restart        0
         [ 78] gal_srv_maxrounds_restart        0
         [ 79] gal_srv_winlimit_restart         0
         [ 80] gal_srv_fraglimit_restart        0
         [ 81] gal_endofmapvote                 1
         [ 82] gal_endofmapvote_expiration      0
         [ 83] gal_endofmapvote_start           1
         [ 84] gal_nextmap_change               0
         [ 85] gal_nextmap_votemap              1
         [ 86] gal_vote_mapchoices              5
         [ 87] gal_vote_mapchoices_next         1
         [ 88] gal_vote_duration                20
         [ 89] gal_vote_mapfile                 *
         [ 90] gal_vote_minplayers              0
         [ 91] gal_vote_midplayers              0
         [ 92] gal_nom_minplayers_control       0
         [ 93] gal_vote_minplayers_mapfile      addons
         [ 94] gal_vote_midplayers_mapfile      addons
         [ 95] gal_whitelist_minplayers         1
         [ 96] gal_whitelist_nom_block          1
         [ 97] gal_whitelist_block_out          0
         [ 98] gal_vote_whitelist_mapfile       addons
         [ 99] gal_vote_uniqueprefixes          0
         [100] gal_nom_playerallowance          2
         [101] gal_nom_cleaning                 0
         [102] gal_nom_mapfile                  *
         [103] gal_nom_prefixes                 1
         [104] gal_nom_qtyused                  0
         [105] gal_unnominate_disconnected      0
         [106] gal_vote_announcechoice          1
         [107] gal_emptyserver_wait             0
         [108] gal_emptyserver_change           0
         [109] gal_emptyserver_mapfile          addons
         [110] gal_sounds_mute                  0

        vs

         [ 76] gal_srv_move_cursor      6
         [ 77] gal_game_crash_recreati  0
         [ 78] gal_srv_timelimit_resta  0
         [ 79] gal_srv_maxrounds_resta  0
         [ 80] gal_srv_winlimit_restar  0
         [ 81] gal_srv_fraglimit_resta  0
         [ 82] gal_endofmapvote         1
         [ 83] gal_endofmapvote_expira  0
         [ 84] gal_endofmapvote_start   1
         [ 85] gal_nextmap_change       0
         [ 86] gal_nextmap_votemap      1
         [ 87] gal_vote_mapchoices      5
         [ 88] gal_vote_mapchoices_nex  1
         [ 89] gal_vote_duration        20
         [ 90] gal_vote_mapfile         *
         [ 91] gal_vote_minplayers      0
         [ 92] gal_vote_midplayers      0
         [ 93] gal_nom_minplayers_cont  0
         [ 94] gal_vote_minplayers_map  addons
         [ 95] gal_vote_midplayers_map  addons
         [ 96] gal_whitelist_minplayer  1
         [ 97] gal_whitelist_nom_block  1
         [ 98] gal_whitelist_block_out  0
         [ 99] gal_vote_whitelist_mapf  addons
         [100] gal_vote_uniqueprefixes  0
         [101] gal_nom_playerallowance  2
         [102] gal_nom_cleaning         0
         [103] gal_nom_mapfile          *
         [104] gal_nom_prefixes         1
         [105] gal_nom_qtyused          0
         [106] gal_unnominate_disconne  0
         [107] gal_vote_announcechoice  1
         [108] gal_emptyserver_wait     0
         [109] gal_emptyserver_change   0
         [110] gal_emptyserver_mapfile  addons

It did it because the command `amxx cvars` are cutting my cvars names too much. At the firs moment I tough the cvars max name allowed were 31 chars, as the maximum variable name length in pawn. However after a simple test I noticed it was not true and the maximum size is well bigger than this.

Therefore increasing the size from 23 to 31 (+8 chars) just because there is a plugins using cvars named about 25 chars does not seems the path to go to fix the real output put problem. Moreover I tough about creating another list (not table), after complete table, only within those extraordinary plugin's cvars.

On it would be just put all the information cut from the first table. For example, if the cvar A1, was cut on its name or value's contents, we just output it fully with not cuts.

      Managed cvars:
             NAME                     VALUE                    PLUGIN             BOUND    HOOKED   BOUNDED 
       - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
       [  1] Aaaaaaaaaaaaaaaaaaaaaaa  valueeeeeeeeeeeeeeeeeee  pluinnnnnnnnnnnnn  no       no       no      
       [  2] Aaaaaaaaaaa2             valueeeeeeeeeeeeeeeeeee  pluinnnnnnnnnnnnn  no       no       no      
       [  2] Aaaaaaaaaaaaaaaaaaa3     valueeeeeeeeeeeeeeeeeee  pluinnnnnnnnnnnnn  no       no       no      
      ...

      Cutted values:
            NAME - VALUE - PLUGIN
      [  1] Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1 - valueeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee - pluinnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn1
      [  2] Aaaaaaaaaaa2 - valueeeeeeeeeeeeeeeeeeeeeeee - pluinnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn2
      [  3] Aaaaaaaaaaaaaaaaaaa3 - valueeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee - pluinnnnnnnnnnnnnnnnnnnnnn3

      
