### PR TITLE
Update Fun module

### DIFF
--- a/modules/fun/fun.cpp
+++ b/modules/fun/fun.cpp
@@ -290,7 +290,7 @@ static cell AMX_NATIVE_CALL get_user_gravity(AMX *amx, cell *params)
 	return amx_ftoc(pPlayer->v.gravity); 
 }
 
-// native set_user_hitzones(index = 0, target = 0, body = 255)
+// native set_user_hitzones(index = 0, target = 0, body = HITZONES_DEFAULT)
 static cell AMX_NATIVE_CALL set_user_hitzones(AMX *amx, cell *params)
 {
 	enum args { arg_count, arg_attacker, arg_target, arg_hitzones };
@@ -445,28 +445,28 @@ AMX_NATIVE_INFO fun_Exports[] =
 {
 	{ "get_client_listen" , get_client_listening },
 	{ "set_client_listen" , set_client_listening },
-	{ "set_user_godmode"  , set_user_godmode },
-	{ "get_user_godmode"  , get_user_godmode },
-	{ "set_user_health"   , set_user_health },
-	{ "give_item"         , give_item },
-	{ "spawn"             , spawn },
-	{ "set_user_frags"    , set_user_frags },
-	{ "set_user_armor"    , set_user_armor },
-	{ "set_user_origin"   , set_user_origin },
-	{ "set_user_rendering", set_user_rendering },
-	{ "get_user_rendering",	get_user_rendering},
-	{ "set_user_maxspeed" , set_user_maxspeed },
-	{ "get_user_maxspeed" , get_user_maxspeed },
-	{ "set_user_gravity"  , set_user_gravity },
-	{ "get_user_gravity"  , get_user_gravity },
-	{ "get_user_footsteps", get_user_footsteps },
-	{ "set_user_hitzones" , set_user_hitzones },
-	{ "get_user_hitzones" , get_user_hitzones },
-	{ "set_user_noclip"   , set_user_noclip },
-	{ "get_user_noclip"   , get_user_noclip },
-	{ "set_user_footsteps", set_user_footsteps },
-	{ "strip_user_weapons", strip_user_weapons },
-	{ NULL                , NULL }
+	{ "set_user_godmode"  , set_user_godmode     },
+	{ "get_user_godmode"  , get_user_godmode     },
+	{ "set_user_health"   , set_user_health      },
+	{ "give_item"         , give_item            },
+	{ "spawn"             , spawn                },
+	{ "set_user_frags"    , set_user_frags       },
+	{ "set_user_armor"    , set_user_armor       },
+	{ "set_user_origin"   , set_user_origin      },
+	{ "set_user_rendering", set_user_rendering   },
+	{ "get_user_rendering",	get_user_rendering   },
+	{ "set_user_maxspeed" , set_user_maxspeed    },
+	{ "get_user_maxspeed" , get_user_maxspeed    },
+	{ "set_user_gravity"  , set_user_gravity     },
+	{ "get_user_gravity"  , get_user_gravity     },
+	{ "get_user_footsteps", get_user_footsteps   },
+	{ "set_user_hitzones" , set_user_hitzones    },
+	{ "get_user_hitzones" , get_user_hitzones    },
+	{ "set_user_noclip"   , set_user_noclip      },
+	{ "get_user_noclip"   , get_user_noclip      },
+	{ "set_user_footsteps", set_user_footsteps   },
+	{ "strip_user_weapons", strip_user_weapons   },
+	{ nullptr             , nullptr              }
 };
 
 

--- a/modules/fun/fun.cpp
+++ b/modules/fun/fun.cpp
@@ -188,7 +188,7 @@ static cell AMX_NATIVE_CALL give_item(AMX *amx, cell *params) // native give_ite
 		return -1;
 	}
 
-	return ENTINDEX(pItemEntity);
+	return TypeConversion.edict_to_id(pItemEntity);
 }
 
 static cell AMX_NATIVE_CALL spawn(AMX *amx, cell *params) // spawn(id) = 1 param
@@ -574,7 +574,7 @@ AMX_NATIVE_INFO fun_Exports[] = {
 /******************************************************************************************/
 void PlayerPreThink(edict_t *pEntity)
 {
-	if (Players[ENTINDEX(pEntity)].HasSilentFootsteps()) {
+	if (Players[TypeConversion.edict_to_id(pEntity)].HasSilentFootsteps()) {
 		pEntity->v.flTimeStepSound = 999; 
 		RETURN_META(MRES_HANDLED);
 	}
@@ -584,7 +584,7 @@ void PlayerPreThink(edict_t *pEntity)
 
 int ClientConnect(edict_t *pPlayer, const char *pszName, const char *pszAddress, char szRejectReason[128])
 {
-	Players[ENTINDEX(pPlayer)].Reset();
+	Players[TypeConversion.edict_to_id(pPlayer)].Reset();
 
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
@@ -593,8 +593,8 @@ void TraceLine(const float *v1, const float *v2, int fNoMonsters, edict_t *shoot
 	TRACE_LINE(v1, v2, fNoMonsters, shooter, ptr);
 	if ( ptr->pHit && (ptr->pHit->v.flags& (FL_CLIENT | FL_FAKECLIENT))
 	&& shooter && (shooter->v.flags & (FL_CLIENT | FL_FAKECLIENT)) ) {
-		int shooterIndex = ENTINDEX(shooter);
-		if ( !(Players[shooterIndex].GetBodyHits(ENTINDEX(ptr->pHit))& (1<<ptr->iHitgroup)) )
+		int shooterIndex = TypeConversion.edict_to_id(shooter);
+		if ( !(Players[shooterIndex].GetBodyHits(TypeConversion.edict_to_id(ptr->pHit))& (1<<ptr->iHitgroup)) )
 			ptr->flFraction = 1.0;
 	}
 	RETURN_META(MRES_SUPERCEDE);

--- a/modules/fun/fun.cpp
+++ b/modules/fun/fun.cpp
@@ -11,298 +11,201 @@
 // Fun Module
 //
 
-#include <string.h>
 #include "fun.h"
 #include <HLTypeConversion.h>
-
-/*
-	JGHG says:
-
-	Ok this is what I use below, it may probably not be right with all natives etc but I try to maintain this style to natives.
-	Note that this is still very much subject to change, regarding return values etc!
-	(Ok I haven't checked all natives that they comply with this yet, this is just a model I'm working on and which I might implement soon.)
-
-	static cell AMX_NATIVE_CALL nativename(AMX *amx, cell *params) // nativename(argument1, argument2); = 2 params
-	{
-		// Description what this native does.					<--- Description what this native does
-		// params[1] = argument1								<--- Description of each argument, so we don't have to allocate new variables and can
-		// params[2] = argument2								<--- use the ones in params[n] directly, to save some time.
-
-		// Check receiver and sender validity.					<--- Check ents, maybe need to do this better and more proper later?
-		CHECK_PLAYER(params[1])
-		CHECK_PLAYER(params[2])
-
-		// Get * pointer.
-		edict_t *pPlayer = MF_GetPlayerEdict(params[1]);		<--- Players require a different function than INDEXENT because of an HLSDK bug
-
-		return 1												<--- If native succeeded, return 1, if the native isn't supposed to return a specific value.		
-																Note: Should be able to do: if (thenative()) and it should return false when it fails, and true when succeeds... is -1 treated as false, or is 0 a must?
-	}
-*/
 
 HLTypeConversion TypeConversion;
 CPlayer Players[kMaxClients + 1];
 
-
-// ######## Natives:
-static cell AMX_NATIVE_CALL get_client_listening(AMX *amx, cell *params) // get_client_listening(receiver, sender); = 2 params
+// native get_client_listen(receiver, sender)
+static cell AMX_NATIVE_CALL get_client_listening(AMX *amx, cell *params)
 {
-	// Gets who can listen to who.
-	// params[1] = receiver
-	// params[2] = sender
+	enum args { arg_count, arg_receiver, arg_sender };
 
-	// Check receiver and sender validity.
-	CHECK_PLAYER(params[1]);
-	CHECK_PLAYER(params[2]);
+	CHECK_PLAYER(params[arg_receiver]);
+	CHECK_PLAYER(params[arg_sender]);
 
-	// GET- AND SETCLIENTLISTENING returns "qboolean", an int, probably 0 or 1...
-	return GETCLIENTLISTENING(params[1], params[2]);
+	return GETCLIENTLISTENING(params[arg_receiver], params[arg_sender]);
 }
 
-static cell AMX_NATIVE_CALL set_client_listening(AMX *amx, cell *params) // set_client_listening(receiver, sender, listen); = 3 params
+// native set_client_listen(receiver, sender, listen)
+static cell AMX_NATIVE_CALL set_client_listening(AMX *amx, cell *params)
 {
-	// Sets who can listen to who.
-	// params[1] = receiver
-	// params[2] = sender
-	// params[3] = listen
+	enum args { arg_count, arg_receiver, arg_sender, arg_listen };
 
-	// Check receiver and sender validity.
-	CHECK_PLAYER(params[1]);
-	CHECK_PLAYER(params[2]);
+	CHECK_PLAYER(params[arg_receiver]);
+	CHECK_PLAYER(params[arg_sender]);
 
-	// Make a check on params[3] here later, and call run time error when it's wrong.
-	// To do: find out the possible values to set (0, 1?)
-
-	// GET- AND SETCLIENTLISTENING returns "qboolean", an int, probably 0 or 1...
-	return SETCLIENTLISTENING(params[1], params[2], params[3]);
+	return SETCLIENTLISTENING(params[arg_receiver], params[arg_sender], params[arg_listen]);
 }
 
-static cell AMX_NATIVE_CALL set_user_godmode(AMX *amx, cell *params) // set_user_godmode(index, godmode = 0); = 2 params
+// native set_user_godmode(index, godmode = 0)
+static cell AMX_NATIVE_CALL set_user_godmode(AMX *amx, cell *params)
 {
-	/* Sets player godmode. If you want to disable godmode set only first parameter. */
-	// params[1] = index
-	// params[2] = godmode = 0
+	enum args { arg_count, arg_user, arg_godmode };
 
-	// Check index.
-	CHECK_PLAYER(params[1]);
+	CHECK_PLAYER(params[arg_user]);
 
-	// Get player pointer.
-	edict_t *pPlayer = TypeConversion.id_to_edict(params[1]);
+	auto pPlayer = TypeConversion.id_to_edict(params[arg_user]);
 
-	if (params[2] == 1) {
-		// Enable godmode
-		pPlayer->v.takedamage = 0.0;	// 0.0, the player doesn't seem to be able to get hurt.
-	}
-	else {
-		// Disable godmode
-		pPlayer->v.takedamage = 2.0;	// 2.0 seems to be standard value?
-	}
+	pPlayer->v.takedamage = params[arg_godmode] != 0 ? DAMAGE_NO : DAMAGE_AIM;
 
 	return 1;
 }
 
-static cell AMX_NATIVE_CALL get_user_godmode(AMX *amx, cell *params) // get_user_godmode(index); = 1 param
+// native get_user_godmode(index)
+static cell AMX_NATIVE_CALL get_user_godmode(AMX *amx, cell *params)
 {
-	/* Returns 1 if godmode is set. */
-	// params[1] = index
+	enum args { arg_count, arg_user };
 
-	// Check index.
-	CHECK_PLAYER(params[1]);
+	CHECK_PLAYER(params[arg_user]);
 
-	// Get player pointer.
-	edict_t *pPlayer = TypeConversion.id_to_edict(params[1]);
+	auto pPlayer = TypeConversion.id_to_edict(params[arg_user]);
 
-	int godmode = 0;
-
-	if (pPlayer->v.takedamage == 0.0) {
-		// God mode is enabled
-		godmode = 1;
-	}
-
-	return godmode;
+	return pPlayer->v.takedamage == DAMAGE_NO;
 }
 
-static cell AMX_NATIVE_CALL give_item(AMX *amx, cell *params) // native give_item(index, const item[]); = 2 params
+// native give_item(index, const item[])
+static cell AMX_NATIVE_CALL give_item(AMX *amx, cell *params)
 {
-	/* Gives item to player, name of item can start
-	* with weapon_, ammo_ and item_. This event
-	* is announced with proper message to all players. */
-	// params[1] = index
-	// params[2] = item...
+	enum args { arg_count, arg_index, arg_item };
 
-	// Check index.
-	CHECK_PLAYER(params[1]);
+	CHECK_PLAYER(params[arg_index]);
 
-	// Get player pointer.
-	edict_t *pPlayer = TypeConversion.id_to_edict(params[1]);
+	auto itemLength = 0;
+	auto item = MF_GetAmxString(amx, params[arg_item], 1, &itemLength);
 
-	// Create item entity pointer
-	edict_t	*pItemEntity;
-
-	// Make an "intstring" out of 2nd parameter
-	int length;
-	const char *szItem = MF_GetAmxString(amx, params[2], 1, &length);
-
-	//check for valid item
-	if (strncmp(szItem, "weapon_", 7) && 
-		strncmp(szItem, "ammo_", 5) && 
-		strncmp(szItem, "item_", 5) &&
-		strncmp(szItem, "tf_weapon_", 10)
-	) {
+	if (!itemLength 
+		||(strncmp(item, "weapon_", 7)
+		&& strncmp(item, "ammo_", 5)
+		&& strncmp(item, "item_", 5)
+		&& strncmp(item, "tf_weapon_", 10)))
+	{
 		return 0;
 	}
 
-	//string_t item = MAKE_STRING(szItem);
-	string_t item = ALLOC_STRING(szItem); // Using MAKE_STRING makes "item" contents get lost when we leave this scope! ALLOC_STRING seems to allocate properly...
-	// Create the entity, returns to pointer
-	pItemEntity = CREATE_NAMED_ENTITY(item);
+	auto pEntity = CREATE_NAMED_ENTITY(ALLOC_STRING(item));
 
-	if (FNullEnt(pItemEntity)) {
-		MF_LogError(amx, AMX_ERR_NATIVE, "Item \"%s\" failed to create", szItem);
+	if (FNullEnt(pEntity))
+	{
+		MF_LogError(amx, AMX_ERR_NATIVE, "Item \"%s\" failed to create", item);
 		return 0;
 	}
 
-	//VARS(pItemEntity)->origin = VARS(pPlayer)->origin; // nice to do VARS(ent)->origin instead of ent->v.origin? :-I
-	//I'm not sure, normally I use macros too =P
-	pItemEntity->v.origin = pPlayer->v.origin;
-	pItemEntity->v.spawnflags |= SF_NORESPAWN;	//SF_NORESPAWN;
+	auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
 
-	MDLL_Spawn(pItemEntity);
+	pEntity->v.origin = pPlayer->v.origin;
+	pEntity->v.spawnflags |= SF_NORESPAWN;
 
-	int save = pItemEntity->v.solid;
+	MDLL_Spawn(pEntity);
 
-	MDLL_Touch(pItemEntity, ENT(pPlayer));
+	auto oldSolid = pEntity->v.solid;
 
-	//The problem with the original give_item was the
-	// item was not removed.  I had tried this but it
-	// did not work.  OLO's implementation is better.
-	/*
-	int iEnt = ENTINDEX(pItemEntity->v.owner);
-	if (iEnt > 32 || iEnt <1 ) {
-		MDLL_Think(pItemEntity);
-	}*/
+	MDLL_Touch(pEntity, pPlayer);
 
-	if (pItemEntity->v.solid == save) {
-		REMOVE_ENTITY(pItemEntity);
-		//the function did not fail - we're just deleting the item
+	if (pEntity->v.solid == oldSolid)
+	{
+		REMOVE_ENTITY(pEntity); // The function did not fail - we're just deleting the item
 		return -1;
 	}
 
-	return TypeConversion.edict_to_id(pItemEntity);
+	return TypeConversion.edict_to_id(pEntity);
 }
 
-static cell AMX_NATIVE_CALL spawn(AMX *amx, cell *params) // spawn(id) = 1 param
+// native spawn(index)
+static cell AMX_NATIVE_CALL spawn(AMX *amx, cell *params)
 {
-	// Spawns an entity, this can be a user/player -> spawns at spawnpoints, or created entities seems to need this as a final "kick" into the game? :-)
-	// params[1] = entity to spawn
+	enum args { arg_count, arg_index };
 
-	CHECK_ENTITY(params[1]);
+	CHECK_ENTITY(params[arg_index]);
 
-	edict_t *pEnt = TypeConversion.id_to_edict(params[1]);
+	auto pEntity = TypeConversion.id_to_edict(params[arg_index]);
 
-	MDLL_Spawn(pEnt);
+	MDLL_Spawn(pEntity);
 
 	return 1;
 }
 
-static cell AMX_NATIVE_CALL set_user_health(AMX *amx, cell *params) // set_user_health(index, health); = 2 arguments
+// native set_user_health(index, health)
+static cell AMX_NATIVE_CALL set_user_health(AMX *amx, cell *params)
 {
-	// Sets user health. If health is 0 and below, also kill...
-	// params[1] = index
-	// params[2] = health
+	enum args { arg_count, arg_index, arg_health };
 
-	// Check index
-	CHECK_PLAYER(params[1]);
+	CHECK_PLAYER(params[arg_index]);
 
-	// Fetch player pointer
-	edict_t *pPlayer = TypeConversion.id_to_edict(params[1]);
+	auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
+	auto health  = float(params[arg_health]);
 
-	// Kill if health too low.
-	if (params[2] > 0)
-		pPlayer->v.health = float(params[2]);
+	if (health > 0.0f)
+	{
+		pPlayer->v.health = health;
+	}
 	else
+	{
 		MDLL_ClientKill(pPlayer);
+	}
 
 	return 1;
 }
 
-static cell AMX_NATIVE_CALL set_user_frags(AMX *amx, cell *params) // set_user_frags(index, frags); = 2 arguments
+// native set_user_frags(index, frags)
+static cell AMX_NATIVE_CALL set_user_frags(AMX *amx, cell *params)
 {
-	// Sets user frags.
-	// params[1] = index
-	// params[2] = frags
+	enum args { arg_count, arg_index, arg_frags };
 
-	// Check index
-	CHECK_PLAYER(params[1]);
+	CHECK_PLAYER(params[arg_index]);
 
-	// Fetch player pointer
-	edict_t *pPlayer = TypeConversion.id_to_edict(params[1]);
+	auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
 
-	pPlayer->v.frags = params[2];
+	pPlayer->v.frags = float(params[arg_frags]);
 
 	return 1;
 }
 
-static cell AMX_NATIVE_CALL set_user_armor(AMX *amx, cell *params) // set_user_armor(index, armor); = 2 arguments
+// native set_user_armor(index, armor)
+static cell AMX_NATIVE_CALL set_user_armor(AMX *amx, cell *params)
 {
-	// Sets user armor.
-	// params[1] = index
-	// params[2] = armor
+	enum args { arg_count, arg_index, arg_armor };
 
-	// Check index
-	CHECK_PLAYER(params[1]);
+	CHECK_PLAYER(params[arg_index]);
 
-	// Fetch player pointer
-	edict_t *pPlayer = TypeConversion.id_to_edict(params[1]);
+	auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
 
-	pPlayer->v.armorvalue = params[2];
+	pPlayer->v.armorvalue = float(params[arg_armor]);
 
 	return 1;
 }
 
-static cell AMX_NATIVE_CALL set_user_origin(AMX *amx, cell *params) // set_user_origin(index, origin[3]); = 2 arguments
+// native set_user_origin(index, const origin[3])
+static cell AMX_NATIVE_CALL set_user_origin(AMX *amx, cell *params)
 {
-	// Sets user origin.
-	// params[1] = index
-	// params[2] = origin
+	enum args { arg_count, arg_index, arg_origin };
 
-	// Check index
-	CHECK_PLAYER(params[1]);
+	CHECK_PLAYER(params[arg_index]);
 
-	// Fetch player pointer
-	edict_t *pPlayer = TypeConversion.id_to_edict(params[1]);
-
-	cell *newVectorCell = MF_GetAmxAddr(amx, params[2]);
+	auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
+	auto pVector = MF_GetAmxAddr(amx, params[arg_origin]);
 
 	SET_SIZE(pPlayer, pPlayer->v.mins, pPlayer->v.maxs);
-	SET_ORIGIN(pPlayer, Vector((float)newVectorCell[0], (float)newVectorCell[1], (float)newVectorCell[2]));
-	
+	SET_ORIGIN(pPlayer, Vector(float(pVector[0]), float(pVector[1]), float(pVector[2])));
+
 	return 1;
 }
 
-static cell AMX_NATIVE_CALL set_user_rendering(AMX *amx, cell *params) // set_user_rendering(index, fx = kRenderFxNone, r = 255, g = 255, b = 255, render = kRenderNormal, amount = 16); = 7 arguments
+// native set_user_rendering(index, fx = kRenderFxNone, r = 0, g = 0, b = 0, render = kRenderNormal, amount = 0)
+static cell AMX_NATIVE_CALL set_user_rendering(AMX *amx, cell *params)
 {
-	// Sets user rendering.
-	// params[1] = index
-	// params[2] = fx
-	// params[3] = r
-	// params[4] = g
-	// params[5] = b
-	// params[6] = render
-	// params[7] = amount
+	enum args { arg_count, arg_index, arg_fx, arg_red, arg_green, arg_blue, arg_render, arg_amount };
 
-	// Check index
-	CHECK_PLAYER(params[1]);
+	CHECK_PLAYER(params[arg_index]);
 
-	// Fetch player pointer
-	edict_t *pPlayer = TypeConversion.id_to_edict(params[1]);
+	auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
 
-	pPlayer->v.renderfx = params[2];
-	Vector newVector = Vector(float(params[3]), float(params[4]), float(params[5]));
-	pPlayer->v.rendercolor = newVector;
-	pPlayer->v.rendermode = params[6];
-	pPlayer->v.renderamt = params[7];
-	
+	pPlayer->v.renderfx    = params[arg_fx];
+	pPlayer->v.rendercolor = Vector(float(params[arg_red]), float(params[arg_green]), float(params[arg_blue]));
+	pPlayer->v.rendermode  = params[arg_render];
+	pPlayer->v.renderamt   = float(params[arg_amount]);
+
 	return 1;
 }
 
@@ -333,248 +236,249 @@ static cell AMX_NATIVE_CALL get_user_rendering(AMX *amx, cell *params) // get_us
 	return 1;
 }
 
-static cell AMX_NATIVE_CALL set_user_maxspeed(AMX *amx, cell *params) // set_user_maxspeed(index, Float:speed = -1.0) = 2 arguments
+// native set_user_maxspeed(index, Float:speed = -1.0)
+static cell AMX_NATIVE_CALL set_user_maxspeed(AMX *amx, cell *params)
 {
-	// Sets user maxspeed.
-	// params[1] = index
-	// params[2] = speed (should be -1.0 if not specified) (JGHG: unspecified parameters seems to always be -1.0!)
+	enum args { arg_count, arg_index, arg_speed };
 
-	REAL fNewSpeed = amx_ctof(params[2]);
+	CHECK_PLAYER(params[arg_index]);
 
-	// Check index
-	CHECK_PLAYER(params[1]);
+	auto pPlayer  = TypeConversion.id_to_edict(params[arg_index]);
+	auto newSpeed = amx_ctof(params[arg_speed]);
 
-	// Fetch player pointer
-	edict_t *pPlayer = TypeConversion.id_to_edict(params[1]);
-
-	SETCLIENTMAXSPEED(pPlayer, fNewSpeed);
-	pPlayer->v.maxspeed = fNewSpeed;
+	SETCLIENTMAXSPEED(pPlayer, newSpeed);
+	pPlayer->v.maxspeed = newSpeed;
 
 	return 1;
 }
 
-static cell AMX_NATIVE_CALL get_user_maxspeed(AMX *amx, cell *params) // Float:get_user_maxspeed(index) = 1 argument
+// native Float:get_user_maxspeed(index)
+static cell AMX_NATIVE_CALL get_user_maxspeed(AMX *amx, cell *params)
 {
-	// Gets user maxspeed.
-	// params[1] = index
+	enum args { arg_count, arg_index };
 
-	// Check index
-	CHECK_PLAYER(params[1]);
+	CHECK_PLAYER(params[arg_index]);
 
-	// Fetch player pointer
-	edict_t *pPlayer = TypeConversion.id_to_edict(params[1]);
+	auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
 
 	return amx_ftoc(pPlayer->v.maxspeed);
 }
 
-static cell AMX_NATIVE_CALL set_user_gravity(AMX *amx, cell *params) // set_user_gravity(index, Float:gravity = 1.0) = 2 arguments
+// native set_user_gravity(index, Float:gravity = 1.0)
+static cell AMX_NATIVE_CALL set_user_gravity(AMX *amx, cell *params)
 {
-	// Sets user gravity.
-	// params[1] = index
-	// params[2] = gravity (=-1.0)
-	// Check index
-	CHECK_PLAYER(params[1]);
+	enum args { arg_count, arg_index, arg_gravity };
 
-	// Fetch player pointer
-	edict_t *pPlayer = TypeConversion.id_to_edict(params[1]);
+	CHECK_PLAYER(params[arg_index]);
 
-	pPlayer->v.gravity = amx_ctof(params[2]);
+	auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
+
+	pPlayer->v.gravity = amx_ctof(params[arg_gravity]);
 
 	return 1;
 }
 
-static cell AMX_NATIVE_CALL get_user_gravity(AMX *amx, cell *params) // Float:get_user_gravity(index) = 1 argument
+// native Float:get_user_gravity(index)
+static cell AMX_NATIVE_CALL get_user_gravity(AMX *amx, cell *params)
 {
-	// Gets user gravity.
-	// params[1] = index
+	enum args { arg_count, arg_index };
 
-	// Check index
-	CHECK_PLAYER(params[1]);
+	CHECK_PLAYER(params[arg_index]);
 
-	// Fetch player pointer
-	edict_t *pPlayer = TypeConversion.id_to_edict(params[1]);
+	auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
 
 	return amx_ftoc(pPlayer->v.gravity); 
 }
 
-static cell AMX_NATIVE_CALL set_user_hitzones(AMX *amx, cell *params) // set_user_hitzones(index = 0, target = 0, body = 255); = 3 arguments
+// native set_user_hitzones(index = 0, target = 0, body = 255)
+static cell AMX_NATIVE_CALL set_user_hitzones(AMX *amx, cell *params)
 {
-	// Sets user hitzones.
-	// params[1] = the one(s) who shoot(s), shooter
-	int shooter = params[1];
+	enum args { arg_count, arg_attacker, arg_target, arg_hitzones };
 
-	// params[2] = the one getting hit
-	int gettingHit = params[2];
+	int attacker = params[arg_attacker];
+	int target   = params[arg_target];
+	int hitzones = params[arg_hitzones];
 
-	// params[3] = specified hit zones
-	int hitzones = params[3];
-
-	//set_user_hitzones(id, 0, 0) // Makes ID not able to shoot EVERYONE - id can shoot on 0 (all) at 0
-	//set_user_hitzones(0, id, 0) // Makes EVERYONE not able to shoot ID - 0 (all) can shoot id at 0
-	if (shooter == 0 && gettingHit == 0) {
-		for (int i = 1; i <= gpGlobals->maxClients; i++) {
-			for (int j = 1; j <= gpGlobals->maxClients; j++) {
+	if (attacker == 0 && target == 0)
+	{
+		for (auto i = 1; i <= gpGlobals->maxClients; ++i) 
+		{
+			for (auto j = 1; j <= gpGlobals->maxClients; ++j) 
+			{
 				Players[i].SetBodyHits(j, hitzones);
 			}
-			//g_zones_toHit[i] = hitzones;
-			//g_zones_getHit[i] = hitzones;
 		}
 	}
-	else if (shooter == 0 && gettingHit != 0) {
-		// "All" shooters, target (gettingHit) should be existing player id
-		CHECK_PLAYER(gettingHit);
-		// Where can all hit gettingHit?
-		for (int i = 1; i <= gpGlobals->maxClients; i++)
-			Players[i].SetBodyHits(gettingHit, hitzones);
+	else if (attacker == 0 && target != 0)
+	{
+		CHECK_PLAYER(target);
+
+		for (auto i = 1; i <= gpGlobals->maxClients; ++i)
+		{
+			Players[i].SetBodyHits(target, hitzones);
+		}
 	}
-	else if (shooter != 0 && gettingHit == 0) {
-		// Shooter can hit all in bodyparts.
-		CHECK_PLAYER(shooter);
-		for (int i = 1; i <= gpGlobals->maxClients; i++)
-			Players[shooter].SetBodyHits(i, hitzones);
+	else if (attacker != 0 && target == 0) 
+	{
+		CHECK_PLAYER(attacker);
+
+		for (auto i = 1; i <= gpGlobals->maxClients; ++i)
+		{
+			Players[attacker].SetBodyHits(i, hitzones);
+		}
 	}
-	else {
-		// Specified, where can player A hit player B?
-		CHECK_PLAYER(shooter);
-		CHECK_PLAYER(gettingHit);
-		Players[shooter].SetBodyHits(gettingHit, hitzones);
-	}
-
-	return 1;
-}
-
-static cell AMX_NATIVE_CALL get_user_hitzones(AMX *amx, cell *params) // get_user_hitzones(index, target); = 2 arguments
-{
-	int shooter = params[1];
-	CHECK_PLAYER(shooter);
-	int target = params[2];
-	CHECK_PLAYER(target);
-	return Players[shooter].GetBodyHits(target);
-}
-
-static cell AMX_NATIVE_CALL set_user_noclip(AMX *amx, cell *params) // set_user_noclip(index, noclip = 0); = 2 arguments
-{
-	// Sets user to no clipping mode.
-	// params[1] = index
-	// params[2] = no clip or not...
-
-	// Check index
-	CHECK_PLAYER(params[1]);
-
-	// Fetch player pointer
-	edict_t *pPlayer = TypeConversion.id_to_edict(params[1]);
-
-	if (params[2] == 1)
-		pPlayer->v.movetype = MOVETYPE_NOCLIP;
 	else
-		pPlayer->v.movetype = MOVETYPE_WALK;
+	{
+		CHECK_PLAYER(attacker);
+		CHECK_PLAYER(target);
+
+		Players[attacker].SetBodyHits(target, hitzones);
+	}
 
 	return 1;
 }
 
-static cell AMX_NATIVE_CALL get_user_noclip(AMX *amx, cell *params) // get_user_noclip(index); = 1 argument
+// native get_user_hitzones(index, target)
+static cell AMX_NATIVE_CALL get_user_hitzones(AMX *amx, cell *params)
 {
-	// Gets user noclip.
-	// params[1] = index
+	enum args { arg_count, arg_attacker, arg_target };
 
-	// Check index
-	CHECK_PLAYER(params[1]);
+	auto attacker = params[arg_attacker];
 
-	// Fetch player pointer
-	edict_t *pPlayer = TypeConversion.id_to_edict(params[1]);
+	CHECK_PLAYER(attacker);
+
+	auto target = params[arg_target];
+
+	CHECK_PLAYER(target);
+
+	return Players[attacker].GetBodyHits(target);
+}
+
+// native set_user_noclip(index, noclip = 0)
+static cell AMX_NATIVE_CALL set_user_noclip(AMX *amx, cell *params)
+{
+	enum args { arg_count, arg_index, arg_noclip };
+
+	CHECK_PLAYER(params[arg_index]);
+
+	auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
+
+	pPlayer->v.movetype = params[arg_noclip] != 0 ? MOVETYPE_NOCLIP : MOVETYPE_WALK;
+
+	return 1;
+}
+
+// native get_user_noclip(index)
+static cell AMX_NATIVE_CALL get_user_noclip(AMX *amx, cell *params)
+{
+	enum args { arg_count, arg_index };
+
+	CHECK_PLAYER(params[arg_index]);
+
+	auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
 
 	return pPlayer->v.movetype == MOVETYPE_NOCLIP;
 }
 
-// JustinHoMi made this one originally
-static cell AMX_NATIVE_CALL set_user_footsteps(AMX *amx, cell *params) // set_user_footsteps(id, set = 1); = 2 params
+// native set_user_footsteps(id, set = 1)
+static cell AMX_NATIVE_CALL set_user_footsteps(AMX *amx, cell *params)
 {
-	// Gives player silent footsteps.
-	// if set=0 it will return footsteps to normal
-	// params[1] = index of player
-	// params[2] = 0 = normal footstep sound, 1 = silent slippers
+	enum args { arg_count, arg_index, arg_footsteps };
 
-	// Check index
-	CHECK_PLAYER(params[1]);
+	auto index = params[arg_index];
 
-	// Fetch player pointer
-	edict_t *pPlayer = TypeConversion.id_to_edict(params[1]);
+	CHECK_PLAYER(index);
 
-	if (params[2]) {
+	auto pPlayer = TypeConversion.id_to_edict(index);
+
+	if (params[arg_footsteps] != 0)
+	{
 		pPlayer->v.flTimeStepSound = 999;
-		Players[params[1]].SetSilentFootsteps(true);
+		Players[index].SetSilentFootsteps(true);
 	}
-	else {
+	else 
+	{
 		pPlayer->v.flTimeStepSound = STANDARDTIMESTEPSOUND;
-		Players[params[1]].SetSilentFootsteps(false);
+		Players[index].SetSilentFootsteps(false);
 	}
 
 	return 1;
 }
 
+// native get_user_footsteps(index)
 static cell AMX_NATIVE_CALL get_user_footsteps(AMX *amx, cell *params)
 {
-	CHECK_PLAYER(params[1]);
+	enum args { arg_count, arg_index };
 
-	return Players[params[1]].HasSilentFootsteps();
+	auto index = params[arg_index];
+
+	CHECK_PLAYER(index);
+
+	return Players[index].HasSilentFootsteps();
 }
 
-// SidLuke
-static cell AMX_NATIVE_CALL strip_user_weapons(AMX *amx, cell *params) // index
+// native strip_user_weapons(index)
+static cell AMX_NATIVE_CALL strip_user_weapons(AMX *amx, cell *params)
 {
-	CHECK_PLAYER(params[1]);
+	enum args { arg_count, arg_index };
 
-	edict_t* pPlayer = TypeConversion.id_to_edict(params[1]);
+	auto index = params[arg_index];
 
-	string_t item = MAKE_STRING("player_weaponstrip");
-	edict_t *pent = CREATE_NAMED_ENTITY(item);
+	CHECK_PLAYER(index);
 
-	if (FNullEnt(pent))
+	auto pPlayer = TypeConversion.id_to_edict(index);
+	auto pEntity = CREATE_NAMED_ENTITY(MAKE_STRING("player_weaponstrip"));
+
+	if (FNullEnt(pEntity))
 	{
 		return 0;
 	}
 
-	MDLL_Spawn(pent);
-	MDLL_Use(pent, pPlayer);
-	REMOVE_ENTITY(pent);
+	MDLL_Spawn(pEntity);
+	MDLL_Use(pEntity, pPlayer);
+	REMOVE_ENTITY(pEntity);
 
-	*reinterpret_cast<int *>(MF_PlayerPropAddr(params[1], Player_CurrentWeapon)) = 0;
+	*reinterpret_cast<int *>(MF_PlayerPropAddr(index, Player_CurrentWeapon)) = 0;
 
 	return 1;
 }
 
-AMX_NATIVE_INFO fun_Exports[] = {
-	{"get_client_listen",		get_client_listening},
-	{"set_client_listen",		set_client_listening},
-	{"set_user_godmode",		set_user_godmode},
-	{"get_user_godmode",		get_user_godmode},
-	{"set_user_health",			set_user_health},
-	{"give_item",				give_item},
-	{"spawn",					spawn},
-	{"set_user_frags",			set_user_frags},
-	{"set_user_armor",			set_user_armor},
-	{"set_user_origin",			set_user_origin},
-	{"set_user_rendering",		set_user_rendering},
-	{"get_user_rendering",		get_user_rendering},
-	{"set_user_maxspeed",		set_user_maxspeed},
-	{"get_user_maxspeed",		get_user_maxspeed},
-	{"set_user_gravity",		set_user_gravity},
-	{"get_user_gravity",		get_user_gravity},
-	{"get_user_footsteps",		get_user_footsteps},
-	{"set_user_hitzones",		set_user_hitzones},
-	{"get_user_hitzones",		get_user_hitzones},
-	{"set_user_noclip",			set_user_noclip},
-	{"get_user_noclip",			get_user_noclip},
-	{"set_user_footsteps",		set_user_footsteps},
-	{"strip_user_weapons",		strip_user_weapons},
-	  /////////////////// <--- 19 chars max in current small version
-	{NULL,					NULL}
+
+AMX_NATIVE_INFO fun_Exports[] = 
+{
+	{ "get_client_listen" , get_client_listening },
+	{ "set_client_listen" , set_client_listening },
+	{ "set_user_godmode"  , set_user_godmode },
+	{ "get_user_godmode"  , get_user_godmode },
+	{ "set_user_health"   , set_user_health },
+	{ "give_item"         , give_item },
+	{ "spawn"             , spawn },
+	{ "set_user_frags"    , set_user_frags },
+	{ "set_user_armor"    , set_user_armor },
+	{ "set_user_origin"   , set_user_origin },
+	{ "set_user_rendering", set_user_rendering },
+	{ "get_user_rendering",	get_user_rendering},
+	{ "set_user_maxspeed" , set_user_maxspeed },
+	{ "get_user_maxspeed" , get_user_maxspeed },
+	{ "set_user_gravity"  , set_user_gravity },
+	{ "get_user_gravity"  , get_user_gravity },
+	{ "get_user_footsteps", get_user_footsteps },
+	{ "set_user_hitzones" , set_user_hitzones },
+	{ "get_user_hitzones" , get_user_hitzones },
+	{ "set_user_noclip"   , set_user_noclip },
+	{ "get_user_noclip"   , get_user_noclip },
+	{ "set_user_footsteps", set_user_footsteps },
+	{ "strip_user_weapons", strip_user_weapons },
+	{ NULL                , NULL }
 };
 
-/******************************************************************************************/
+
 void PlayerPreThink(edict_t *pEntity)
 {
-	if (Players[TypeConversion.edict_to_id(pEntity)].HasSilentFootsteps()) {
+	auto index = TypeConversion.edict_to_id(pEntity);
+
+	if (Players[index].HasSilentFootsteps())
+	{
 		pEntity->v.flTimeStepSound = 999; 
 		RETURN_META(MRES_HANDLED);
 	}
@@ -584,75 +488,44 @@ void PlayerPreThink(edict_t *pEntity)
 
 int ClientConnect(edict_t *pPlayer, const char *pszName, const char *pszAddress, char szRejectReason[128])
 {
-	Players[TypeConversion.edict_to_id(pPlayer)].Reset();
+	auto index = TypeConversion.edict_to_id(pPlayer);
+
+	Players[index].Reset();
 
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
-void TraceLine(const float *v1, const float *v2, int fNoMonsters, edict_t *shooter, TraceResult *ptr) {
+void TraceLine(const float *v1, const float *v2, int fNoMonsters, edict_t *shooter, TraceResult *ptr) 
+{
 	TRACE_LINE(v1, v2, fNoMonsters, shooter, ptr);
-	if ( ptr->pHit && (ptr->pHit->v.flags& (FL_CLIENT | FL_FAKECLIENT))
-	&& shooter && (shooter->v.flags & (FL_CLIENT | FL_FAKECLIENT)) ) {
-		int shooterIndex = TypeConversion.edict_to_id(shooter);
-		if ( !(Players[shooterIndex].GetBodyHits(TypeConversion.edict_to_id(ptr->pHit))& (1<<ptr->iHitgroup)) )
+
+	if (ptr->pHit && (ptr->pHit->v.flags & (FL_CLIENT | FL_FAKECLIENT))
+	    && shooter &&  (shooter->v.flags & (FL_CLIENT | FL_FAKECLIENT)) ) 
+	{
+		auto shooterIndex = TypeConversion.edict_to_id(shooter);
+		auto targetIndex  = TypeConversion.edict_to_id(ptr->pHit);
+
+		if (!(Players[shooterIndex].GetBodyHits(targetIndex) & (1 << ptr->iHitgroup)))
+		{
 			ptr->flFraction = 1.0;
+		}
 	}
+
 	RETURN_META(MRES_SUPERCEDE);
 }
-
-
-//int g_hitIndex, g_canTargetGetHit, g_canShooterHitThere;
-//void TraceLine(const float *v1, const float *v2, int fNoMonsters, edict_t *shooter, TraceResult *ptr) {
-//	if (!pentToSkip || (pentToSkip->v.flags & (FL_CLIENT | FL_FAKECLIENT)) == false || pentToSkip->v.deadflag != DEAD_NO)
-//		RETURN_META(MRES_IGNORED);
-//
-//	TRACE_LINE(v1, v2, fNoMonsters, shooter, ptr); // Filter shooter
-//
-//	if (!ptr->pHit || (ptr->pHit->v.flags & (FL_CLIENT | FL_FAKECLIENT)) == false )
-//		RETURN_META(MRES_SUPERCEDE);
-//
-//	g_hitIndex = ENTINDEX(ptr->pHit);
-//	//bool blocked = false;
-//	g_canTargetGetHit = g_zones_getHit[g_hitIndex] & (1 << ptr->iHitgroup);
-//	g_canShooterHitThere = g_zones_toHit[ENTINDEX(shooter)] & (1 << ptr->iHitgroup);
-//
-//	if (!g_canTargetGetHit || !g_canShooterHitThere) {
-//		ptr->flFraction = 1.0;	// set to not hit anything (1.0 = shot doesn't hit anything)
-//		//blocked = true;
-//	}
-//	/*
-//	if (blocked) {
-//		MF_PrintSrvConsole("%s was blocked from hitting %s: %d and %d\n", MF_GetPlayerName(ENTINDEX(pentToSkip)), MF_GetPlayerName(hitIndex), canTargetGetHit, canShooterHitThere);
-//	}
-//	else {
-//		MF_PrintSrvConsole("%s was NOT blocked from hitting %s: %d and %d\n", MF_GetPlayerName(ENTINDEX(pentToSkip)), MF_GetPlayerName(hitIndex), canTargetGetHit, canShooterHitThere);
-//	}
-//	*/
-//
-//	RETURN_META(MRES_SUPERCEDE);
-//}
 
 void OnAmxxAttach()
 {
 	MF_AddNatives(fun_Exports);
 }
 
-// The content of OnPluginsLoaded() was moved from OnAmxxAttach with AMXx 1.5 because for some reason gpGlobals->maxClients wasn't
-// initialized to its proper value until some time after OnAmxxAttach(). In OnAmxxAttach() it always showed 0. /JGHG
-void OnPluginsLoaded() {
-	// Reset stuff - hopefully this should
-	for (int i = 1; i <= gpGlobals->maxClients; i++) {
-		// Reset all hitzones
+void OnPluginsLoaded() 
+{
+	for (auto i = 1; i <= gpGlobals->maxClients; ++i) 
+	{
 		Players[i].Reset();
 	}
 
 	TypeConversion.init();
 }
-/*
-void ClientConnectFakeBot(int index)
-{
-	FUNUTIL_ResetPlayer(index);
-	//MF_Log("A bot connects, forwarded to fun! The bot is %d!", index);
-	//CPlayer* player;
-}
-*/
+

--- a/modules/fun/fun.cpp
+++ b/modules/fun/fun.cpp
@@ -395,11 +395,26 @@ static cell AMX_NATIVE_CALL set_user_footsteps(AMX *amx, cell *params)
 	{
 		pPlayer->v.flTimeStepSound = 999;
 		Players[index].SetSilentFootsteps(true);
+
+		g_pFunctionTable->pfnPlayerPreThink = PlayerPreThink;
 	}
 	else 
 	{
 		pPlayer->v.flTimeStepSound = STANDARDTIMESTEPSOUND;
 		Players[index].SetSilentFootsteps(false);
+
+		if (g_pFunctionTable->pfnPlayerPreThink)
+		{
+			for (auto i = 1; i <= gpGlobals->maxClients; ++i)
+			{
+				if (Players[i].HasSilentFootsteps())
+				{
+					return 1;
+				}
+			}
+
+			g_pFunctionTable->pfnPlayerPreThink = nullptr;
+		}
 	}
 
 	return 1;
@@ -527,5 +542,13 @@ void OnPluginsLoaded()
 	}
 
 	TypeConversion.init();
+
+	g_pFunctionTable->pfnPlayerPreThink = nullptr;
 }
 
+void ServerDeactivate()
+{
+	g_pFunctionTable->pfnPlayerPreThink = nullptr;
+
+	RETURN_META(MRES_IGNORED);
+}

--- a/modules/fun/fun.cpp
+++ b/modules/fun/fun.cpp
@@ -510,10 +510,8 @@ int ClientConnect(edict_t *pPlayer, const char *pszName, const char *pszAddress,
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
-void TraceLine(const float *v1, const float *v2, int fNoMonsters, edict_t *shooter, TraceResult *ptr) 
+void TraceLine_Post(const float *v1, const float *v2, int fNoMonsters, edict_t *shooter, TraceResult *ptr)
 {
-	TRACE_LINE(v1, v2, fNoMonsters, shooter, ptr);
-
 	if (ptr->pHit && (ptr->pHit->v.flags & (FL_CLIENT | FL_FAKECLIENT))
 	    && shooter &&  (shooter->v.flags & (FL_CLIENT | FL_FAKECLIENT)) ) 
 	{
@@ -523,10 +521,11 @@ void TraceLine(const float *v1, const float *v2, int fNoMonsters, edict_t *shoot
 		if (!(Players[shooterIndex].GetBodyHits(targetIndex) & (1 << ptr->iHitgroup)))
 		{
 			ptr->flFraction = 1.0;
+			RETURN_META(MRES_HANDLED);
 		}
 	}
 
-	RETURN_META(MRES_SUPERCEDE);
+	RETURN_META(MRES_IGNORED);
 }
 
 void OnAmxxAttach()

--- a/modules/fun/fun.cpp
+++ b/modules/fun/fun.cpp
@@ -323,6 +323,8 @@ static cell AMX_NATIVE_CALL set_user_hitzones(AMX *amx, cell *params)
 		Players.SetBodyHits(attacker, target, hitzones);
 	}
 
+	g_pengfuncsTable_Post->pfnTraceLine = Players.HaveBodyHits() ? TraceLine_Post : nullptr;
+
 	return 1;
 }
 
@@ -520,11 +522,13 @@ void OnPluginsLoaded()
 	TypeConversion.init();
 
 	g_pFunctionTable->pfnPlayerPreThink = nullptr;
+	g_pengfuncsTable_Post->pfnTraceLine = nullptr;
 }
 
 void ServerDeactivate()
 {
 	g_pFunctionTable->pfnPlayerPreThink = nullptr;
+	g_pengfuncsTable_Post->pfnTraceLine = nullptr;
 
 	RETURN_META(MRES_IGNORED);
 }

--- a/modules/fun/fun.cpp
+++ b/modules/fun/fun.cpp
@@ -214,7 +214,7 @@ static cell AMX_NATIVE_CALL get_user_rendering(AMX *amx, cell *params)
 {
 	enum args { arg_count, arg_index, arg_fx, arg_red, arg_green, arg_blue, arg_render, arg_amount };
 
-	CHECK_PLAYER(params[1]);
+	CHECK_PLAYER(params[arg_index]);
 
 	auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
 
@@ -299,13 +299,13 @@ static cell AMX_NATIVE_CALL set_user_hitzones(AMX *amx, cell *params)
 	{
 		CHECK_PLAYER(target);
 
-		Players.SetTargetsBodyHits(attacker, hitzones);
+		Players.SetAttackersBodyHits(target, hitzones);
 	}
 	else if (attacker != 0 && target == 0)
 	{
 		CHECK_PLAYER(attacker);
 
-		Players.SetAttackersBodyHits(target, hitzones);
+		Players.SetTargetsBodyHits(attacker, hitzones);
 	}
 	else
 	{

--- a/modules/fun/fun.cpp
+++ b/modules/fun/fun.cpp
@@ -46,7 +46,7 @@ static cell AMX_NATIVE_CALL set_user_godmode(AMX *amx, cell *params)
 
 	CHECK_PLAYER(params[arg_user]);
 
-	auto pPlayer = TypeConversion.id_to_edict(params[arg_user]);
+	const auto pPlayer = TypeConversion.id_to_edict(params[arg_user]);
 
 	pPlayer->v.takedamage = params[arg_godmode] != 0 ? DAMAGE_NO : DAMAGE_AIM;
 
@@ -60,7 +60,7 @@ static cell AMX_NATIVE_CALL get_user_godmode(AMX *amx, cell *params)
 
 	CHECK_PLAYER(params[arg_user]);
 
-	auto pPlayer = TypeConversion.id_to_edict(params[arg_user]);
+	const auto pPlayer = TypeConversion.id_to_edict(params[arg_user]);
 
 	return pPlayer->v.takedamage == DAMAGE_NO;
 }
@@ -73,13 +73,13 @@ static cell AMX_NATIVE_CALL give_item(AMX *amx, cell *params)
 	CHECK_PLAYER(params[arg_index]);
 
 	auto itemLength = 0;
-	auto item = MF_GetAmxString(amx, params[arg_item], 1, &itemLength);
+	const auto item = MF_GetAmxString(amx, params[arg_item], 1, &itemLength);
 
-	if (!itemLength 
-		||(strncmp(item, "weapon_", 7)
-		&& strncmp(item, "ammo_", 5)
-		&& strncmp(item, "item_", 5)
-		&& strncmp(item, "tf_weapon_", 10)))
+	if (!itemLength
+		||(strncmp(item, "weapon_", 7) != 0
+		&& strncmp(item, "ammo_", 5) != 0
+		&& strncmp(item, "item_", 5) != 0
+		&& strncmp(item, "tf_weapon_", 10) != 0))
 	{
 		return 0;
 	}
@@ -92,14 +92,14 @@ static cell AMX_NATIVE_CALL give_item(AMX *amx, cell *params)
 		return 0;
 	}
 
-	auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
+	const auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
 
 	pEntity->v.origin = pPlayer->v.origin;
 	pEntity->v.spawnflags |= SF_NORESPAWN;
 
 	MDLL_Spawn(pEntity);
 
-	auto oldSolid = pEntity->v.solid;
+	const auto oldSolid = pEntity->v.solid;
 
 	MDLL_Touch(pEntity, pPlayer);
 
@@ -119,7 +119,7 @@ static cell AMX_NATIVE_CALL spawn(AMX *amx, cell *params)
 
 	CHECK_ENTITY(params[arg_index]);
 
-	auto pEntity = TypeConversion.id_to_edict(params[arg_index]);
+	const auto pEntity = TypeConversion.id_to_edict(params[arg_index]);
 
 	MDLL_Spawn(pEntity);
 
@@ -133,8 +133,8 @@ static cell AMX_NATIVE_CALL set_user_health(AMX *amx, cell *params)
 
 	CHECK_PLAYER(params[arg_index]);
 
-	auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
-	auto health  = float(params[arg_health]);
+	const auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
+	const auto health  = float(params[arg_health]);
 
 	if (health > 0.0f)
 	{
@@ -155,7 +155,7 @@ static cell AMX_NATIVE_CALL set_user_frags(AMX *amx, cell *params)
 
 	CHECK_PLAYER(params[arg_index]);
 
-	auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
+	const auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
 
 	pPlayer->v.frags = float(params[arg_frags]);
 
@@ -169,7 +169,7 @@ static cell AMX_NATIVE_CALL set_user_armor(AMX *amx, cell *params)
 
 	CHECK_PLAYER(params[arg_index]);
 
-	auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
+	const auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
 
 	pPlayer->v.armorvalue = float(params[arg_armor]);
 
@@ -184,7 +184,7 @@ static cell AMX_NATIVE_CALL set_user_origin(AMX *amx, cell *params)
 	CHECK_PLAYER(params[arg_index]);
 
 	auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
-	auto pVector = MF_GetAmxAddr(amx, params[arg_origin]);
+	const auto pVector = MF_GetAmxAddr(amx, params[arg_origin]);
 
 	SET_SIZE(pPlayer, pPlayer->v.mins, pPlayer->v.maxs);
 	SET_ORIGIN(pPlayer, Vector(float(pVector[0]), float(pVector[1]), float(pVector[2])));
@@ -209,30 +209,22 @@ static cell AMX_NATIVE_CALL set_user_rendering(AMX *amx, cell *params)
 	return 1;
 }
 
-static cell AMX_NATIVE_CALL get_user_rendering(AMX *amx, cell *params) // get_user_rendering(index, &fx = kRenderFxNone, &r = 0, &g = 0, &b = 0, &render = kRenderNormal, &amount = 0); = 7 arguments
+// get_user_rendering(index, &fx = kRenderFxNone, &r = 0, &g = 0, &b = 0, &render = kRenderNormal, &amount = 0);
+static cell AMX_NATIVE_CALL get_user_rendering(AMX *amx, cell *params)
 {
-	// Gets user rendering.
-	// params[1] = index
-	// params[2] = fx
-	// params[3] = r
-	// params[4] = g
-	// params[5] = b
-	// params[6] = render
-	// params[7] = amount
+	enum args { arg_count, arg_index, arg_fx, arg_red, arg_green, arg_blue, arg_render, arg_amount };
 
-	// Check index
 	CHECK_PLAYER(params[1]);
 
-	// Fetch player pointer
-	edict_t *pPlayer = TypeConversion.id_to_edict(params[1]);
+	auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
 
-	*MF_GetAmxAddr(amx, params[2]) = pPlayer->v.renderfx;
-	*MF_GetAmxAddr(amx, params[3]) = pPlayer->v.rendercolor[0];
-	*MF_GetAmxAddr(amx, params[4]) = pPlayer->v.rendercolor[1];
-	*MF_GetAmxAddr(amx, params[5]) = pPlayer->v.rendercolor[2];
-	*MF_GetAmxAddr(amx, params[6]) = pPlayer->v.rendermode;
-	*MF_GetAmxAddr(amx, params[7]) = pPlayer->v.renderamt;
-	
+	*MF_GetAmxAddr(amx, params[arg_fx])     = pPlayer->v.renderfx;
+	*MF_GetAmxAddr(amx, params[arg_red])    = pPlayer->v.rendercolor[0];
+	*MF_GetAmxAddr(amx, params[arg_green])  = pPlayer->v.rendercolor[1];
+	*MF_GetAmxAddr(amx, params[arg_blue])   = pPlayer->v.rendercolor[2];
+	*MF_GetAmxAddr(amx, params[arg_render]) = pPlayer->v.rendermode;
+	*MF_GetAmxAddr(amx, params[arg_amount]) = pPlayer->v.renderamt;
+
 	return 1;
 }
 
@@ -243,8 +235,8 @@ static cell AMX_NATIVE_CALL set_user_maxspeed(AMX *amx, cell *params)
 
 	CHECK_PLAYER(params[arg_index]);
 
-	auto pPlayer  = TypeConversion.id_to_edict(params[arg_index]);
-	auto newSpeed = amx_ctof(params[arg_speed]);
+	const auto pPlayer  = TypeConversion.id_to_edict(params[arg_index]);
+	const auto newSpeed = amx_ctof(params[arg_speed]);
 
 	SETCLIENTMAXSPEED(pPlayer, newSpeed);
 	pPlayer->v.maxspeed = newSpeed;
@@ -259,7 +251,7 @@ static cell AMX_NATIVE_CALL get_user_maxspeed(AMX *amx, cell *params)
 
 	CHECK_PLAYER(params[arg_index]);
 
-	auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
+	const auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
 
 	return amx_ftoc(pPlayer->v.maxspeed);
 }
@@ -271,7 +263,7 @@ static cell AMX_NATIVE_CALL set_user_gravity(AMX *amx, cell *params)
 
 	CHECK_PLAYER(params[arg_index]);
 
-	auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
+	const auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
 
 	pPlayer->v.gravity = amx_ctof(params[arg_gravity]);
 
@@ -285,9 +277,9 @@ static cell AMX_NATIVE_CALL get_user_gravity(AMX *amx, cell *params)
 
 	CHECK_PLAYER(params[arg_index]);
 
-	auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
+	const auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
 
-	return amx_ftoc(pPlayer->v.gravity); 
+	return amx_ftoc(pPlayer->v.gravity);
 }
 
 // native set_user_hitzones(index = 0, target = 0, body = HITZONES_DEFAULT)
@@ -295,9 +287,9 @@ static cell AMX_NATIVE_CALL set_user_hitzones(AMX *amx, cell *params)
 {
 	enum args { arg_count, arg_attacker, arg_target, arg_hitzones };
 
-	int attacker = params[arg_attacker];
-	int target   = params[arg_target];
-	int hitzones = params[arg_hitzones];
+	const int attacker = params[arg_attacker];
+	const int target   = params[arg_target];
+	const int hitzones = params[arg_hitzones];
 
 	if (attacker == 0 && target == 0)
 	{
@@ -309,7 +301,7 @@ static cell AMX_NATIVE_CALL set_user_hitzones(AMX *amx, cell *params)
 
 		Players.SetTargetsBodyHits(attacker, hitzones);
 	}
-	else if (attacker != 0 && target == 0) 
+	else if (attacker != 0 && target == 0)
 	{
 		CHECK_PLAYER(attacker);
 
@@ -333,11 +325,11 @@ static cell AMX_NATIVE_CALL get_user_hitzones(AMX *amx, cell *params)
 {
 	enum args { arg_count, arg_attacker, arg_target };
 
-	auto attacker = params[arg_attacker];
+	const auto attacker = params[arg_attacker];
 
 	CHECK_PLAYER(attacker);
 
-	auto target = params[arg_target];
+	const auto target = params[arg_target];
 
 	CHECK_PLAYER(target);
 
@@ -351,7 +343,7 @@ static cell AMX_NATIVE_CALL set_user_noclip(AMX *amx, cell *params)
 
 	CHECK_PLAYER(params[arg_index]);
 
-	auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
+	const auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
 
 	pPlayer->v.movetype = params[arg_noclip] != 0 ? MOVETYPE_NOCLIP : MOVETYPE_WALK;
 
@@ -365,7 +357,7 @@ static cell AMX_NATIVE_CALL get_user_noclip(AMX *amx, cell *params)
 
 	CHECK_PLAYER(params[arg_index]);
 
-	auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
+	const auto pPlayer = TypeConversion.id_to_edict(params[arg_index]);
 
 	return pPlayer->v.movetype == MOVETYPE_NOCLIP;
 }
@@ -375,11 +367,11 @@ static cell AMX_NATIVE_CALL set_user_footsteps(AMX *amx, cell *params)
 {
 	enum args { arg_count, arg_index, arg_footsteps };
 
-	auto index = params[arg_index];
+	const auto index = params[arg_index];
 
 	CHECK_PLAYER(index);
 
-	auto pPlayer = TypeConversion.id_to_edict(index);
+	const auto pPlayer = TypeConversion.id_to_edict(index);
 
 	if (params[arg_footsteps] != 0)
 	{
@@ -388,7 +380,7 @@ static cell AMX_NATIVE_CALL set_user_footsteps(AMX *amx, cell *params)
 
 		g_pFunctionTable->pfnPlayerPreThink = PlayerPreThink;
 	}
-	else 
+	else
 	{
 		pPlayer->v.flTimeStepSound = STANDARDTIMESTEPSOUND;
 		Players[index].SetSilentFootsteps(false);
@@ -407,7 +399,7 @@ static cell AMX_NATIVE_CALL get_user_footsteps(AMX *amx, cell *params)
 {
 	enum args { arg_count, arg_index };
 
-	auto index = params[arg_index];
+	const auto index = params[arg_index];
 
 	CHECK_PLAYER(index);
 
@@ -419,12 +411,12 @@ static cell AMX_NATIVE_CALL strip_user_weapons(AMX *amx, cell *params)
 {
 	enum args { arg_count, arg_index };
 
-	auto index = params[arg_index];
+	const auto index = params[arg_index];
 
 	CHECK_PLAYER(index);
 
-	auto pPlayer = TypeConversion.id_to_edict(index);
-	auto pEntity = CREATE_NAMED_ENTITY(MAKE_STRING("player_weaponstrip"));
+	const auto pPlayer = TypeConversion.id_to_edict(index);
+	const auto pEntity = CREATE_NAMED_ENTITY(MAKE_STRING("player_weaponstrip"));
 
 	if (FNullEnt(pEntity))
 	{
@@ -441,7 +433,7 @@ static cell AMX_NATIVE_CALL strip_user_weapons(AMX *amx, cell *params)
 }
 
 
-AMX_NATIVE_INFO fun_Exports[] = 
+AMX_NATIVE_INFO fun_Exports[] =
 {
 	{ "get_client_listen" , get_client_listening },
 	{ "set_client_listen" , set_client_listening },
@@ -472,11 +464,11 @@ AMX_NATIVE_INFO fun_Exports[] =
 
 void PlayerPreThink(edict_t *pEntity)
 {
-	auto index = TypeConversion.edict_to_id(pEntity);
+	const auto index = TypeConversion.edict_to_id(pEntity);
 
 	if (Players[index].HasSilentFootsteps())
 	{
-		pEntity->v.flTimeStepSound = 999; 
+		pEntity->v.flTimeStepSound = 999;
 		RETURN_META(MRES_HANDLED);
 	}
 
@@ -485,7 +477,7 @@ void PlayerPreThink(edict_t *pEntity)
 
 int ClientConnect(edict_t *pPlayer, const char *pszName, const char *pszAddress, char szRejectReason[128])
 {
-	auto index = TypeConversion.edict_to_id(pPlayer);
+	const auto index = TypeConversion.edict_to_id(pPlayer);
 
 	Players[index].Clear();
 
@@ -495,10 +487,10 @@ int ClientConnect(edict_t *pPlayer, const char *pszName, const char *pszAddress,
 void TraceLine_Post(const float *v1, const float *v2, int fNoMonsters, edict_t *shooter, TraceResult *ptr)
 {
 	if (ptr->pHit && (ptr->pHit->v.flags & (FL_CLIENT | FL_FAKECLIENT))
-	    && shooter &&  (shooter->v.flags & (FL_CLIENT | FL_FAKECLIENT)) ) 
+	    && shooter &&  (shooter->v.flags & (FL_CLIENT | FL_FAKECLIENT)) )
 	{
-		auto shooterIndex = TypeConversion.edict_to_id(shooter);
-		auto targetIndex  = TypeConversion.edict_to_id(ptr->pHit);
+		const auto shooterIndex = TypeConversion.edict_to_id(shooter);
+		const auto targetIndex  = TypeConversion.edict_to_id(ptr->pHit);
 
 		if (!(Players[shooterIndex].GetBodyHits(targetIndex) & (1 << ptr->iHitgroup)))
 		{
@@ -510,12 +502,13 @@ void TraceLine_Post(const float *v1, const float *v2, int fNoMonsters, edict_t *
 	RETURN_META(MRES_IGNORED);
 }
 
+
 void OnAmxxAttach()
 {
 	MF_AddNatives(fun_Exports);
 }
 
-void OnPluginsLoaded() 
+void OnPluginsLoaded()
 {
 	Players.Clear();
 

--- a/modules/fun/fun.h
+++ b/modules/fun/fun.h
@@ -29,6 +29,54 @@
 #define HITGROUP_RIGHTARM		5 // 32
 #define HITGROUP_LEFTLEG		6 // 64
 #define HITGROUP_RIGHTLEG		7 // 128
+#define HITGROUP_MAX            8
+
+
+static const auto kHitGroupsBits = (1 << HITGROUP_MAX) - 1;
+static const auto kMaxClients = 32u;
+
+class CPlayer
+{
+	public:
+
+		CPlayer()
+		{
+			Reset();
+		}
+
+	public:
+
+		int GetBodyHits(int other) const
+		{
+			return m_BodyHits[other];
+		}
+
+		void SetBodyHits(int other, int flags)
+		{
+			m_BodyHits[other] = flags;
+		}
+
+		bool HasSilentFootsteps() const
+		{
+			return m_HasSilentFootsteps;
+		}
+
+		void SetSilentFootsteps(bool state)
+		{
+			m_HasSilentFootsteps = state;
+		}
+
+		void Reset()
+		{
+			memset(m_BodyHits, kHitGroupsBits, sizeof(m_BodyHits));
+			m_HasSilentFootsteps = false;
+		}
+
+	private:
+
+		int  m_BodyHits[kMaxClients + 1];
+		bool m_HasSilentFootsteps;
+};
 
 #define CHECK_ENTITY(x) \
 	if (x < 0 || x > gpGlobals->maxEntities) { \

--- a/modules/fun/fun.h
+++ b/modules/fun/fun.h
@@ -32,6 +32,7 @@
 #define HITGROUP_MAX            8
 
 extern DLL_FUNCTIONS *g_pFunctionTable;
+extern enginefuncs_t *g_pengfuncsTable_Post;
 
 static const auto kHitGroupsBits = (1 << HITGROUP_MAX) - 1;
 static const auto kMaxClients = 32u;

--- a/modules/fun/fun.h
+++ b/modules/fun/fun.h
@@ -31,6 +31,7 @@
 #define HITGROUP_RIGHTLEG		7 // 128
 #define HITGROUP_MAX            8
 
+extern DLL_FUNCTIONS *g_pFunctionTable;
 
 static const auto kHitGroupsBits = (1 << HITGROUP_MAX) - 1;
 static const auto kMaxClients = 32u;

--- a/modules/fun/fun.h
+++ b/modules/fun/fun.h
@@ -76,9 +76,9 @@ class CPlayer
 			bodyHits_[other] = flags;
 		}
 
-		void SetBodyHits(int flags)
+		void SetBodyHits(const int flags)
 		{
-			memset(bodyHits_, kHitGroupsBits, sizeof bodyHits_);
+			memset(bodyHits_, flags, sizeof bodyHits_);
 		}
 
 	public:

--- a/modules/fun/fun.h
+++ b/modules/fun/fun.h
@@ -42,41 +42,155 @@ class CPlayer
 
 		CPlayer()
 		{
-			Reset();
+			Clear();
 		}
 
 	public:
 
+		bool HasBodyHits()
+		{
+			for (auto i = 1; i <= gpGlobals->maxClients; ++i)
+			{
+				if (GetBodyHits(i) != kHitGroupsBits)
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
+
 		int GetBodyHits(int other) const
 		{
-			return m_BodyHits[other];
+			return bodyHits_[other];
 		}
 
 		void SetBodyHits(int other, int flags)
 		{
-			m_BodyHits[other] = flags;
+			bodyHits_[other] = flags;
 		}
+
+		void SetBodyHits(int flags)
+		{
+			memset(bodyHits_, kHitGroupsBits, sizeof(bodyHits_));
+		}
+
+	public:
 
 		bool HasSilentFootsteps() const
 		{
-			return m_HasSilentFootsteps;
+			return silentFootsteps_;
 		}
 
 		void SetSilentFootsteps(bool state)
 		{
-			m_HasSilentFootsteps = state;
+			silentFootsteps_ = state;
 		}
 
-		void Reset()
+	public:
+
+		void Clear()
 		{
-			memset(m_BodyHits, kHitGroupsBits, sizeof(m_BodyHits));
-			m_HasSilentFootsteps = false;
+			SetBodyHits(kHitGroupsBits);
+			SetSilentFootsteps(false);
 		}
 
 	private:
 
-		int  m_BodyHits[kMaxClients + 1];
-		bool m_HasSilentFootsteps;
+		int  bodyHits_[kMaxClients + 1];
+		bool silentFootsteps_;
+};
+
+class CPlayers
+{
+	using Internal = CPlayer;
+
+	public:
+
+		CPlayers()
+		{}
+
+	public:
+
+		bool HaveBodyHits()
+		{
+			for (auto i = 1; i <= gpGlobals->maxClients; ++i)
+			{
+				if (players_[i].HasBodyHits())
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		void SetBodyHits(int attacker, int target, int flags)
+		{
+			players_[attacker].SetBodyHits(target, flags);
+		}
+
+		void SetTargetsBodyHits(int attacker, int flags)
+		{
+			players_[attacker].SetBodyHits(flags);
+		}
+
+		void SetAttackersBodyHits(int target, int flags)
+		{
+			for (auto i = 1; i <= gpGlobals->maxClients; ++i)
+			{
+				players_[i].SetBodyHits(target, flags);
+			}
+		}
+
+		void SetEveryoneBodyHits(int flags)
+		{
+			for (auto i = 1; i <= gpGlobals->maxClients; ++i)
+			{
+				players_[i].SetBodyHits(flags);
+			}
+		}
+
+	public:
+
+		bool HaveSilentFootsteps() const
+		{
+			for (auto i = 1; i <= gpGlobals->maxClients; ++i)
+			{
+				if (players_[i].HasSilentFootsteps())
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+	public:
+
+		void Clear()
+		{
+			for (auto i = 1; i <= gpGlobals->maxClients; ++i)
+			{
+				players_[i].Clear();
+			}
+		}
+
+	public:
+
+		Internal& operator [](size_t index)
+		{
+			return players_[index];
+		}
+
+		const Internal& operator [](size_t index) const
+		{
+			return players_[index];
+		}
+
+	private:
+
+		Internal players_[kMaxClients + 1];
 };
 
 #define CHECK_ENTITY(x) \

--- a/modules/fun/fun.h
+++ b/modules/fun/fun.h
@@ -11,7 +11,9 @@
 // Fun Module
 //
 
-#include "amxxmodule.h"
+#pragma once
+
+#include <amxxmodule.h>
 
 // Fun-specific defines below
 #define GETCLIENTLISTENING		(*g_engfuncs.pfnVoice_GetClientListening)
@@ -34,6 +36,9 @@
 extern DLL_FUNCTIONS *g_pFunctionTable;
 extern enginefuncs_t *g_pengfuncsTable_Post;
 
+void PlayerPreThink(edict_t *pEntity);
+void TraceLine_Post(const float *v1, const float *v2, int fNoMonsters, edict_t *shooter, TraceResult *ptr);
+
 static const auto kHitGroupsBits = (1 << HITGROUP_MAX) - 1;
 static const auto kMaxClients = 32u;
 
@@ -48,7 +53,7 @@ class CPlayer
 
 	public:
 
-		bool HasBodyHits()
+		bool HasBodyHits() const
 		{
 			for (auto i = 1; i <= gpGlobals->maxClients; ++i)
 			{
@@ -61,19 +66,19 @@ class CPlayer
 			return false;
 		}
 
-		int GetBodyHits(int other) const
+		int GetBodyHits(const int other) const
 		{
 			return bodyHits_[other];
 		}
 
-		void SetBodyHits(int other, int flags)
+		void SetBodyHits(const int other, const int flags)
 		{
 			bodyHits_[other] = flags;
 		}
 
 		void SetBodyHits(int flags)
 		{
-			memset(bodyHits_, kHitGroupsBits, sizeof(bodyHits_));
+			memset(bodyHits_, kHitGroupsBits, sizeof bodyHits_);
 		}
 
 	public:
@@ -83,7 +88,7 @@ class CPlayer
 			return silentFootsteps_;
 		}
 
-		void SetSilentFootsteps(bool state)
+		void SetSilentFootsteps(const bool state)
 		{
 			silentFootsteps_ = state;
 		}
@@ -98,8 +103,8 @@ class CPlayer
 
 	private:
 
-		int  bodyHits_[kMaxClients + 1];
-		bool silentFootsteps_;
+		int  bodyHits_[kMaxClients + 1] {};
+		bool silentFootsteps_ {};
 };
 
 class CPlayers
@@ -108,12 +113,7 @@ class CPlayers
 
 	public:
 
-		CPlayers()
-		{}
-
-	public:
-
-		bool HaveBodyHits()
+		bool HaveBodyHits() const
 		{
 			for (auto i = 1; i <= gpGlobals->maxClients; ++i)
 			{
@@ -126,17 +126,17 @@ class CPlayers
 			return false;
 		}
 
-		void SetBodyHits(int attacker, int target, int flags)
+		void SetBodyHits(const int attacker, const int target, const int flags)
 		{
 			players_[attacker].SetBodyHits(target, flags);
 		}
 
-		void SetTargetsBodyHits(int attacker, int flags)
+		void SetTargetsBodyHits(const int attacker, const int flags)
 		{
 			players_[attacker].SetBodyHits(flags);
 		}
 
-		void SetAttackersBodyHits(int target, int flags)
+		void SetAttackersBodyHits(const int target, const int flags)
 		{
 			for (auto i = 1; i <= gpGlobals->maxClients; ++i)
 			{
@@ -144,7 +144,7 @@ class CPlayers
 			}
 		}
 
-		void SetEveryoneBodyHits(int flags)
+		void SetEveryoneBodyHits(const int flags)
 		{
 			for (auto i = 1; i <= gpGlobals->maxClients; ++i)
 			{
@@ -179,12 +179,12 @@ class CPlayers
 
 	public:
 
-		Internal& operator [](size_t index)
+		Internal& operator [](const size_t index)
 		{
 			return players_[index];
 		}
 
-		const Internal& operator [](size_t index) const
+		const Internal& operator [](const size_t index) const
 		{
 			return players_[index];
 		}
@@ -195,17 +195,17 @@ class CPlayers
 };
 
 #define CHECK_ENTITY(x) \
-	if (x < 0 || x > gpGlobals->maxEntities) { \
+	if ((x) < 0 || (x) > gpGlobals->maxEntities) { \
 		MF_LogError(amx, AMX_ERR_NATIVE, "Entity out of range (%d)", x); \
 		return 0; \
 	} else { \
-		if (x <= gpGlobals->maxClients) { \
+		if ((x) <= gpGlobals->maxClients) { \
 			if (!MF_IsPlayerIngame(x)) { \
 				MF_LogError(amx, AMX_ERR_NATIVE, "Invalid player %d (not in-game)", x); \
 				return 0; \
 			} \
 		} else { \
-			if (x != 0 && FNullEnt(TypeConversion.id_to_edict(x))) { \
+			if ((x) != 0 && FNullEnt(TypeConversion.id_to_edict(x))) { \
 				MF_LogError(amx, AMX_ERR_NATIVE, "Invalid entity %d", x); \
 				return 0; \
 			} \
@@ -213,7 +213,7 @@ class CPlayers
 	}
 
 #define CHECK_PLAYER(x) \
-	if (x < 1 || x > gpGlobals->maxClients) { \
+	if ((x) < 1 || (x) > gpGlobals->maxClients) { \
 		MF_LogError(amx, AMX_ERR_NATIVE, "Player out of range (%d)", x); \
 		return 0; \
 	} else { \

--- a/modules/fun/moduleconfig.h
+++ b/modules/fun/moduleconfig.h
@@ -120,7 +120,7 @@
 // #define FN_ClientUserInfoChanged		ClientUserInfoChanged		/* pfnClientUserInfoChanged()	(wd) Client has updated their setinfo structure */
 // #define FN_ServerActivate			ServerActivate				/* pfnServerActivate()			(wd) Server is starting a new map */
 #define FN_ServerDeactivate			ServerDeactivate			/* pfnServerDeactivate()		(wd) Server is leaving the map (shutdown or changelevel); SDK2 */
-#define FN_PlayerPreThink			PlayerPreThink				/* pfnPlayerPreThink() */
+// #define FN_PlayerPreThink			PlayerPreThink				/* pfnPlayerPreThink() */
 // #define FN_PlayerPostThink			PlayerPostThink				/* pfnPlayerPostThink() */
 // #define FN_StartFrame				StartFrame					/* pfnStartFrame() */
 // #define FN_ParmsNewLevel				ParmsNewLevel				/* pfnParmsNewLevel() */
@@ -378,7 +378,7 @@
 // #define FN_SetOrigin_Post					SetOrigin_Post
 // #define FN_EmitSound_Post					EmitSound_Post
 // #define FN_EmitAmbientSound_Post				EmitAmbientSound_Post
- #define FN_TraceLine_Post					TraceLine_Post
+// #define FN_TraceLine_Post					TraceLine_Post
 // #define FN_TraceToss_Post					TraceToss_Post
 // #define FN_TraceMonsterHull_Post				TraceMonsterHull_Post
 // #define FN_TraceHull_Post					TraceHull_Post

--- a/modules/fun/moduleconfig.h
+++ b/modules/fun/moduleconfig.h
@@ -119,7 +119,7 @@
 // #define FN_ClientCommand				ClientCommand				/* pfnClientCommand()			(wd) Player has sent a command (typed or from a bind) */
 // #define FN_ClientUserInfoChanged		ClientUserInfoChanged		/* pfnClientUserInfoChanged()	(wd) Client has updated their setinfo structure */
 // #define FN_ServerActivate			ServerActivate				/* pfnServerActivate()			(wd) Server is starting a new map */
-// #define FN_ServerDeactivate			ServerDeactivate			/* pfnServerDeactivate()		(wd) Server is leaving the map (shutdown or changelevel); SDK2 */
+#define FN_ServerDeactivate			ServerDeactivate			/* pfnServerDeactivate()		(wd) Server is leaving the map (shutdown or changelevel); SDK2 */
 #define FN_PlayerPreThink			PlayerPreThink				/* pfnPlayerPreThink() */
 // #define FN_PlayerPostThink			PlayerPostThink				/* pfnPlayerPostThink() */
 // #define FN_StartFrame				StartFrame					/* pfnStartFrame() */

--- a/modules/fun/moduleconfig.h
+++ b/modules/fun/moduleconfig.h
@@ -232,7 +232,7 @@
 // #define FN_SetOrigin							SetOrigin
 // #define FN_EmitSound							EmitSound
 // #define FN_EmitAmbientSound					EmitAmbientSound
-#define FN_TraceLine							TraceLine
+// #define FN_TraceLine							TraceLine
 // #define FN_TraceToss							TraceToss
 // #define FN_TraceMonsterHull					TraceMonsterHull
 // #define FN_TraceHull							TraceHull
@@ -378,7 +378,7 @@
 // #define FN_SetOrigin_Post					SetOrigin_Post
 // #define FN_EmitSound_Post					EmitSound_Post
 // #define FN_EmitAmbientSound_Post				EmitAmbientSound_Post
-// #define FN_TraceLine_Post					TraceLine_Post
+ #define FN_TraceLine_Post					TraceLine_Post
 // #define FN_TraceToss_Post					TraceToss_Post
 // #define FN_TraceMonsterHull_Post				TraceMonsterHull_Post
 // #define FN_TraceHull_Post					TraceHull_Post

--- a/plugins/include/fun.inc
+++ b/plugins/include/fun.inc
@@ -21,6 +21,21 @@
 	#pragma loadlib fun
 #endif
 
+
+/**
+ * Parts of body for hits, for use with set_user_hitzones().
+ */
+const HITZONE_GENERIC  = (1 << HIT_GENERIC);   // 1
+const HITZONE_HEAD     = (1 << HIT_HEAD);      // 2
+const HITZONE_CHEST    = (1 << HIT_CHEST);     // 4
+const HITZONE_STOMATCH = (1 << HIT_STOMATCH);  // 8
+const HITZONE_LEFTARM  = (1 << HIT_LEFTARM);   // 16
+const HITZONE_RIGHTARM = (1 << HIT_RIGHTARM);  // 32
+const HITZONE_LEFTLEG  = (1 << HIT_LEFTLEG);   // 64
+const HITZONE_RIGHTLEG = (1 << HIT_RIGHTLEG);  // 128
+const HITZONES_DEFAULT = HITZONE_GENERIC | HITZONE_HEAD     | HITZONE_CHEST   | HITZONE_STOMATCH | 
+                         HITZONE_LEFTARM | HITZONE_RIGHTARM | HITZONE_LEFTLEG | HITZONE_RIGHTLEG; // 255
+
 /**
  * Tells whether receiver hears sender via voice communication.
  *
@@ -169,26 +184,18 @@ native give_item(index, const item[]);
  *
  * @param index         Client index
  * @param target        The target player
- * @param body          A bitsum of the body parts that can/can't be shot:
- *                      1   - generic
- *                      2   - head
- *                      4   - chest
- *                      8   - stomach
- *                      16  - left arm
- *                      32  - right arm
- *                      64  - left leg
- *                      128 - right leg
+ * @param body          A bitsum of the body parts that can/can't be shot. See HITZONE* constants.
  *
  * @noreturn
  * @error               If player is not connected or not within the range
  *                      of 1 to MaxClients.
  */
-native set_user_hitzones(index = 0, target = 0, body = 255);
+native set_user_hitzones(index = 0, target = 0, body = HITZONES_DEFAULT);
 
 /**
  * Gets the set of hit zone "rules" between @index and @target players.
  *
- * @note For the body part bitsum take a look at the set_user_hitzones() native.
+ * @note For the body part bitsum, see HITZONE* constants.
  *
  * @param index         Client index
  * @param target        The target player


### PR DESCRIPTION
This is essentially a code clean up following with some welcomed changes:
- Updated documentation (made by @rsKliPPy)
- Toggled internal `PlayerPreThink` (used with `get/set_user_footsteps`) and `TraceLine` (used with `get/set_user_hitzones)` forwards on-demand (in others words, those forwards won't be hooked if no plugins are using such natives or if no players are actually set by them)
- Added `HITZONE_*` constants for `get/set_user_hitzones`.
- Made `TraceLine` a post forward.  Reason: as it is it breaks plugins hooking `TraceLine` because of the original game call is being superceded and other modules can't catch it. It looks like it's this way from the very start fun module has been introduced 13 years ago. Fakemeta module comes a little later. Change should be safe 1) it's unlikely having both plugins, one using `set_user_hitzones` and another hooking `TraceLine` as the latter would not work properly 2) This native is rarely used. 

To do:
- [x] Testing more