### PR TITLE
Fix UTF-8 character parsing due to improper casting

### DIFF
--- a/amxmodx/string.cpp
+++ b/amxmodx/string.cpp
@@ -708,7 +708,7 @@ static cell AMX_NATIVE_CALL parse(AMX *amx, cell *params) /* 3 param */
 			c = *get_amxaddr(amx, params[iarg++]);
 			
 			while (c-- && *arg)
-				*cptr++ = (cell)*arg++;
+				*cptr++ = (unsigned char)*arg++;
 			*cptr = 0;
 		}
 	}
@@ -1006,7 +1006,7 @@ static cell AMX_NATIVE_CALL argparse(AMX *amx, cell *params)
 			break;
 
 		if (size_t(bufpos - buffer) < buflen)
-			*bufpos++ = input[i];
+			*bufpos++ = (unsigned char)input[i];
 	}
 
 	*bufpos = '\0';
@@ -1068,7 +1068,7 @@ do_copy:
 				{
 					start = &(string[i]);
 					while (end--)
-						*right++ = (cell)*start++;
+						*right++ = (unsigned char)*start++;
 				}
 				*right = '\0';
 				return 1;


### PR DESCRIPTION
Upcasting of -ve signed characters (char) to signed integers (cell) results in -ve signed integers which don't represent valid printable characters.
eg. UTF-8 Character '中' (0xE4 0xB8 0xAD) when casted results in 0xFFFFFFE4 0xFFFFFFB8 0xFFFFFFAD which are not valid printable characters.
Simple Characters like '4' (0x34) don't get affected because they are +ve signed characters.