### PR TITLE
Fix returning strings from variadic functions (lost changes from previous commit)

### DIFF
--- a/compiler/libpc300/sc1.c
+++ b/compiler/libpc300/sc1.c
@@ -5308,6 +5308,18 @@ static symbol *fetchlab(char *name)
   return sym;
 }
 
+static int is_variadic(symbol *sym)
+{
+  arginfo *arg;
+
+  assert(sym->ident==iFUNCTN);
+  for (arg = sym->dim.arglist; arg->ident; arg++) {
+    if (arg->ident == iVARARGS)
+      return TRUE;
+  }
+  return FALSE;
+}
+
 /*  doreturn
  *
  *  Global references: rettype  (altered)
@@ -5412,7 +5424,11 @@ static void doreturn(void)
        * it stays on the heap for the moment, and it is removed -usually- at
        * the end of the expression/statement, see expression() in SC3.C)
        */
-      address(sub,sALT);                /* ALT = destination */
+      if (is_variadic(curfunc)) {
+        load_hidden_arg();
+      } else {
+        address(sub,sALT);           /* ALT = destination */
+      }
       arraysize=calc_arraysize(dim,numdim,0);
       memcopy(arraysize*sizeof(cell));  /* source already in PRI */
       /* moveto1(); is not necessary, callfunction() does a popreg() */


### PR DESCRIPTION
This re-adds the changes in `sc1.c` commited from #121 + 567fbcd5179ba582492c3d5cdc2ec864a8c1822b + ccf919c58cdefcb0ef917541e5238e6deb5211e8.

It looks like such changes have been lost in 520493fab177830c63809fb4b29b2a317773b166.

Thanks to PRoSToTeM@ for reporting me the issue.