### PR TITLE
Add Array/Stack blocksize getter

### DIFF
--- a/amxmodx/datastructs.cpp
+++ b/amxmodx/datastructs.cpp
@@ -893,6 +893,22 @@ static cell AMX_NATIVE_CALL ArrayFindValue(AMX* amx, cell* params)
 	return -1;
 }
 
+// native ArrayGetBlockSize(Array:which); 
+static cell AMX_NATIVE_CALL ArrayGetBlockSize(AMX *amx, cell *params)
+{
+	enum args { arg_count, arg_handle };
+
+	auto vec = ArrayHandles.lookup(params[arg_handle]);
+
+	if (!vec)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Invalid array handle provided (%d)", params[arg_handle]);
+		return -1;
+	}
+
+	return vec->blocksize();
+}
+
 AMX_NATIVE_INFO g_DataStructNatives[] = 
 {
 	{ "ArrayCreate"            , ArrayCreate },
@@ -923,5 +939,6 @@ AMX_NATIVE_INFO g_DataStructNatives[] =
 	{ "ArraySortEx"            , ArraySortEx },
 	{ "ArrayFindString"        , ArrayFindString },
 	{ "ArrayFindValue"         , ArrayFindValue },
+	{ "ArrayGetBlockSize"      , ArrayGetBlockSize },
 	{ nullptr                  , nullptr }
 };

--- a/amxmodx/stackstructs.cpp
+++ b/amxmodx/stackstructs.cpp
@@ -229,6 +229,23 @@ static cell AMX_NATIVE_CALL IsStackEmpty(AMX* amx, cell* params)
 	return vec->size() == 0;
 }
 
+// native GetStackBlockSize(Stack:handle); 
+static cell AMX_NATIVE_CALL GetStackBlockSize(AMX *amx, cell *params)
+{
+	enum args { arg_count, arg_handle };
+
+	auto vec = ArrayHandles.lookup(params[arg_handle]);
+
+	if (!vec)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Invalid array handle provided (%d)", params[arg_handle]);
+		return -1;
+	}
+
+	return vec->blocksize();
+}
+
+
 // native DestroyStack(&Stack:which);
 static cell AMX_NATIVE_CALL DestroyStack(AMX* amx, cell* params)
 {
@@ -252,14 +269,15 @@ static cell AMX_NATIVE_CALL DestroyStack(AMX* amx, cell* params)
 
 AMX_NATIVE_INFO g_StackNatives[] =
 {
-	{ "CreateStack",     CreateStack     },
-	{ "IsStackEmpty",    IsStackEmpty    },
-	{ "PopStackArray",   PopStackArray   },
-	{ "PopStackCell",    PopStackCell    },
-	{ "PopStackString",  PopStackString  },
-	{ "PushStackArray",  PushStackArray  },
-	{ "PushStackCell",   PushStackCell   },
-	{ "PushStackString", PushStackString },
-	{ "DestroyStack",    DestroyStack    },
-	{ nullptr,           nullptr         },
+	{ "CreateStack",       CreateStack     },
+	{ "IsStackEmpty",      IsStackEmpty    },
+	{ "GetStackBlockSize", GetStackBlockSize },
+	{ "PopStackArray",     PopStackArray   },
+	{ "PopStackCell",      PopStackCell    },
+	{ "PopStackString",    PopStackString  },
+	{ "PushStackArray",    PushStackArray  },
+	{ "PushStackCell",     PushStackCell   },
+	{ "PushStackString",   PushStackString },
+	{ "DestroyStack",      DestroyStack    },
+	{ nullptr,             nullptr         },
 };

--- a/plugins/include/cellarray.inc
+++ b/plugins/include/cellarray.inc
@@ -407,6 +407,17 @@ native ArrayFindString(Array:which, const item[]);
 native ArrayFindValue(Array:which, any:item);
 
 /**
+ * Returns the blocksize the array was created with.
+ *
+ * @param which         Array handle
+ *
+ * @return              The blocksize of the array
+ * @error               If an invalid handle is provided an error will be
+ *                      thrown.
+ */
+ native ArrayGetBlockSize(Array:which);
+
+/**
  * Creates a special handle that can be passed to a string format routine for
  * printing as a string (with the %a format option).
  *

--- a/plugins/include/cellstack.inc
+++ b/plugins/include/cellstack.inc
@@ -139,6 +139,17 @@ native bool:PopStackArray(Stack:handle, any:buffer[], size = -1);
 native bool:IsStackEmpty(Stack:handle);
 
 /**
+ * Returns the blocksize the stack was created with.
+ *
+ * @param handle        Stack handle
+ *
+ * @return              The blocksize of the stack
+ * @error               If an invalid handle is provided an error will be
+ *                      thrown.
+ */
+ native GetStackBlockSize(Stack:handle);
+
+/**
  * Pops a value off a stack, ignoring it completely.
  *
  * @param handle    Stack handle


### PR DESCRIPTION
This adds `ArrayGetBlockSize` and `GetStackBlockSize` to get the `blocksize` the array or stack was created with. Useful when dealing with array handles from other plugins you didn't create yourself.`

Related to #76.