### PR TITLE
Add RequestFrame() native

### DIFF
--- a/amxmodx/CFrameAction.h
+++ b/amxmodx/CFrameAction.h
@@ -3,6 +3,7 @@
 
 #include "amxmodx.h"
 #include <amtl/am-deque.h>
+#include <amtl/am-autoptr.h>
 
 class CFrameActionMngr
 {
@@ -46,15 +47,14 @@ public:
 		int callbacksToRun = m_requestedFrames.length();
 		while (callbacksToRun--)
 		{
-			auto action = m_requestedFrames.popFrontCopy();
+			ke::AutoPtr<CFrameAction> action = ke::Move(m_requestedFrames.front());
+			m_requestedFrames.popFront();
 			action->Execute();
-
-			delete action;
 		}
 	}
 
 private:
-	ke::Deque<CFrameAction *> m_requestedFrames;
+	ke::Deque<ke::AutoPtr<CFrameAction>> m_requestedFrames;
 
 };
 

--- a/amxmodx/CFrameAction.h
+++ b/amxmodx/CFrameAction.h
@@ -1,0 +1,62 @@
+#ifndef FRAMEACTION_H
+#define FRAMEACTION_H
+
+#include "amxmodx.h"
+#include "CQueue.h"
+
+class CFrameActionMngr
+{
+public:
+
+	class CFrameAction
+	{
+	public:
+		CFrameAction(int callbackForward, cell callbackData) :
+			m_callbackForward(callbackForward),
+			m_callbackData(callbackData)
+		{
+
+		}
+
+		~CFrameAction()
+		{
+			unregisterSPForward(m_callbackForward);
+		}
+
+		void Execute()
+		{
+			executeForwards(m_callbackForward, m_callbackData);
+		}
+
+	public:
+		int m_callbackForward;
+		cell m_callbackData;
+	};
+
+public:
+
+	void AddFrameAction(int callbackForward, cell callbackData)
+	{
+		m_requestedFrames.push(new CFrameAction(callbackForward, callbackData));
+	}
+
+	void ExecuteFrameCallbacks()
+	{
+		// In case a frame callback requests another frame, newly added frames won't be executed this way
+		int callbacksToRun = m_requestedFrames.size();
+		while (callbacksToRun--)
+		{
+			CFrameAction *action = m_requestedFrames.front();
+			m_requestedFrames.pop();
+
+			action->Execute();
+			delete action;
+		}
+	}
+
+private:
+	CQueue<CFrameAction *> m_requestedFrames;
+
+};
+
+#endif // FRAMEACTION_H

--- a/amxmodx/CFrameAction.h
+++ b/amxmodx/CFrameAction.h
@@ -2,7 +2,7 @@
 #define FRAMEACTION_H
 
 #include "amxmodx.h"
-#include "CQueue.h"
+#include <amtl/am-deque.h>
 
 class CFrameActionMngr
 {
@@ -37,25 +37,24 @@ public:
 
 	void AddFrameAction(int callbackForward, cell callbackData)
 	{
-		m_requestedFrames.push(new CFrameAction(callbackForward, callbackData));
+		m_requestedFrames.append(new CFrameAction(callbackForward, callbackData));
 	}
 
 	void ExecuteFrameCallbacks()
 	{
 		// In case a frame callback requests another frame, newly added frames won't be executed this way
-		int callbacksToRun = m_requestedFrames.size();
+		int callbacksToRun = m_requestedFrames.length();
 		while (callbacksToRun--)
 		{
-			CFrameAction *action = m_requestedFrames.front();
-			m_requestedFrames.pop();
-
+			auto action = m_requestedFrames.popFrontCopy();
 			action->Execute();
+
 			delete action;
 		}
 	}
 
 private:
-	CQueue<CFrameAction *> m_requestedFrames;
+	ke::Deque<CFrameAction *> m_requestedFrames;
 
 };
 

--- a/amxmodx/amxmodx.cpp
+++ b/amxmodx/amxmodx.cpp
@@ -4636,6 +4636,24 @@ static cell AMX_NATIVE_CALL AutoExecConfig(AMX *amx, cell *params)
 	return 1;
 }
 
+//native RequestFrame(const callback[], any:data);
+static cell AMX_NATIVE_CALL RequestFrame(AMX *amx, cell *params)
+{
+	int len;
+	const char *funcName = get_amxstring(amx, params[1], 0, len);
+
+	int func = registerSPForwardByName(amx, funcName, FP_CELL, FP_DONE);
+	if (func < 0)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Function \"%s\" was not found", funcName);
+		return 0;
+	}
+
+	g_frameActionMngr.AddFrameAction(func, params[2]);
+
+	return 0;
+}
+
 static cell AMX_NATIVE_CALL is_rukia_a_hag(AMX *amx, cell *params)
 {
 	return 1;
@@ -4834,6 +4852,7 @@ AMX_NATIVE_INFO amxmodx_Natives[] =
 	{"PrepareArray",			PrepareArray},
 	{"ShowSyncHudMsg",			ShowSyncHudMsg},
 	{"AutoExecConfig",			AutoExecConfig},
+	{"RequestFrame",			RequestFrame},
 	{"is_rukia_a_hag",			is_rukia_a_hag},
 	{NULL,						NULL}
 };

--- a/amxmodx/amxmodx.cpp
+++ b/amxmodx/amxmodx.cpp
@@ -4651,7 +4651,7 @@ static cell AMX_NATIVE_CALL RequestFrame(AMX *amx, cell *params)
 
 	g_frameActionMngr.AddFrameAction(func, params[2]);
 
-	return 0;
+	return 1;
 }
 
 static cell AMX_NATIVE_CALL is_rukia_a_hag(AMX *amx, cell *params)

--- a/amxmodx/amxmodx.h
+++ b/amxmodx/amxmodx.h
@@ -51,6 +51,7 @@
 #include "amxxlog.h"
 #include "CvarManager.h"
 #include "CoreConfig.h"
+#include "CFrameAction.h"
 #include <amxmodx_version.h>
 #include <HLTypeConversion.h>
 
@@ -166,6 +167,7 @@ struct fakecmd_t
 extern CLog g_log;
 extern CPluginMngr g_plugins;
 extern CTaskMngr g_tasksMngr;
+extern CFrameActionMngr g_frameActionMngr;
 extern CPlayer g_players[33];
 extern CPlayer* mPlayer;
 extern CmdMngr g_commands;

--- a/amxmodx/meta_api.cpp
+++ b/amxmodx/meta_api.cpp
@@ -71,6 +71,7 @@ CPlayer g_players[33];
 CPlayer* mPlayer;
 CPluginMngr g_plugins;
 CTaskMngr g_tasksMngr;
+CFrameActionMngr g_frameActionMngr;
 CmdMngr g_commands;
 CFlagManager FlagMan;
 EventsMngr g_events;
@@ -1216,6 +1217,8 @@ void C_StartFrame_Post(void)
 		g_memreport_count++;
 	}
 #endif // MEMORY_TEST
+
+	g_frameActionMngr.ExecuteFrameCallbacks();
 
 	if (g_task_time > gpGlobals->time)
 		RETURN_META(MRES_IGNORED);

--- a/amxmodx/msvc12/amxmodx_mm.vcxproj
+++ b/amxmodx/msvc12/amxmodx_mm.vcxproj
@@ -376,6 +376,7 @@
     <ClInclude Include="..\trie_natives.h" />
     <ClInclude Include="..\..\public\sdk\amxxmodule.h" />
     <ClInclude Include="..\..\public\sdk\moduleconfig.h" />
+    <ClInclude Include="..\CFrameAction.h">
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\version.rc" />

--- a/amxmodx/msvc12/amxmodx_mm.vcxproj.filters
+++ b/amxmodx/msvc12/amxmodx_mm.vcxproj.filters
@@ -500,6 +500,9 @@
     <ClInclude Include="..\CoreConfig.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\CFrameAction.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\version.rc">

--- a/plugins/include/amxmodx.inc
+++ b/plugins/include/amxmodx.inc
@@ -3290,5 +3290,18 @@ forward OnAutoConfigsBuffered();
  */
 native AutoExecConfig(bool:autoCreate = true, const name[] = "", const folder[] = "");
 
+/**
+ * Creates a single use hook for the next frame.
+ *
+ * @param callback      Function to be executed on the next frame.
+ * @param data          Optional data to be passed to the callback function.
+ *
+ * @note                Callback function prototype:
+ *                          public function(data)
+ *
+ * @noreturn
+ */
+native RequestFrame(const callback[], any:data = 0);
+
 // Always keep this at the bottom of this file
 #include <message_stocks>

--- a/plugins/testsuite/request_frame_test.sma
+++ b/plugins/testsuite/request_frame_test.sma
@@ -1,0 +1,66 @@
+#include <amxmodx>
+#include <fakemeta>
+
+/*
+Expected console output:
+
+Command_Test - Frame: X
+FrameCallback1 - Frame: X + 1 Data: 100
+FrameCallback2 - Frame: X + 2 Data: 200
+FrameCallback3 - Frame: X + 2 Data: 300
+FrameCallback4 - Frame: X + 3 Data: 400
+FrameCallback4 - Frame: X + 3 Data: 500
+*/
+
+
+new g_frameNumber = 0;
+
+public plugin_precache()
+{
+	register_forward(FM_StartFrame, "OnStartFrame", false);
+}
+
+public plugin_init()
+{
+	register_plugin("RequestFrame() Test", "1.0.0", "KliPPy");
+
+	register_concmd("request_frame_test", "Command_Test");
+}
+
+public OnStartFrame()
+{
+	g_frameNumber++;
+}
+
+public Command_Test()
+{
+	console_print(0, "Command_Test - Frame: %d", g_frameNumber);
+
+	RequestFrame("FrameCallback1", 100);
+}
+
+public FrameCallback1(data)
+{
+	console_print(0, "FrameCallback1 - Frame: %d Data: %d", g_frameNumber, data);
+
+	RequestFrame("FrameCallback2", 200);
+	RequestFrame("FrameCallback3", 300);
+}
+
+public FrameCallback2(data)
+{
+	console_print(0, "FrameCallback2 - Frame: %d Data: %d", g_frameNumber, data);
+	RequestFrame("FrameCallback4", 400);
+}
+
+public FrameCallback3(data)
+{
+	console_print(0, "FrameCallback3 - Frame: %d Data: %d", g_frameNumber, data);
+	RequestFrame("FrameCallback4", 500);
+}
+
+public FrameCallback4(data)
+{
+	console_print(0, "FrameCallback4 - Frame: %d Data: %d", g_frameNumber, data);
+}
+

--- a/support/PackageScript
+++ b/support/PackageScript
@@ -267,6 +267,7 @@ scripting_files = [
   'testsuite/textparse_test.sma',
   'testsuite/textparse_test.cfg',
   'testsuite/textparse_test.ini',
+  'testsuite/request_frame_test.sma',
   'include/amxconst.inc',
   'include/amxmisc.inc',
   'include/amxmodx.inc',


### PR DESCRIPTION
This makes it easy to offset execution to the next frame without manually hooking StartFrame or using other workarounds to do so.
```
/**
 * Creates a single use hook for the next frame.
 *
 * @param callback      Function to be executed on the next frame.
 * @param data          Optional data to be passed to the callback function.
 *
 * @note                Callback function prototype:
 *                          function(data)
 *
 * @noreturn
 */
native RequestFrame(const callback[], any:data = 0);
```

Note: It may be better to hook `void _Host_Frame(float time)` and execute frame hooks in there. Also possibly provide an easy way for other modules to hook that too in the future. I would like feedback on this matter.

Test plugin provided in *plugins/testsuite/request_frame_test.sma*.