### PR TITLE
Introduce Trie Iterators

### DIFF
--- a/amxmodx/meta_api.cpp
+++ b/amxmodx/meta_api.cpp
@@ -410,6 +410,7 @@ int	C_Spawn(edict_t *pent)
 
 	ArrayHandles.clear();
 	TrieHandles.clear();
+	TrieIterHandles.clear();
 	TrieSnapshotHandles.clear();
 	DataPackHandles.clear();
 	TextParsersHandles.clear();

--- a/amxmodx/natives_handles.h
+++ b/amxmodx/natives_handles.h
@@ -45,6 +45,11 @@ class NativeHandle
 			m_handles.clear();
 		}
 
+		size_t size()
+		{
+			return m_handles.length();
+		}
+
 		T *lookup(int handle)
 		{
 			--handle;

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -541,6 +541,35 @@ static cell AMX_NATIVE_CALL TrieIterMore(AMX *amx, cell *params)
 	return 1;
 }
 
+// native TrieIterGetKey(TrieIter:handle, key[], outputsize)
+static cell AMX_NATIVE_CALL TrieIterGetKey(AMX *amx, cell *params)
+{
+	enum args { arg_count, arg_handle, arg_output, arg_outputsize };
+
+	auto handle = TrieIterHandles.lookup(params[arg_handle]);
+
+	if (!handle)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Invalid map iterator handle provided (%d)", params[arg_handle]);
+		return 0;
+	}
+
+	auto iter = handle->iter;
+
+	if (!iter)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Closed map iterator handle provided (%d)", params[arg_handle]);
+		return 0;
+	}
+
+	if (iter->empty())
+	{
+		*get_amxaddr(amx, params[arg_output]) = '\0';
+		return 0;
+	}
+
+	return set_amxstring_utf8(amx, params[arg_output], (*iter)->key.chars(), (*iter)->key.length(), params[arg_outputsize]);
+}
 
 AMX_NATIVE_INFO trie_Natives[] =
 {
@@ -569,6 +598,7 @@ AMX_NATIVE_INFO trie_Natives[] =
 	{ "TrieIterCreate"           ,	TrieIterCreate },
 	{ "TrieIterEnded"            ,	TrieIterEnded },
 	{ "TrieIterMore"             ,	TrieIterMore },
+	{ "TrieIterGetKey"           ,	TrieIterGetKey },
 
 	{ nullptr                    ,	nullptr}
 };

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -10,6 +10,7 @@
 #include "trie_natives.h"
 
 NativeHandle<CellTrie> TrieHandles;
+NativeHandle<CellTrieIter> TrieIterHandles;
 NativeHandle<TrieSnapshot> TrieSnapshotHandles;
 
 // native Trie:TrieCreate();

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -593,6 +593,35 @@ static cell AMX_NATIVE_CALL TrieIterGetSize(AMX *amx, cell *params)
 	return handle->trie->map.elements();
 }
 
+// native bool:TrieIterGetCell(TrieIter:handle, &any:value)
+static cell AMX_NATIVE_CALL TrieIterGetCell(AMX *amx, cell *params)
+{
+	enum args { arg_count, arg_handle, arg_outputvalue };
+
+	auto handle = TrieIterHandles.lookup(params[arg_handle]);
+
+	if (!handle)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Invalid map iterator handle provided (%d)", params[arg_handle]);
+		return 0;
+	}
+
+	if (!handle->iter)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Closed map iterator handle provided (%d)", params[arg_handle]);
+		return 0;
+	}
+
+	if (handle->iter->empty() || !(*handle->iter)->value.isCell())
+	{
+		return false;
+	}
+
+	*get_amxaddr(amx, params[arg_outputvalue]) = (*handle->iter)->value.cell_();
+
+	return true;
+}
+
 
 AMX_NATIVE_INFO trie_Natives[] =
 {
@@ -623,6 +652,7 @@ AMX_NATIVE_INFO trie_Natives[] =
 	{ "TrieIterMore"             ,	TrieIterMore },
 	{ "TrieIterGetKey"           ,	TrieIterGetKey },
 	{ "TrieIterGetSize"          ,  TrieIterGetSize },
+	{ "TrieIterGetCell"          ,  TrieIterGetCell },
 
 	{ nullptr                    ,	nullptr}
 };

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -532,8 +532,8 @@ static cell AMX_NATIVE_CALL TrieIterEnded(AMX *amx, cell *params)
 	return handle->iter->empty();
 }
 
-// native TrieIterMore(TrieIter:handle)
-static cell AMX_NATIVE_CALL TrieIterMore(AMX *amx, cell *params)
+// native TrieIterNext(TrieIter:handle)
+static cell AMX_NATIVE_CALL TrieIterNext(AMX *amx, cell *params)
 {
 	enum args { arg_count, arg_handle };
 
@@ -732,7 +732,7 @@ AMX_NATIVE_INFO trie_Natives[] =
 
 	{ "TrieIterCreate"           ,	TrieIterCreate },
 	{ "TrieIterEnded"            ,	TrieIterEnded },
-	{ "TrieIterMore"             ,	TrieIterMore },
+	{ "TrieIterNext"             ,	TrieIterNext },
 	{ "TrieIterGetKey"           ,	TrieIterGetKey },
 	{ "TrieIterGetSize"          ,  TrieIterGetSize },
 	{ "TrieIterGetCell"          ,  TrieIterGetCell },

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -642,7 +642,7 @@ static cell AMX_NATIVE_CALL TrieIterGetArray(AMX *amx, cell *params)
 
 	CHECK_ITER_HANDLE(handle)
 
-	auto outputSize = size_t(params[arg_outputsize]);
+	auto outputSize = params[arg_outputsize];
 
 	if (outputSize < 0)
 	{
@@ -669,7 +669,7 @@ static cell AMX_NATIVE_CALL TrieIterGetArray(AMX *amx, cell *params)
 	auto length = (*iter)->value.arrayLength();
 	auto base   = (*iter)->value.array();
 
-	if (length > outputSize)
+	if (length > size_t(outputSize))
 	{
 		length = outputSize;
 	}

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -492,6 +492,29 @@ static cell AMX_NATIVE_CALL TrieIterCreate(AMX *amx, cell *params)
 	return static_cast<cell>(index);
 }
 
+// native bool:TrieIterEnded(TrieIter:handle)
+static cell AMX_NATIVE_CALL TrieIterEnded(AMX *amx, cell *params)
+{
+	enum args { arg_count, arg_handle };
+
+	auto handle = TrieIterHandles.lookup(params[arg_handle]);
+
+	if (!handle)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Invalid map iterator handle provided (%d)", params[arg_handle]);
+		return 0;
+	}
+
+	if (!handle->iter)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Closed map iterator handle provided (%d)", params[arg_handle]);
+		return 0;
+	}
+
+	return handle->iter->empty();
+}
+
+
 AMX_NATIVE_INFO trie_Natives[] =
 {
 	{ "TrieCreate"               ,	TrieCreate },
@@ -517,6 +540,7 @@ AMX_NATIVE_INFO trie_Natives[] =
 	{ "TrieSnapshotDestroy"      ,	TrieSnapshotDestroy },
 
 	{ "TrieIterCreate"           ,	TrieIterCreate },
+	{ "TrieIterEnded"            ,	TrieIterEnded },
 
 	{ nullptr                    ,	nullptr}
 };

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -571,6 +571,29 @@ static cell AMX_NATIVE_CALL TrieIterGetKey(AMX *amx, cell *params)
 	return set_amxstring_utf8(amx, params[arg_output], (*iter)->key.chars(), (*iter)->key.length(), params[arg_outputsize]);
 }
 
+// native TrieIterGetSize(TrieIter:handle)
+static cell AMX_NATIVE_CALL TrieIterGetSize(AMX *amx, cell *params)
+{
+	enum args { arg_count, arg_handle };
+
+	auto handle = TrieIterHandles.lookup(params[arg_handle]);
+
+	if (!handle)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Invalid map iterator handle provided (%d)", params[arg_handle]);
+		return 0;
+	}
+
+	if (!handle->iter)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Closed map iterator handle provided (%d)", params[arg_handle]);
+		return 0;
+	}
+
+	return handle->trie->map.elements();
+}
+
+
 AMX_NATIVE_INFO trie_Natives[] =
 {
 	{ "TrieCreate"               ,	TrieCreate },
@@ -599,6 +622,7 @@ AMX_NATIVE_INFO trie_Natives[] =
 	{ "TrieIterEnded"            ,	TrieIterEnded },
 	{ "TrieIterMore"             ,	TrieIterMore },
 	{ "TrieIterGetKey"           ,	TrieIterGetKey },
+	{ "TrieIterGetSize"          ,  TrieIterGetSize },
 
 	{ nullptr                    ,	nullptr}
 };

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -622,6 +622,43 @@ static cell AMX_NATIVE_CALL TrieIterGetCell(AMX *amx, cell *params)
 	return true;
 }
 
+// native bool:TrieIterGetString(TrieIter:handle, buffer[], outputsize, &size = 0)
+static cell AMX_NATIVE_CALL TrieIterGetString(AMX *amx, cell *params)
+{
+	enum args { arg_count, arg_handle, arg_output, arg_outputsize, arg_refsize };
+
+	auto handle = TrieIterHandles.lookup(params[arg_handle]);
+
+	if (!handle)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Invalid map iterator handle provided (%d)", params[arg_handle]);
+		return 0;
+	}
+
+	if (!handle->iter)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Closed map iterator handle provided (%d)", params[arg_handle]);
+		return 0;
+	}
+
+	if (params[arg_outputsize] < 0)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Invalid buffer size (%d)", params[arg_outputsize]);
+		return 0;
+	}
+
+	if (handle->iter->empty() || !(*handle->iter)->value.isString())
+	{
+		return false;
+	}
+
+	auto refsize = get_amxaddr(amx, params[arg_refsize]);
+
+	*refsize = set_amxstring_utf8(amx, params[arg_output], (*handle->iter)->value.chars(), strlen((*handle->iter)->value.chars()), params[arg_outputsize]);
+
+	return true;
+}
+
 
 AMX_NATIVE_INFO trie_Natives[] =
 {
@@ -653,6 +690,7 @@ AMX_NATIVE_INFO trie_Natives[] =
 	{ "TrieIterGetKey"           ,	TrieIterGetKey },
 	{ "TrieIterGetSize"          ,  TrieIterGetSize },
 	{ "TrieIterGetCell"          ,  TrieIterGetCell },
+	{ "TrieIterGetString"        ,  TrieIterGetString },
 
 	{ nullptr                    ,	nullptr}
 };

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -510,12 +510,8 @@ static cell AMX_NATIVE_CALL TrieIterCreate(AMX *amx, cell *params)
 		return 0;
 	}
 
-	auto index = TrieIterHandles.create();
+	auto index = TrieIterHandles.create(handle);
 	auto iter  = TrieIterHandles.lookup(index);
-
-	iter->trie = handle;
-	iter->iter.assign(handle->map.iter_p());
-	iter->mod_count = handle->map.mod_count();
 
 	return static_cast<cell>(index);
 }
@@ -529,7 +525,7 @@ static cell AMX_NATIVE_CALL TrieIterEnded(AMX *amx, cell *params)
 
 	CHECK_ITER_HANDLE(handle)
 
-	return handle->iter->empty();
+	return handle->iter.empty();
 }
 
 // native TrieIterNext(TrieIter:handle)
@@ -541,12 +537,12 @@ static cell AMX_NATIVE_CALL TrieIterNext(AMX *amx, cell *params)
 
 	CHECK_ITER_HANDLE(handle)
 
-	if (handle->iter->empty())
+	if (handle->iter.empty())
 	{
 		return 0;
 	}
 
-	handle->iter->next();
+	handle->iter.next();
 
 	return 1;
 }
@@ -560,15 +556,15 @@ static cell AMX_NATIVE_CALL TrieIterGetKey(AMX *amx, cell *params)
 
 	CHECK_ITER_HANDLE(handle)
 
-	auto iter = handle->iter.get();
+	auto& iter = handle->iter;
 
-	if (iter->empty())
+	if (iter.empty())
 	{
 		*get_amxaddr(amx, params[arg_output]) = '\0';
 		return 0;
 	}
 
-	return set_amxstring_utf8(amx, params[arg_output], (*iter)->key.chars(), (*iter)->key.length(), params[arg_outputsize]);
+	return set_amxstring_utf8(amx, params[arg_output], iter->key.chars(), iter->key.length(), params[arg_outputsize]);
 }
 
 // native TrieIterGetSize(TrieIter:handle)
@@ -592,14 +588,14 @@ static cell AMX_NATIVE_CALL TrieIterGetCell(AMX *amx, cell *params)
 
 	CHECK_ITER_HANDLE(handle)
 
-	auto iter = handle->iter.get();
+	auto& iter = handle->iter;
 
-	if (iter->empty() || !(*iter)->value.isCell())
+	if (iter.empty() || !iter->value.isCell())
 	{
 		return false;
 	}
 
-	*get_amxaddr(amx, params[arg_outputvalue]) = (*iter)->value.cell_();
+	*get_amxaddr(amx, params[arg_outputvalue]) = iter->value.cell_();
 
 	return true;
 }
@@ -619,16 +615,16 @@ static cell AMX_NATIVE_CALL TrieIterGetString(AMX *amx, cell *params)
 		return 0;
 	}
 
-	auto iter = handle->iter.get();
+	auto& iter = handle->iter;
 
-	if (iter->empty() || !(*iter)->value.isString())
+	if (iter.empty() || !iter->value.isString())
 	{
 		return false;
 	}
 
 	auto refsize = get_amxaddr(amx, params[arg_refsize]);
 
-	*refsize = set_amxstring_utf8(amx, params[arg_output], (*iter)->value.chars(), strlen((*iter)->value.chars()), params[arg_outputsize]);
+	*refsize = set_amxstring_utf8(amx, params[arg_output], iter->value.chars(), strlen(iter->value.chars()), params[arg_outputsize]);
 
 	return true;
 }
@@ -650,9 +646,9 @@ static cell AMX_NATIVE_CALL TrieIterGetArray(AMX *amx, cell *params)
 		return 0;
 	}
 
-	auto iter = handle->iter.get();
+	auto& iter = handle->iter;
 
-	if (iter->empty() || !(*iter)->value.isArray())
+	if (iter.empty() || !iter->value.isArray())
 	{
 		return false;
 	}
@@ -660,14 +656,14 @@ static cell AMX_NATIVE_CALL TrieIterGetArray(AMX *amx, cell *params)
 	auto pOutput = get_amxaddr(amx, params[arg_output]);
 	auto pSize   = get_amxaddr(amx, params[arg_refsize]);
 
-	if (!(*iter)->value.array() || !outputSize)
+	if (!iter->value.array() || !outputSize)
 	{
 		*pSize = 0;
 		return false;
 	}
 
-	auto length = (*iter)->value.arrayLength();
-	auto base   = (*iter)->value.array();
+	auto length = iter->value.arrayLength();
+	auto base   = iter->value.array();
 
 	if (length > size_t(outputSize))
 	{

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -470,6 +470,28 @@ static cell AMX_NATIVE_CALL TrieSnapshotDestroy(AMX *amx, cell *params)
 	return 0;
 }
 
+// native TrieIter:TrieIterCreate(Trie:handle)
+static cell AMX_NATIVE_CALL TrieIterCreate(AMX *amx, cell *params)
+{
+	enum args { arg_count, arg_handle };
+
+	auto handle = TrieHandles.lookup(params[arg_handle]);
+
+	if (!handle)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Invalid map handle provided (%d)", params[arg_handle]);
+		return 0;
+	}
+
+	auto index = TrieIterHandles.create();
+	auto iter  = TrieIterHandles.lookup(index);
+
+	iter->trie = handle;
+	iter->iter = handle->map.iter_p();
+
+	return static_cast<cell>(index);
+}
+
 AMX_NATIVE_INFO trie_Natives[] =
 {
 	{ "TrieCreate"               ,	TrieCreate },
@@ -493,6 +515,8 @@ AMX_NATIVE_INFO trie_Natives[] =
 	{ "TrieSnapshotKeyBufferSize",	TrieSnapshotKeyBufferSize },
 	{ "TrieSnapshotGetKey"       ,	TrieSnapshotGetKey },
 	{ "TrieSnapshotDestroy"      ,	TrieSnapshotDestroy },
+
+	{ "TrieIterCreate"           ,	TrieIterCreate },
 
 	{ nullptr                    ,	nullptr}
 };

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -345,6 +345,18 @@ static cell AMX_NATIVE_CALL TrieDestroy(AMX *amx, cell *params)
 		return 0;
 	}
 
+	CellTrieIter *iter;
+ 	for (size_t index = 1; index <= TrieIterHandles.size(); index++)
+ 	{
+ 		if ((iter = TrieIterHandles.lookup(index)))
+ 		{
+			if (iter->trie == t)
+			{
+				iter->trie = nullptr;
+			}
+ 		}
+ 	}
+
 	if (TrieHandles.destroy(*ptr))
 	{
 		*ptr = 0;
@@ -714,6 +726,33 @@ static cell AMX_NATIVE_CALL TrieIterGetArray(AMX *amx, cell *params)
 	return true;
 }
 
+// native TrieIterDestroy(&TrieIter:handle)
+static cell AMX_NATIVE_CALL TrieIterDestroy(AMX *amx, cell *params)
+{
+	enum args { arg_count, arg_handle };
+
+	auto refhandle = get_amxaddr(amx, params[arg_handle]);
+	auto handle = TrieIterHandles.lookup(*refhandle);
+
+	if (!handle)
+	{
+		return false;
+	}
+
+	delete handle->iter;
+
+	handle->iter = nullptr;
+	handle->trie = nullptr;
+
+	if (TrieIterHandles.destroy(*refhandle))
+	{
+		*refhandle = 0;
+		return true;
+	}
+
+	return false;
+}
+
 
 AMX_NATIVE_INFO trie_Natives[] =
 {
@@ -747,6 +786,7 @@ AMX_NATIVE_INFO trie_Natives[] =
 	{ "TrieIterGetCell"          ,  TrieIterGetCell },
 	{ "TrieIterGetString"        ,  TrieIterGetString },
 	{ "TrieIterGetArray"         ,  TrieIterGetArray },
+	{ "TrieIterDestroy"          ,  TrieIterDestroy },
 
 	{ nullptr                    ,	nullptr}
 };

--- a/amxmodx/trie_natives.cpp
+++ b/amxmodx/trie_natives.cpp
@@ -514,6 +514,33 @@ static cell AMX_NATIVE_CALL TrieIterEnded(AMX *amx, cell *params)
 	return handle->iter->empty();
 }
 
+// native TrieIterMore(TrieIter:handle)
+static cell AMX_NATIVE_CALL TrieIterMore(AMX *amx, cell *params)
+{
+	enum args { arg_count, arg_handle };
+
+	auto handle = TrieIterHandles.lookup(params[arg_handle]);
+
+	if (!handle)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Invalid map iterator handle provided (%d)", params[arg_handle]);
+		return 0;
+	}
+
+	if (!handle->iter)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Closed map iterator handle provided (%d)", params[arg_handle]);
+		return 0;
+	}
+
+	if (!handle->iter->empty())
+	{
+		handle->iter->next();
+	}
+
+	return 1;
+}
+
 
 AMX_NATIVE_INFO trie_Natives[] =
 {
@@ -541,6 +568,7 @@ AMX_NATIVE_INFO trie_Natives[] =
 
 	{ "TrieIterCreate"           ,	TrieIterCreate },
 	{ "TrieIterEnded"            ,	TrieIterEnded },
+	{ "TrieIterMore"             ,	TrieIterMore },
 
 	{ nullptr                    ,	nullptr}
 };

--- a/amxmodx/trie_natives.h
+++ b/amxmodx/trie_natives.h
@@ -143,6 +143,12 @@ struct CellTrie
 	StringHashMap<Entry> map;
 };
 
+struct CellTrieIter
+{
+	CellTrie *trie;
+	StringHashMap<Entry>::iterator *iter;
+};
+
 struct TrieSnapshot
 {
 	TrieSnapshot()
@@ -160,6 +166,7 @@ struct TrieSnapshot
 };
 
 extern NativeHandle<CellTrie> TrieHandles;
+extern NativeHandle<CellTrieIter> TrieIterHandles;
 extern NativeHandle<TrieSnapshot> TrieSnapshotHandles;
 extern AMX_NATIVE_INFO trie_Natives[];
 

--- a/amxmodx/trie_natives.h
+++ b/amxmodx/trie_natives.h
@@ -145,8 +145,12 @@ struct CellTrie
 
 struct CellTrieIter
 {
+	CellTrieIter() : trie(nullptr), iter(nullptr), mod_count(0) 
+	{}
+
 	CellTrie *trie;
 	StringHashMap<Entry>::iterator *iter;
+	size_t mod_count;
 };
 
 struct TrieSnapshot

--- a/amxmodx/trie_natives.h
+++ b/amxmodx/trie_natives.h
@@ -14,6 +14,7 @@
 #include <sm_stringhashmap.h>
 #include <sm_memtable.h>
 #include "natives_handles.h"
+#include <amtl/am-uniqueptr.h>
 
 enum EntryType
 {
@@ -145,11 +146,11 @@ struct CellTrie
 
 struct CellTrieIter
 {
-	CellTrieIter() : trie(nullptr), iter(nullptr), mod_count(0) 
+	CellTrieIter() : trie(nullptr), iter(nullptr), mod_count(0)
 	{}
 
 	CellTrie *trie;
-	StringHashMap<Entry>::iterator *iter;
+	ke::UniquePtr<StringHashMap<Entry>::iterator> iter;
 	size_t mod_count;
 };
 

--- a/amxmodx/trie_natives.h
+++ b/amxmodx/trie_natives.h
@@ -139,18 +139,127 @@ private:
 	cell data_;
 };
 
+
+template <typename T>
+class StringHashMapCustom
+{
+	typedef StringHashMap<T> Internal;
+
+public:
+	StringHashMapCustom() : mod_count_(0)
+	{}
+
+public:
+	typedef typename Internal::Result Result;
+	typedef typename Internal::Insert Insert;
+	typedef typename Internal::iterator iterator;
+
+public:
+	size_t elements() const
+	{
+		return internal_.elements();
+	}
+
+	iterator iter()
+	{
+		return internal_.iter();
+	}
+
+	bool contains(const char *aKey)
+	{
+		return internal_.contains(aKey);
+	}
+
+	bool replace(const char *aKey, const T &value)
+	{
+		return internal_.contains(aKey, value);
+	}
+
+	bool insert(const char *aKey, const T &value)
+	{
+		if (internal_.insert(aKey, value))
+		{
+			mod_count_++;
+			return true;
+		}
+		return false;
+	}
+
+	bool remove(const char *aKey)
+	{
+		if (internal_.remove(aKey))
+		{
+			mod_count_++;
+			return true;
+		}
+		return false;
+	}
+
+	void clear()
+	{
+		mod_count_++;
+		internal_.clear();
+	}
+
+	void remove(Result &r)
+	{
+		mod_count_++;
+		internal_.remove(r);
+	}
+
+	Result find(const char *aKey)
+	{
+		return internal_.find(aKey);
+	}
+
+	Insert findForAdd(const char *aKey)
+	{
+		return internal_.findForAdd(aKey);
+	}
+
+	bool add(Insert &i, const char *aKey)
+	{
+		if (internal_.add(i, aKey))
+		{
+			mod_count_++;
+			return true;
+		}
+		return false;
+	}
+
+	bool add(Insert &i)
+	{
+		if (internal_.add(i))
+		{
+			mod_count_++;
+			return true;
+		}
+		return false;
+	}
+
+public:
+	size_t mod_count() const
+	{
+		return mod_count_;
+	}
+	
+private:
+	Internal internal_;
+	size_t mod_count_;
+};
+
 struct CellTrie
 {
-	StringHashMap<Entry> map;
+	StringHashMapCustom<Entry> map;
 };
 
 struct CellTrieIter
 {
-	CellTrieIter() : trie(nullptr), iter(nullptr), mod_count(0)
+	CellTrieIter(CellTrie *_trie) : trie(_trie), iter(_trie->map.iter()), mod_count(_trie->map.mod_count())
 	{}
 
 	CellTrie *trie;
-	ke::UniquePtr<StringHashMap<Entry>::iterator> iter;
+	StringHashMapCustom<Entry>::iterator iter;
 	size_t mod_count;
 };
 

--- a/plugins/include/celltrie.inc
+++ b/plugins/include/celltrie.inc
@@ -310,6 +310,8 @@ native TrieIter:TrieIterCreate(Trie:handle);
  *
  * @return              True if iterator has reached the end, false otherwise
  * @error               Invalid Handle
+ *                      Iterator has been closed (underlying map destroyed)
+ *                      Iterator is outdated
  */
 native bool:TrieIterEnded(TrieIter:handle);
 
@@ -319,6 +321,8 @@ native bool:TrieIterEnded(TrieIter:handle);
  * @param handle        Iterator handle
  *
  * @error               Invalid Handle
+ *                      Iterator has been closed (underlying map destroyed)
+ *                      Iterator is outdated
  */
 native TrieIterMore(TrieIter:handle);
 
@@ -331,6 +335,8 @@ native TrieIterMore(TrieIter:handle);
  *
  * @return 				Nnumber of bytes written to the buffer
  * @error				Invalid handle
+ *                      Iterator has been closed (underlying map destroyed)
+ *                      Iterator is outdated
  */
 native TrieIterGetKey(TrieIter:handle, key[], outputsize);
 
@@ -343,6 +349,8 @@ native TrieIterGetKey(TrieIter:handle, key[], outputsize);
  *
  * @return				Number of elements in the map
  * @error				Invalid handle
+ *                      Iterator has been closed (underlying map destroyed)
+ *                      Iterator is outdated
  */
 native TrieIterGetSize(TrieIter:handle);
 
@@ -355,6 +363,8 @@ native TrieIterGetSize(TrieIter:handle);
  * @return 				True on success, false if the iterator is empty or the current
  *						value is an array or a string.
  * @error				Invalid handle
+ *                      Iterator has been closed (underlying map destroyed)
+ *                      Iterator is outdated
  */
 native bool:TrieIterGetCell(TrieIter:handle, &any:value);
 
@@ -370,6 +380,8 @@ native bool:TrieIterGetCell(TrieIter:handle, &any:value);
  *						is not a string.
  * @error				Invalid handle
  *                      Invalid buffer size
+ *                      Iterator has been closed (underlying map destroyed)
+ *                      Iterator is outdated
  */
 native bool:TrieIterGetString(TrieIter:handle, buffer[], outputsize, &size = 0);
 
@@ -385,6 +397,8 @@ native bool:TrieIterGetString(TrieIter:handle, buffer[], outputsize, &size = 0);
  *						value is not an array.
  * @error				Invalid handle
  *						Invalid buffer size
+ *                      Iterator has been closed (underlying map destroyed)
+ *                      Iterator is outdated
  */
 native bool:TrieIterGetArray(TrieIter:handle, any:array[], outputsize, &size = 0);
 

--- a/plugins/include/celltrie.inc
+++ b/plugins/include/celltrie.inc
@@ -387,3 +387,12 @@ native bool:TrieIterGetString(TrieIter:handle, buffer[], outputsize, &size = 0);
  *						Invalid buffer size
  */
 native bool:TrieIterGetArray(TrieIter:handle, any:array[], outputsize, &size = 0);
+
+/**
+ * Destroys an iterator handle.
+ *
+ * @param handle	Iterator handle.
+ *
+ * @return			True on success, false if the value was never set.
+ */
+native TrieIterDestroy(&TrieIter:handle);

--- a/plugins/include/celltrie.inc
+++ b/plugins/include/celltrie.inc
@@ -322,3 +322,14 @@ native bool:TrieIterEnded(TrieIter:handle);
  */
 native TrieIterMore(TrieIter:handle);
 
+/**
+ * Retrieves the key the iterator currently points to.
+ *
+ * @param handle		Iterator handle.
+ * @param key			Buffer to store the current key in.
+ * @param outputsize	Maximum size of string buffer.
+ *
+ * @return 				Nnumber of bytes written to the buffer
+ * @error				Invalid handle
+ */
+native TrieIterGetKey(TrieIter:handle, key[], outputsize);

--- a/plugins/include/celltrie.inc
+++ b/plugins/include/celltrie.inc
@@ -345,3 +345,15 @@ native TrieIterGetKey(TrieIter:handle, key[], outputsize);
  * @error				Invalid handle
  */
 native TrieIterGetSize(TrieIter:handle);
+
+/**
+ * Retrieves a value at the current position of the iterator.
+ *
+ * @param handle		Iterator handle
+ * @param value			Variable to store value in
+ *
+ * @return 				True on success, false if the iterator is empty or the current
+ *						value is an array or a string.
+ * @error				Invalid handle
+ */
+native bool:TrieIterGetCell(TrieIter:handle, &any:value);

--- a/plugins/include/celltrie.inc
+++ b/plugins/include/celltrie.inc
@@ -357,3 +357,18 @@ native TrieIterGetSize(TrieIter:handle);
  * @error				Invalid handle
  */
 native bool:TrieIterGetCell(TrieIter:handle, &any:value);
+
+/**
+ * Retrieves a string at the current position of the iterator.
+ *
+ * @param handle		Iterator handle
+ * @param buffer		Buffer to store the string in
+ * @param outputsize	Maximum size of string buffer
+ * @param size			Optional parameter to store the number of bytes written to the buffer.
+ *
+ * @return 				True on success, false if the iterator is empty or the current value
+ *						is not a string.
+ * @error				Invalid handle
+ *                      Invalid buffer size
+ */
+native bool:TrieIterGetString(TrieIter:handle, buffer[], outputsize, &size = 0);

--- a/plugins/include/celltrie.inc
+++ b/plugins/include/celltrie.inc
@@ -302,3 +302,14 @@ native TrieSnapshotDestroy(&Snapshot:handle);
  * @error               Invalid Handle
  */
 native TrieIter:TrieIterCreate(Trie:handle);
+
+/**
+ * Returns if the iterator has reached its end and no more data can be read.
+ *
+ * @param handle        Iterator handle
+ *
+ * @return              True if iterator has reached the end, false otherwise
+ * @error               Invalid Handle
+ */
+native bool:TrieIterEnded(TrieIter:handle);
+

--- a/plugins/include/celltrie.inc
+++ b/plugins/include/celltrie.inc
@@ -291,8 +291,9 @@ native TrieSnapshotDestroy(&Snapshot:handle);
  *
  * @note Just like in snapshots the key/value pairs are not sorted.
  * @note Any mutating change - that is key addition or key removal - to the underlying map will
- *       be invalidated. Updating the value of already existing keys is allowed and will be
- *       immediately changed.
+ *       be invalidated.
+ * @note Updating the value of already existing keys will not mark iterators as outdated. Iterators
+ *       will immediately reflect updated values. Nothing is cached.
  * @note Iterators are designed to be short-lived and not be permanently stored or cached.
  *       Creating new iterators is very fast, exhibiting virtually no overhead, even for very
  *       large tries. It is generally recommended to create them on-demand. Value retrieval
@@ -329,12 +330,12 @@ native TrieIterMore(TrieIter:handle);
 /**
  * Retrieves the key the iterator currently points to.
  *
- * @param handle		Iterator handle.
- * @param key			Buffer to store the current key in.
- * @param outputsize	Maximum size of string buffer.
+ * @param handle        Iterator handle.
+ * @param key           Buffer to store the current key in.
+ * @param outputsize    Maximum size of string buffer.
  *
- * @return 				Nnumber of bytes written to the buffer
- * @error				Invalid handle
+ * @return              Nnumber of bytes written to the buffer
+ * @error               Invalid handle
  *                      Iterator has been closed (underlying map destroyed)
  *                      Iterator is outdated
  */
@@ -345,10 +346,10 @@ native TrieIterGetKey(TrieIter:handle, key[], outputsize);
  *
  * @note When used on a valid iterator this is exactly the same as calling TrieGetSize on the map directly.
  *
- * @param handle		Iterator handle
+ * @param handle        Iterator handle
  *
- * @return				Number of elements in the map
- * @error				Invalid handle
+ * @return              Number of elements in the map
+ * @error               Invalid handle
  *                      Iterator has been closed (underlying map destroyed)
  *                      Iterator is outdated
  */
@@ -357,12 +358,12 @@ native TrieIterGetSize(TrieIter:handle);
 /**
  * Retrieves a value at the current position of the iterator.
  *
- * @param handle		Iterator handle
- * @param value			Variable to store value in
+ * @param handle        Iterator handle
+ * @param value         Variable to store value in
  *
- * @return 				True on success, false if the iterator is empty or the current
- *						value is an array or a string.
- * @error				Invalid handle
+ * @return              True on success, false if the iterator is empty or the current
+ *                      value is an array or a string.
+ * @error               Invalid handle
  *                      Iterator has been closed (underlying map destroyed)
  *                      Iterator is outdated
  */
@@ -371,14 +372,14 @@ native bool:TrieIterGetCell(TrieIter:handle, &any:value);
 /**
  * Retrieves a string at the current position of the iterator.
  *
- * @param handle		Iterator handle
- * @param buffer		Buffer to store the string in
- * @param outputsize	Maximum size of string buffer
- * @param size			Optional parameter to store the number of bytes written to the buffer.
+ * @param handle        Iterator handle
+ * @param buffer        Buffer to store the string in
+ * @param outputsize    Maximum size of string buffer
+ * @param size          Optional parameter to store the number of bytes written to the buffer.
  *
- * @return 				True on success, false if the iterator is empty or the current value
- *						is not a string.
- * @error				Invalid handle
+ * @return              True on success, false if the iterator is empty or the current value
+ *                      is not a string.
+ * @error               Invalid handle
  *                      Invalid buffer size
  *                      Iterator has been closed (underlying map destroyed)
  *                      Iterator is outdated
@@ -388,15 +389,15 @@ native bool:TrieIterGetString(TrieIter:handle, buffer[], outputsize, &size = 0);
 /**
  * Retrieves an array at the current position of the iterator.
  *
- * @param handle		Iterator handle
- * @param buffer		Buffer to store the array
- * @param outputsize	Maximum size of buffer
- * @param size			Optional parameter to store the number of bytes written to the buffer
+ * @param handle        Iterator handle
+ * @param buffer        Buffer to store the array
+ * @param outputsize    Maximum size of buffer
+ * @param size          Optional parameter to store the number of bytes written to the buffer
  *
- * @return 				True on success, false if the iterator is empty or the current
- *						value is not an array.
- * @error				Invalid handle
- *						Invalid buffer size
+ * @return              True on success, false if the iterator is empty or the current
+ *                      value is not an array.
+ * @error               Invalid handle
+ *                      Invalid buffer size
  *                      Iterator has been closed (underlying map destroyed)
  *                      Iterator is outdated
  */
@@ -405,8 +406,8 @@ native bool:TrieIterGetArray(TrieIter:handle, any:array[], outputsize, &size = 0
 /**
  * Destroys an iterator handle.
  *
- * @param handle	Iterator handle.
+ * @param handle    Iterator handle.
  *
- * @return			True on success, false if the value was never set.
+ * @return          True on success, false if the value was never set.
  */
 native TrieIterDestroy(&TrieIter:handle);

--- a/plugins/include/celltrie.inc
+++ b/plugins/include/celltrie.inc
@@ -325,7 +325,7 @@ native bool:TrieIterEnded(TrieIter:handle);
  *                      Iterator has been closed (underlying map destroyed)
  *                      Iterator is outdated
  */
-native TrieIterMore(TrieIter:handle);
+native TrieIterNext(TrieIter:handle);
 
 /**
  * Retrieves the key the iterator currently points to.

--- a/plugins/include/celltrie.inc
+++ b/plugins/include/celltrie.inc
@@ -313,3 +313,12 @@ native TrieIter:TrieIterCreate(Trie:handle);
  */
 native bool:TrieIterEnded(TrieIter:handle);
 
+/**
+ * Advances the iterator to the next key/value pair if one is available.
+ *
+ * @param handle        Iterator handle
+ *
+ * @error               Invalid Handle
+ */
+native TrieIterMore(TrieIter:handle);
+

--- a/plugins/include/celltrie.inc
+++ b/plugins/include/celltrie.inc
@@ -333,3 +333,15 @@ native TrieIterMore(TrieIter:handle);
  * @error				Invalid handle
  */
 native TrieIterGetKey(TrieIter:handle, key[], outputsize);
+
+/**
+ * Retrieves the number of elements in the underlying map.
+ *
+ * @note When used on a valid iterator this is exactly the same as calling TrieGetSize on the map directly.
+ *
+ * @param handle		Iterator handle
+ *
+ * @return				Number of elements in the map
+ * @error				Invalid handle
+ */
+native TrieIterGetSize(TrieIter:handle);

--- a/plugins/include/celltrie.inc
+++ b/plugins/include/celltrie.inc
@@ -372,3 +372,18 @@ native bool:TrieIterGetCell(TrieIter:handle, &any:value);
  *                      Invalid buffer size
  */
 native bool:TrieIterGetString(TrieIter:handle, buffer[], outputsize, &size = 0);
+
+/**
+ * Retrieves an array at the current position of the iterator.
+ *
+ * @param handle		Iterator handle
+ * @param buffer		Buffer to store the array
+ * @param outputsize	Maximum size of buffer
+ * @param size			Optional parameter to store the number of bytes written to the buffer
+ *
+ * @return 				True on success, false if the iterator is empty or the current
+ *						value is not an array.
+ * @error				Invalid handle
+ *						Invalid buffer size
+ */
+native bool:TrieIterGetArray(TrieIter:handle, any:array[], outputsize, &size = 0);

--- a/plugins/include/celltrie.inc
+++ b/plugins/include/celltrie.inc
@@ -287,17 +287,16 @@ native TrieSnapshotDestroy(&Snapshot:handle);
 
 
 /**
- * Creates an iterator for a map. An iterator provides iterative read-only access to a map.
+ * Creates an iterator for a map. It provides iterative read-only access to the
+ * maps contents.
  *
- * @note Just like in snapshots the key/value pairs are not sorted.
- * @note Any mutating change - that is key addition or key removal - to the underlying map will
- *       be invalidated.
- * @note Updating the value of already existing keys will not mark iterators as outdated. Iterators
- *       will immediately reflect updated values. Nothing is cached.
- * @note Iterators are designed to be short-lived and not be permanently stored or cached.
- *       Creating new iterators is very fast, exhibiting virtually no overhead, even for very
- *       large tries. It is generally recommended to create them on-demand. Value retrieval
- *       can be done through the iterator and is as fast as directly reading from the underlying map.
+ * @note Removing or adding keys to the underlying map will invalidate all its
+ *       iterators. Updating values of existing keys is allowed and the changes 
+ *       will be immediately reflected in the iterator.
+ * @note Iterators are designed to be short-lived and not stored, and creating
+ *       them is very cheap. Reading data from an iterator is just as fast as 
+ *       reading directly from the map.
+ * @note Just like in snapshots the keys are not sorted.
  *
  * @return              New iterator handle, which must be freed via TrieIterDestroy().
  * @error               Invalid Handle

--- a/plugins/include/celltrie.inc
+++ b/plugins/include/celltrie.inc
@@ -28,6 +28,21 @@ enum Trie
 };
 
 /**
+ * Hash map iterator tag declaration
+ *
+ * @note The word "Trie" in this API is historical. As of AMX Mod X 1.8.3,
+ *       tries have been internally replaced with hash tables, which have O(1)
+ *       insertion time instead of O(n).
+ * @note Plugins are responsible for freeing all TrieIter handles they acquire.
+ *       Failing to free handles will result in the plugin and AMXX leaking
+ *       memory.
+ */
+enum TrieIter
+{
+	Invalid_TrieIter = 0
+}
+
+/**
  * Hash map snapshot tag declaration
  *
  * @note Plugins are responsible for freeing all Snapshot handles they acquire.
@@ -269,3 +284,21 @@ native TrieSnapshotGetKey(Snapshot:handle, index, buffer[], maxlength);
  * @return          1 on success, 0 if an invalid handle was passed in
  */
 native TrieSnapshotDestroy(&Snapshot:handle);
+
+
+/**
+ * Creates an iterator for a map. An iterator provides iterative read-only access to a map.
+ *
+ * @note Just like in snapshots the key/value pairs are not sorted.
+ * @note Any mutating change - that is key addition or key removal - to the underlying map will
+ *       be invalidated. Updating the value of already existing keys is allowed and will be
+ *       immediately changed.
+ * @note Iterators are designed to be short-lived and not be permanently stored or cached.
+ *       Creating new iterators is very fast, exhibiting virtually no overhead, even for very
+ *       large tries. It is generally recommended to create them on-demand. Value retrieval
+ *       can be done through the iterator and is as fast as directly reading from the underlying map.
+ *
+ * @return              New iterator handle, which must be freed via TrieIterDestroy().
+ * @error               Invalid Handle
+ */
+native TrieIter:TrieIterCreate(Trie:handle);

--- a/plugins/testsuite/trietest.sma
+++ b/plugins/testsuite/trietest.sma
@@ -367,7 +367,7 @@ public trietest()
 				// TrieSetString(t, "monkey", "island");
 				// TrieDeleteKey(t, "full");
 				// TrieClear(t);
-		
+
 				TrieIterNext(iter);
 			}
 
@@ -495,6 +495,36 @@ public trietest()
 					}
 				}
 			}
+		}
+
+		TrieClear(t);
+		TrieSetCell(t, "1", 1);
+		TrieSetCell(t, "2", 2);
+		TrieSetCell(t, "3", 3);
+
+		new totalSum = 0;
+		new element1, element2;
+		new TrieIter:iter1, TrieIter:iter2;
+
+		iter1 = TrieIterCreate(t)
+		for (; !TrieIterEnded(iter1); TrieIterNext(iter1))
+		{
+			iter2 = TrieIterCreate(t);
+			for(; !TrieIterEnded(iter2); TrieIterNext(iter2))
+			{
+				TrieIterGetCell(iter1, element1);
+				TrieIterGetCell(iter2, element2);
+
+				totalSum += element1 * element2;
+			}
+			TrieIterDestroy(iter2);
+		}
+		TrieIterDestroy(iter1);
+
+		if (totalSum != 36)
+		{
+			server_print("Sum should be 36, got %d", totalSum);
+			ok = false;
 		}
 
 		TrieIterDestroy(iter);

--- a/plugins/testsuite/trietest.sma
+++ b/plugins/testsuite/trietest.sma
@@ -363,7 +363,7 @@ public trietest()
 					ok = false;
 				}
 
-				TrieIterMore(iter);
+				TrieIterNext(iter);
 			}
 
 			if (!valid[0] || !valid[1] || !valid[2])
@@ -394,7 +394,7 @@ public trietest()
 
 			arrayset(valid, false, sizeof(valid));
 
-			for (; !TrieIterEnded(iter); TrieIterMore(iter))
+			for (; !TrieIterEnded(iter); TrieIterNext(iter))
 			{
 				if (TrieIterGetCell(iter, value[0]) || TrieIterGetArray(iter, array, sizeof(array)))
 				{
@@ -442,7 +442,7 @@ public trietest()
 		{
 			TrieDestroy(t);
 			// Should throw an error
-			// TrieIterMore(iter)
+			// TrieIterNext(iter)
 		}
 
 		if (!TrieIterDestroy(iter))
@@ -463,7 +463,7 @@ public trietest()
 			ok = false;
 		}
 
-		for (; !TrieIterEnded(iter); TrieIterMore(iter))
+		for (; !TrieIterEnded(iter); TrieIterNext(iter))
 		{
 			TrieIterGetKey(iter, key, charsmax(key));
 

--- a/plugins/testsuite/trietest.sma
+++ b/plugins/testsuite/trietest.sma
@@ -363,6 +363,11 @@ public trietest()
 					ok = false;
 				}
 
+				// Should thrown an error
+				// TrieSetString(t, "monkey", "island");
+				// TrieDeleteKey(t, "full");
+				// TrieClear(t);
+		
 				TrieIterNext(iter);
 			}
 
@@ -372,11 +377,6 @@ public trietest()
 				ok = false;
 			}
 		}
-
-		// Should thrown an error
-		// TrieSetString(t, "monkey", "island");
-		// TrieDeleteKey(t, "full");
-		// TrieClear(t);
 
 		TrieIterDestroy(iter);
 

--- a/public/sm_stringhashmap.h
+++ b/public/sm_stringhashmap.h
@@ -107,7 +107,8 @@ class StringHashMap
 public:
 	StringHashMap()
 		: internal_(ke::SystemAllocatorPolicy()),
-		  memory_used_(0)
+		  memory_used_(0),
+		  mod_count_(0)
 	{
 		if (!internal_.init())
 			internal_.allocPolicy().reportOutOfMemory();
@@ -162,6 +163,7 @@ public:
 		Insert i = internal_.findForAdd(key);
 		if (i.found())
 			return false;
+		mod_count_++;
 		if (!internal_.add(i, aKey, value))
 			return false;
 		memory_used_ += key.length() + 1;
@@ -175,17 +177,20 @@ public:
 		if (!r.found())
 			return false;
 		memory_used_ -= key.length() + 1;
+		mod_count_++;
 		internal_.remove(r);
 		return true;
 	}
 
 	void remove(Result &r)
 	{
+		mod_count_++;
 		internal_.remove(r);
 	}
 
 	void clear()
 	{
+		mod_count_++;
 		internal_.clear();
 	}
 
@@ -221,20 +226,28 @@ public:
 	// functions as the combined variants above are safer.
 	bool add(Insert &i)
 	{
+		mod_count_++;
 		return internal_.add(i);
 	}
 
 	// Only value needs to be set after.
 	bool add(Insert &i, const char *aKey)
 	{
+		mod_count_++;
 		if (!internal_.add(i, aKey))
 			return false;
 		return true;
 	}
 
+	size_t mod_count() const
+	{
+		return mod_count_;
+	}
+
 private:
 	Internal internal_;
 	size_t memory_used_;
+	size_t mod_count_;
 };
 
 //}

--- a/public/sm_stringhashmap.h
+++ b/public/sm_stringhashmap.h
@@ -194,6 +194,11 @@ public:
 		return internal_.iter();
 	}
 
+	iterator* iter_p()
+	{
+		return new iterator(iter());
+	}
+
 	size_t mem_usage() const
 	{
 		return internal_.estimateMemoryUse() + memory_used_;

--- a/public/sm_stringhashmap.h
+++ b/public/sm_stringhashmap.h
@@ -107,8 +107,7 @@ class StringHashMap
 public:
 	StringHashMap()
 		: internal_(ke::SystemAllocatorPolicy()),
-		  memory_used_(0),
-		  mod_count_(0)
+		  memory_used_(0)
 	{
 		if (!internal_.init())
 			internal_.allocPolicy().reportOutOfMemory();
@@ -163,7 +162,6 @@ public:
 		Insert i = internal_.findForAdd(key);
 		if (i.found())
 			return false;
-		mod_count_++;
 		if (!internal_.add(i, aKey, value))
 			return false;
 		memory_used_ += key.length() + 1;
@@ -177,31 +175,23 @@ public:
 		if (!r.found())
 			return false;
 		memory_used_ -= key.length() + 1;
-		mod_count_++;
 		internal_.remove(r);
 		return true;
 	}
 
 	void remove(Result &r)
 	{
-		mod_count_++;
 		internal_.remove(r);
 	}
 
 	void clear()
 	{
-		mod_count_++;
 		internal_.clear();
 	}
 
 	iterator iter()
 	{
 		return internal_.iter();
-	}
-
-	iterator* iter_p()
-	{
-		return new iterator(iter());
 	}
 
 	size_t mem_usage() const
@@ -226,28 +216,20 @@ public:
 	// functions as the combined variants above are safer.
 	bool add(Insert &i)
 	{
-		mod_count_++;
 		return internal_.add(i);
 	}
 
 	// Only value needs to be set after.
 	bool add(Insert &i, const char *aKey)
 	{
-		mod_count_++;
 		if (!internal_.add(i, aKey))
 			return false;
 		return true;
 	}
 
-	size_t mod_count() const
-	{
-		return mod_count_;
-	}
-
 private:
 	Internal internal_;
 	size_t memory_used_;
-	size_t mod_count_;
 };
 
 //}


### PR DESCRIPTION
This is essentially a cleanup of #11, originally developed by @Nextra, and follow the suggestions of the discussion there, by simplifying/fixing the API. It would have been such a waste to lose his work. Feel free to read #11 for more information.

Comparing to the previous API:
- Removed `GetStatus`/`Refresh`/`SetPos`/`Status`
- Untangled `GetKey`/`Next` to `GetKey` (key retrieval only) and `Ended` (whether iter has ended only)/`Next` (advances iter only)
- No more direct modifications on AMTL

Long short story TrieIter are new natives around exposing actual iterators for a hashmap, unlike the compromise that snapshots provide, TrieItor has virtually no overhead. They are designed to be short-lived and not be permanently stored or cached. Any attempt to mutate the iterator by deleting or adding keys will result in the iterator be invalidated.

This adds the following natives:
``` SourcePawn
native TrieIter:TrieIterCreate(Trie:handle);
native bool:TrieIterEnded(TrieIter:handle);
native TrieIterNext(TrieIter:handle);
native TrieIterGetKey(TrieIter:handle, key[], outputsize);
native TrieIterGetSize(TrieIter:handle);
native bool:TrieIterGetCell(TrieIter:handle, &any:value);
native bool:TrieIterGetString(TrieIter:handle, buffer[], outputsize, &size = 0);
native bool:TrieIterGetArray(TrieIter:handle, any:array[], outputsize, &size = 0);
native TrieIterDestroy(&TrieIter:handle);
```



