### PR TITLE
Fix a potential crash in ArrayClone for too large arrays

### DIFF
--- a/amxmodx/datastructs.cpp
+++ b/amxmodx/datastructs.cpp
@@ -99,7 +99,15 @@ static cell AMX_NATIVE_CALL ArrayClone(AMX* amx, cell* params)
 		return 0;
 	}
 
-	return ArrayHandles.clone(vec->clone());
+	auto data = vec->clone();
+
+	if (!data)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Failed to clone array. Out of memory.");
+		return 0;
+	}
+
+	return ArrayHandles.clone(data);
 }
 
 // native ArrayGetArray(Array:which, item, any:output[], size = -1);

--- a/amxmodx/datastructs.h
+++ b/amxmodx/datastructs.h
@@ -135,6 +135,13 @@ public:
 		array->m_AllocSize = m_AllocSize;
 		array->m_Size = m_Size;
 		array->m_Data = (cell *)malloc(sizeof(cell)* m_BlockSize * m_AllocSize);
+
+		if (!array->m_Data)
+		{
+			delete array;
+			return nullptr;
+		}
+
 		memcpy(array->m_Data, m_Data, sizeof(cell)* m_BlockSize * m_Size);
 		return array;
 	}


### PR DESCRIPTION
If there is not enough memory to clone an array, throw an error instead of potentially crashing the server.

Related to f78fda6d9c995eced7d6a28f8f2096f21b2fd49a.