### PR TITLE
Fix Warning from MSVC: 'Double to Float precision loss'

### DIFF
--- a/amxmodx/float.cpp
+++ b/amxmodx/float.cpp
@@ -20,7 +20,7 @@
 #include <stdlib.h>     /* for atof() */
 #include <stdio.h>      /* for NULL */
 #include <assert.h>
-#include <math.h>
+#include <cmath>
 
 // this file does not include amxmodx.h, so we have to include the memory manager here
 #ifdef MEMORY_TEST


### PR DESCRIPTION
Using platform toolkit 140_xp

1>..\float.cpp(322): warning C4244: '=': conversion from 'double' to 'float', possible loss of data
1>..\float.cpp(339): warning C4244: '=': conversion from 'double' to 'float', possible loss of data
1>..\float.cpp(356): warning C4244: '=': conversion from 'double' to 'float', possible loss of data
1>..\float.cpp(371): warning C4244: '=': conversion from 'double' to 'float', possible loss of data
1>..\float.cpp(387): warning C4244: '=': conversion from 'double' to 'float', possible loss of data
1>..\float.cpp(403): warning C4244: '=': conversion from 'double' to 'float', possible loss of data
1>..\float.cpp(422): warning C4244: '=': conversion from 'double' to 'float', possible loss of data
1>..\float.cpp(439): warning C4244: '=': conversion from 'double' to 'float', possible loss of data
1>..\float.cpp(455): warning C4244: '=': conversion from 'double' to 'float', possible loss of data
1>..\float.cpp(471): warning C4244: '=': conversion from 'double' to 'float', possible loss of data