### PR TITLE
Fix sockets crash

### DIFF
--- a/modules/sockets/sockets.cpp
+++ b/modules/sockets/sockets.cpp
@@ -203,9 +203,10 @@ static cell AMX_NATIVE_CALL socket_recv(AMX *amx, cell *params)
 	int current_length = 0;
 	int max_length = length - 1;
 
+	const char *buffer = recv_buffer;
 	while(max_length-- && current_length < bytes_received)
 	{
-		*destination++ = (cell)*recv_buffer++;
+		*destination++ = (cell)*buffer++;
 		current_length++;
 	}
 


### PR DESCRIPTION
Related to #301.
Test plugin also taken from #301.

Sockets module crashes server with error.
```*** Error in `/home/karol/Programy/HLDS/hlds_linux': munmap_chunk(): invalid pointer: 0x0910afc9 ***```

Backtrace
```
(gdb) bt
#0  0xf7fd8c89 in __kernel_vsyscall ()
#1  0xf7c1eeb0 in raise () from /usr/lib32/libc.so.6
#2  0xf7c203d7 in abort () from /usr/lib32/libc.so.6
#3  0xf7c5b15f in __libc_message () from /usr/lib32/libc.so.6
#4  0xf7c61d07 in malloc_printerr () from /usr/lib32/libc.so.6
#5  0xf7c62391 in munmap_chunk () from /usr/lib32/libc.so.6
#6  0xf7e384a8 in operator delete (ptr=0x910afc9) at /build/gcc-multilib/src/gcc/libstdc++-v3/libsupc++/del_op.cc:49
#7  0xf7e38508 in operator delete[] (ptr=0x910afc9) at /build/gcc-multilib/src/gcc/libstdc++-v3/libsupc++/del_opv.cc:35
#8  0xf39f9d83 in socket_recv (amx=<optimized out>, params=<optimized out>) at /home/karol/Programy/AlliedMods/GoldSrc/amxmodx/modules/sockets/sockets.cpp:214
#9  0xf341409d in amx_Callback (amx=0x9034850, index=6, result=0xffffbe50, params=0xf32b8c20) at /home/karol/Programy/AlliedMods/GoldSrc/amxmodx/amxmodx/amx.cpp:472
#10 0xf343c0d6 in JIT_OP_SYSREQ () from /home/karol/Programy/HLDS/cstrike/addons/amxmodx/dlls/amxmodx_mm_i386.so
#11 0x09034850 in ?? ()
Backtrace stopped: previous frame inner to this frame (corrupt stack?)
```