### PR TITLE
Rework build pathname functions

### DIFF
--- a/amxmodx/CPlugin.cpp
+++ b/amxmodx/CPlugin.cpp
@@ -19,14 +19,14 @@
 extern const char *no_function;
 
 CPluginMngr::CPlugin* CPluginMngr::loadPlugin(const char* path, const char* name, char* error, int debug)
-{	
+{
 	CPlugin** a = &head;
-	
+
 	while (*a)
 		a = &(*a)->next;
-	
+
 	*a = new CPlugin(pCounter++, path, name, error, debug);
-	
+
 	return (*a);
 }
 
@@ -42,10 +42,10 @@ void CPluginMngr::Finalize()
 {
 	if (m_Finalized)
 		return;
-	
+
 	pNatives = BuildNativeTable();
 	CPlugin *a = head;
-	
+
 	while (a)
 	{
 		if (a->getStatusCode() == ps_running)
@@ -55,7 +55,7 @@ void CPluginMngr::Finalize()
 		}
 		a = a->next;
 	}
-	
+
 	m_Finalized = true;
 }
 
@@ -64,7 +64,7 @@ int CPluginMngr::loadPluginsFromFile(const char* filename, bool warn)
 	char file[PLATFORM_MAX_PATH];
 	FILE *fp = fopen(build_pathname_r(file, sizeof(file), "%s", filename), "rt");
 
-	if (!fp) 
+	if (!fp)
 	{
 		if (warn)
 		{
@@ -72,23 +72,23 @@ int CPluginMngr::loadPluginsFromFile(const char* filename, bool warn)
 		}
 		return 1;
 	}
-	
+
 	// Find now folder
 	char pluginName[256], error[256], debug[256];
 	int debugFlag = 0;
 	const char *pluginsDir = get_localinfo("amxx_pluginsdir", "addons/amxmodx/plugins");
-	
+
 	char line[512];
 
 	List<ke::AString *>::iterator block_iter;
 
-	while (!feof(fp)) 
+	while (!feof(fp))
 	{
 		pluginName[0] = '\0';
-		
+
 		debug[0] = '\0';
 		debugFlag = 0;
-		
+
 		line[0] = '\0';
 		fgets(line, sizeof(line), fp);
 
@@ -104,7 +104,7 @@ int CPluginMngr::loadPluginsFromFile(const char* filename, bool warn)
 			}
 		}
 		sscanf(line, "%s %s", pluginName, debug);
-		
+
 		if (!isalnum(*pluginName))
 		{
 			continue;
@@ -138,7 +138,7 @@ int CPluginMngr::loadPluginsFromFile(const char* filename, bool warn)
 		}
 
 		CPlugin* plugin = loadPlugin(pluginsDir, pluginName, error, debugFlag);
-		
+
 		if (plugin->getStatusCode() == ps_bad_load)
 		{
 			char errorMsg[255];
@@ -173,13 +173,13 @@ int CPluginMngr::loadPluginsFromFile(const char* filename, bool warn)
 
 void CPluginMngr::clear()
 {
-	CPlugin**a = &head;	
-	
+	CPlugin**a = &head;
+
 	while (*a)
 		unloadPlugin(a);
-	
+
 	m_Finalized = false;
-	
+
 	if (pNatives)
 	{
 		delete [] pNatives;
@@ -198,20 +198,20 @@ void CPluginMngr::clear()
 CPluginMngr::CPlugin* CPluginMngr::findPlugin(AMX *amx)
 {
 	CPlugin*a = head;
-	
+
 	while (a && &a->amx != amx)
 		a = a->next;
-	
+
 	return a;
 }
-	
+
 CPluginMngr::CPlugin* CPluginMngr::findPlugin(int index)
 {
 	CPlugin*a = head;
-	
+
 	while (a && index--)
 		a = a->next;
-	
+
 	return a;
 }
 
@@ -219,17 +219,17 @@ CPluginMngr::CPlugin* CPluginMngr::findPlugin(const char* name)
 {
 	if (!name)
 		return 0;
-	
+
 	int len = strlen(name);
-	
+
 	if (!len)
 		return 0;
-	
+
 	CPlugin*a = head;
-	
+
 	while (a && strncmp(a->name.chars(), name, len))
 		a = a->next;
-	
+
 	return a;
 }
 
@@ -248,7 +248,7 @@ const char* CPluginMngr::CPlugin::getStatus() const
 {
 	switch (status)
 	{
-		case ps_running: 
+		case ps_running:
 		{
 			if (m_Debug)
 			{
@@ -263,42 +263,42 @@ const char* CPluginMngr::CPlugin::getStatus() const
 		case ps_stopped: return "stopped";
 		case ps_locked: return "locked";
 	}
-	
+
 	return "error";
 }
 
 CPluginMngr::CPlugin::CPlugin(int i, const char* p, const char* n, char* e, int d) : name(n), title(n), m_pNullStringOfs(nullptr), m_pNullVectorOfs(nullptr)
 {
 	const char* unk = "unknown";
-	
+
 	failcounter = 0;
 	title = unk;
 	author = unk;
 	version = unk;
-	
+
 	char file[PLATFORM_MAX_PATH];
 	char* path = build_pathname_r(file, sizeof(file), "%s/%s", p, n);
 	code = 0;
 	memset(&amx, 0, sizeof(AMX));
 	int err = load_amxscript(&amx, &code, path, e, d);
-	
+
 	if (err == AMX_ERR_NONE)
 	{
 		status = ps_running;
 	} else {
 		status = ps_bad_load;
 	}
-	
+
 	amx.userdata[UD_FINDPLUGIN] = this;
 	paused_fun = 0;
 	next = 0;
 	id = i;
-	
+
 	if (status == ps_running)
 	{
 		m_PauseFwd = registerSPForwardByName(&amx, "plugin_pause", FP_DONE);
 		m_UnpauseFwd = registerSPForwardByName(&amx, "plugin_unpause", FP_DONE);
-		
+
 		if (amx.flags & AMX_FLAG_DEBUG)
 		{
 			m_Debug = true;
@@ -368,17 +368,17 @@ void CPluginMngr::CPlugin::Finalize()
 {
 	char buffer[128];
 	int old_status = status;
-	
+
 	if (CheckModules(&amx, buffer))
 	{
 		if (amx_Register(&amx, core_Natives, -1) != AMX_ERR_NONE)
 		{
 			Handler *pHandler = (Handler *)amx.userdata[UD_HANDLER];
 			int res = 0;
-			
+
 			if (pHandler->IsNativeFiltering())
 				res = amx_CheckNatives(&amx, native_handler);
-			
+
 			if (!res)
 			{
 				status = ps_bad_load;
@@ -394,7 +394,7 @@ void CPluginMngr::CPlugin::Finalize()
 		errorMsg = buffer;
 		amx.error = AMX_ERR_NOTFOUND;
 	}
-	
+
 	if (old_status != status)
 	{
 		AMXXLOG_Log("[AMXX] Plugin \"%s\" failed to load: %s", name.chars(), errorMsg.chars());
@@ -402,7 +402,7 @@ void CPluginMngr::CPlugin::Finalize()
 }
 
 void CPluginMngr::CPlugin::pauseFunction(int id)
-{ 
+{
 }
 
 void CPluginMngr::CPlugin::unpauseFunction(int id)
@@ -410,8 +410,8 @@ void CPluginMngr::CPlugin::unpauseFunction(int id)
 }
 
 void CPluginMngr::CPlugin::setStatus(int a)
-{ 
-	status = a; 
+{
+	status = a;
 	g_commands.clearBufforedInfo(); // ugly way
 }
 
@@ -423,7 +423,7 @@ void CPluginMngr::CPlugin::pausePlugin()
 		// call plugin_pause if provided
 		if (m_PauseFwd != -1)
 			executeForwards(m_PauseFwd);
-	
+
 		setStatus(ps_paused);
 	}
 }
@@ -435,7 +435,7 @@ void CPluginMngr::CPlugin::unpausePlugin()
 	{
 		// set status first so the function will be marked executable
 		setStatus(ps_running);
-		
+
 		// call plugin_unpause if provided
 		if (m_UnpauseFwd != -1)
 		{
@@ -597,7 +597,7 @@ void CPluginMngr::CacheAndLoadModules(const char *plugin)
 	{
 		return;
 	}
-	if ((hdr.defsize != sizeof(AMX_FUNCSTUB)) && 
+	if ((hdr.defsize != sizeof(AMX_FUNCSTUB)) &&
 		(hdr.defsize != sizeof(AMX_FUNCSTUBNT)))
 	{
 		return;
@@ -610,7 +610,7 @@ void CPluginMngr::CacheAndLoadModules(const char *plugin)
 	{
 		return;
 	}
-	
+
 	if (hdr.stp <= 0)
 	{
 		return;
@@ -655,7 +655,7 @@ void CPluginMngr::CacheAndLoadModules(const char *plugin)
 				{
 					RunLibCommand(dc);
 				} else if ( (dc->cmd == LibCmd_ExpectClass) ||
-							(dc->cmd == LibCmd_ExpectLib) ) 
+							(dc->cmd == LibCmd_ExpectLib) )
 				{
 					expects.append(dc);
 				} else if (dc->cmd == LibCmd_DefaultLib) {
@@ -691,7 +691,7 @@ void CPluginMngr::CALMFromFile(const char *file)
 	char filename[PLATFORM_MAX_PATH];
 	FILE *fp = fopen(build_pathname_r(filename, sizeof(filename), "%s", file), "rt");
 
-	if (!fp) 
+	if (!fp)
 	{
 		return;
 	}
@@ -701,7 +701,7 @@ void CPluginMngr::CALMFromFile(const char *file)
 	char line[256];
 	char rline[256];
 
-	while (!feof(fp)) 
+	while (!feof(fp))
 	{
 		fgets(line, sizeof(line)-1, fp);
 		if (line[0] == ';' || line[0] == '\n' || line[0] == '\0')

--- a/amxmodx/CPlugin.cpp
+++ b/amxmodx/CPlugin.cpp
@@ -61,8 +61,8 @@ void CPluginMngr::Finalize()
 
 int CPluginMngr::loadPluginsFromFile(const char* filename, bool warn)
 {
-	char file[256];
-	FILE *fp = fopen(build_pathname_r(file, sizeof(file) - 1, "%s", filename), "rt");
+	char file[PLATFORM_MAX_PATH];
+	FILE *fp = fopen(build_pathname_r(file, sizeof(file), "%s", filename), "rt");
 
 	if (!fp) 
 	{
@@ -276,8 +276,8 @@ CPluginMngr::CPlugin::CPlugin(int i, const char* p, const char* n, char* e, int 
 	author = unk;
 	version = unk;
 	
-	char file[256];
-	char* path = build_pathname_r(file, sizeof(file) - 1, "%s/%s", p, n);
+	char file[PLATFORM_MAX_PATH];
+	char* path = build_pathname_r(file, sizeof(file), "%s/%s", p, n);
 	code = 0;
 	memset(&amx, 0, sizeof(AMX));
 	int err = load_amxscript(&amx, &code, path, e, d);
@@ -688,8 +688,8 @@ void CPluginMngr::CacheAndLoadModules(const char *plugin)
 
 void CPluginMngr::CALMFromFile(const char *file)
 {
-	char filename[256];
-	FILE *fp = fopen(build_pathname_r(filename, sizeof(filename) - 1, "%s", file), "rt");
+	char filename[PLATFORM_MAX_PATH];
+	FILE *fp = fopen(build_pathname_r(filename, sizeof(filename), "%s", file), "rt");
 
 	if (!fp) 
 	{
@@ -751,7 +751,7 @@ void CPluginMngr::CALMFromFile(const char *file)
 			continue;
 		}
 
-		build_pathname_r(filename, sizeof(filename)-1, "%s/%s", get_localinfo("amxx_pluginsdir", "addons/amxmodx/plugins"), pluginName);
+		build_pathname_r(filename, sizeof(filename), "%s/%s", get_localinfo("amxx_pluginsdir", "addons/amxmodx/plugins"), pluginName);
 
 		CacheAndLoadModules(filename);
 	}

--- a/amxmodx/amxmodx.cpp
+++ b/amxmodx/amxmodx.cpp
@@ -1468,9 +1468,9 @@ static cell AMX_NATIVE_CALL amx_md5_file(AMX *amx, cell *params)
 {
 	int len;
 	char *str = get_amxstring(amx, params[1], 0, len);
-	char file[255];
+	char file[PLATFORM_MAX_PATH];
 
-	build_pathname_r(file, sizeof(file)-1, "%s", str);
+	build_pathname_r(file, sizeof(file), "%s", str);
 
 	const char *hash = hashFile((const char *)file, Hash_Md5);
 	if (!hash)
@@ -1502,8 +1502,8 @@ static cell AMX_NATIVE_CALL amx_hash_file(AMX *amx, cell *params)
 {
 	int len;
 	char *str = get_amxstring(amx, params[1], 0, len);
-	char file[255];
-	build_pathname_r(file, sizeof(file)-1, "%s", str);
+	char file[PLATFORM_MAX_PATH];
+	build_pathname_r(file, sizeof(file), "%s", str);
 
 	HashType type = (HashType)params[2];
 
@@ -2016,13 +2016,13 @@ static cell AMX_NATIVE_CALL log_to_file(AMX *amx, cell *params) /* 1 param */
 	int ilen;
 	char* szFile = get_amxstring(amx, params[1], 0, ilen);
 	FILE*fp;
-	char file[256];
+	char file[PLATFORM_MAX_PATH];
 	
 	if (strchr(szFile, '/') || strchr(szFile, '\\'))
 	{
-		build_pathname_r(file, sizeof(file) - 1, "%s", szFile);
+		build_pathname_r(file, sizeof(file), "%s", szFile);
 	} else {
-		build_pathname_r(file, sizeof(file) - 1, "%s/%s", g_log_dir.chars(), szFile);
+		build_pathname_r(file, sizeof(file), "%s/%s", g_log_dir.chars(), szFile);
 	}
 	
 	bool first_time = true;
@@ -3891,8 +3891,8 @@ static cell AMX_NATIVE_CALL get_lang(AMX *amx, cell *params)
 static cell AMX_NATIVE_CALL register_dictionary(AMX *amx, cell *params)
 {
 	int len;
-	static char file[256];
-	int result = g_langMngr.MergeDefinitionFile(build_pathname_r(file, sizeof(file) - 1, "%s/lang/%s", get_localinfo("amxx_datadir", "addons/amxmodx/data"), get_amxstring(amx, params[1], 1, len)));
+	static char file[PLATFORM_MAX_PATH];
+	int result = g_langMngr.MergeDefinitionFile(build_pathname_r(file, sizeof(file), "%s/lang/%s", get_localinfo("amxx_datadir", "addons/amxmodx/data"), get_amxstring(amx, params[1], 1, len)));
 	
 	return result;
 }

--- a/amxmodx/amxmodx.cpp
+++ b/amxmodx/amxmodx.cpp
@@ -35,7 +35,7 @@ static cell AMX_NATIVE_CALL get_xvar_id(AMX *amx, cell *params)
 
 	for (CPluginMngr::iterator a = g_plugins.begin(); a ; ++a)
 	{
-		if ((*a).isValid() && amx_FindPubVar((*a).getAMX(), sName, &ptr) == AMX_ERR_NONE) 
+		if ((*a).isValid() && amx_FindPubVar((*a).getAMX(), sName, &ptr) == AMX_ERR_NONE)
 			return g_xvars.put((*a).getAMX(), get_amxaddr((*a).getAMX(), ptr));
 	}
 
@@ -78,13 +78,13 @@ static cell AMX_NATIVE_CALL emit_sound(AMX *amx, cell *params) /* 7 param */
 		for (int i = 1; i <= gpGlobals->maxClients ; ++i)
 		{
 			CPlayer* pPlayer = GET_PLAYER_POINTER_I(i);
-			
+
 			if (pPlayer->ingame)
 				EMIT_SOUND_DYN2(pPlayer->pEdict, channel, szSample, vol, att, flags, pitch);
 		}
 	} else {
 		edict_t* pEdict = TypeConversion.id_to_edict(params[1]);
-		
+
 		if (!FNullEnt(pEdict))
 			EMIT_SOUND_DYN2(pEdict, channel, szSample, vol, att, flags, pitch);
 	}
@@ -97,14 +97,14 @@ static cell AMX_NATIVE_CALL server_print(AMX *amx, cell *params) /* 1 param */
 	int len;
 	g_langMngr.SetDefLang(LANG_SERVER);			// Default language = server
 	char* message = format_amxstring(amx, params, 1, len);
-	
+
 	if (len > 254)
 		len = 254;
-	
+
 	message[len++] = '\n';
 	message[len] = 0;
 	SERVER_PRINT(message);
-	
+
 	return len;
 }
 
@@ -113,13 +113,13 @@ static cell AMX_NATIVE_CALL engclient_print(AMX *amx, cell *params) /* 3 param *
 	int len = 0;
 	char *msg;
 	PRINT_TYPE type = (PRINT_TYPE)params[2];
-	
+
 	if (params[1] == 0)
 	{
 		for (int i = 1; i <= gpGlobals->maxClients; ++i)
 		{
 			CPlayer* pPlayer = GET_PLAYER_POINTER_I(i);
-			
+
 			if ((type == print_console  && pPlayer->initialized) || pPlayer->ingame)
 			{
 				g_langMngr.SetDefLang(i);
@@ -137,9 +137,9 @@ static cell AMX_NATIVE_CALL engclient_print(AMX *amx, cell *params) /* 3 param *
 			LogError(amx, AMX_ERR_NATIVE, "Invalid player id %d", index);
 			return 0;
 		}
-		
+
 		CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
-		
+
 		if ((type == print_console  && pPlayer->initialized) || pPlayer->ingame)
 		{
 			g_langMngr.SetDefLang(index);
@@ -149,7 +149,7 @@ static cell AMX_NATIVE_CALL engclient_print(AMX *amx, cell *params) /* 3 param *
 			CLIENT_PRINT(pPlayer->pEdict, type, msg);
 		}
 	}
-	
+
 	return len;
 }
 
@@ -159,7 +159,7 @@ static cell AMX_NATIVE_CALL console_cmd(AMX *amx, cell *params) /* 2 param */
 	g_langMngr.SetDefLang(index);
 	int len;
 	char* cmd = format_amxstring(amx, params, 2, len);
-	
+
 	cmd[len++] = '\n';
 	cmd[len] = 0;
 
@@ -168,7 +168,7 @@ static cell AMX_NATIVE_CALL console_cmd(AMX *amx, cell *params) /* 2 param */
 		SERVER_COMMAND(cmd);
 	} else {
 		CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
-		
+
 		if (!pPlayer->IsBot() && pPlayer->initialized)
 			CLIENT_COMMAND(pPlayer->pEdict, "%s", cmd);
 	}
@@ -317,7 +317,7 @@ static cell AMX_NATIVE_CALL client_print_color(AMX *amx, cell *params) /* 3 para
 	int index = params[1];
 	int sender = params[2];
 
-	if (sender < print_team_blue || sender > gpGlobals->maxClients) 
+	if (sender < print_team_blue || sender > gpGlobals->maxClients)
 	{
 		sender = print_team_default;
 	}
@@ -358,7 +358,7 @@ static cell AMX_NATIVE_CALL client_print_color(AMX *amx, cell *params) /* 3 para
 				UTIL_ClientSayText(pPlayer->pEdict, sender ? sender : i, msg);
 			}
 		}
-	} 
+	}
 	else
 	{
 		if (index < 1 || index > gpGlobals->maxClients)
@@ -368,7 +368,7 @@ static cell AMX_NATIVE_CALL client_print_color(AMX *amx, cell *params) /* 3 para
 		}
 
 		CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
-		
+
 		if (pPlayer->ingame && !pPlayer->IsBot())
 		{
 			g_langMngr.SetDefLang(index);
@@ -392,7 +392,7 @@ static cell AMX_NATIVE_CALL client_print_color(AMX *amx, cell *params) /* 3 para
 
 			msg[len++] = '\n';
 			msg[len] = 0;
-		
+
 			UTIL_ClientSayText(pPlayer->pEdict, sender ? sender : index, msg);
 		}
 	}
@@ -404,52 +404,52 @@ static cell AMX_NATIVE_CALL show_motd(AMX *amx, cell *params) /* 3 param */
 {
 	int ilen;
 	const char* szHead = get_amxstring(amx, params[3], 0, ilen);
-	
+
 	if (!ilen)
 		szHead = hostname->string;
 
 	char* szBody = get_amxstring(amx, params[2], 1, ilen);
 	int iFile = 0;
 	char* sToShow = NULL; // = szBody;
-	
+
 	if (ilen < 128)
 		sToShow = (char*)LOAD_FILE_FOR_ME(szBody, &iFile);
-	
+
 	if (!iFile)
 		sToShow = szBody;
 	else
 		ilen = iFile;
-	
+
 	if (params[1] == 0)
 	{
 		for (int i = 1; i <= gpGlobals->maxClients; ++i)
 		{
 			CPlayer* pPlayer = GET_PLAYER_POINTER_I(i);
-			
+
 			if (pPlayer->ingame)
 				UTIL_ShowMOTD(pPlayer->pEdict, sToShow, ilen, szHead);
 		}
 	} else {
 		int index = params[1];
-		
+
 		if (index < 1 || index > gpGlobals->maxClients)
 		{
 			LogError(amx, AMX_ERR_NATIVE, "Invalid player id %d", index);
 			if (iFile)
 				FREE_FILE(sToShow);
-			
+
 			return 0;
 		}
-		
+
 		CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
-		
+
 		if (pPlayer->ingame)
 			UTIL_ShowMOTD(pPlayer->pEdict, sToShow, ilen, szHead);
 	}
-	
+
 	if (iFile)
 		FREE_FILE(sToShow);
-	
+
 	return 1;
 }
 
@@ -468,7 +468,7 @@ static cell AMX_NATIVE_CALL next_hudchannel(AMX *amx, cell *params)
 		LogError(amx, AMX_ERR_NATIVE, "Player %d not in game", index);
 		return 0;
 	}
-	
+
 	return pPlayer->NextHUDChannel();
 }
 
@@ -490,7 +490,7 @@ static cell AMX_NATIVE_CALL set_hudmessage(AMX *amx, cell *params) /* 11 param *
 	g_hudset.fadeinTime = amx_ctof(params[9]);
 	g_hudset.fadeoutTime = amx_ctof(params[10]);
 	g_hudset.channel = params[11];
-	
+
 	return 1;
 }
 
@@ -506,7 +506,7 @@ static cell AMX_NATIVE_CALL show_hudmessage(AMX *amx, cell *params) /* 2 param *
 	 *  "channel" stores the valid channel that core uses.
 	 *  "g_hudset.channel" stores the direct channel passed to the engine.
 	 */
-	
+
 	bool aut = (g_hudset.channel == -1) ? true : false;
 	int channel = -1;
 	if (!aut)
@@ -522,7 +522,7 @@ static cell AMX_NATIVE_CALL show_hudmessage(AMX *amx, cell *params) /* 2 param *
 		for (int i = 1; i <= gpGlobals->maxClients; ++i)
 		{
 			CPlayer *pPlayer = GET_PLAYER_POINTER_I(i);
-			
+
 			if (pPlayer->ingame)
 			{
 				g_langMngr.SetDefLang(i);
@@ -541,15 +541,15 @@ static cell AMX_NATIVE_CALL show_hudmessage(AMX *amx, cell *params) /* 2 param *
 	} else {
 		message = UTIL_SplitHudMessage(format_amxstring(amx, params, 2, len));
 		int index = params[1];
-		
+
 		if (index < 1 || index > gpGlobals->maxClients)
 		{
 			LogError(amx, AMX_ERR_NATIVE, "Invalid player id %d", index);
 			return 0;
 		}
-		
+
 		CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
-		
+
 		if (pPlayer->ingame)
 		{
 			if (aut)
@@ -562,7 +562,7 @@ static cell AMX_NATIVE_CALL show_hudmessage(AMX *amx, cell *params) /* 2 param *
 			UTIL_HudMessage(pPlayer->pEdict, g_hudset, message);
 		}
 	}
-	
+
 	return len;
 }
 
@@ -642,7 +642,7 @@ static cell AMX_NATIVE_CALL show_dhudmessage(AMX *amx, cell *params) /* 2 param 
 				len = 127;
 
 				// Don't truncate a double-byte character
-				if (((message[len - 1] & 0xFF) >= 0xC2) && ((message[len - 1] & 0xFF) <= 0xEF))      
+				if (((message[len - 1] & 0xFF) >= 0xC2) && ((message[len - 1] & 0xFF) <= 0xEF))
 				{
 					--len;
 				}
@@ -672,11 +672,11 @@ static cell AMX_NATIVE_CALL get_user_index(AMX *amx, cell *params) /* 1 param */
 {
 	int i;
 	char* sptemp = get_amxstring(amx, params[1], 0, i);
-	
+
 	for (i = 1; i <= gpGlobals->maxClients; ++i)
 	{
 		CPlayer* pPlayer = GET_PLAYER_POINTER_I(i);
-		
+
 		if (strcmp(pPlayer->name.chars(), sptemp) == 0)
 			return i;
 	}
@@ -725,57 +725,57 @@ static cell AMX_NATIVE_CALL is_map_valid(AMX *amx, cell *params) /* 1 param */
 static cell AMX_NATIVE_CALL is_user_connected(AMX *amx, cell *params) /* 1 param */
 {
 	int index = params[1];
-	
+
 	if (index < 1 || index > gpGlobals->maxClients)
 		return 0;
-	
+
 	CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
-	
+
 	return (pPlayer->ingame ? 1 : 0);
 }
 
 static cell AMX_NATIVE_CALL is_user_connecting(AMX *amx, cell *params) /* 1 param */
 {
 	int index = params[1];
-	
+
 	if (index < 1 || index > gpGlobals->maxClients)
 		return 0;
 
 	CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
-	
+
 	return (!pPlayer->ingame && pPlayer->initialized && (GETPLAYERUSERID(pPlayer->pEdict) > 0)) ? 1 : 0;
 }
 
 static cell AMX_NATIVE_CALL is_user_bot(AMX *amx, cell *params) /* 1 param */
 {
 	int index = params[1];
-	
+
 	if (index < 1 || index > gpGlobals->maxClients)
 		return 0;
-	
+
 	return (GET_PLAYER_POINTER_I(index)->IsBot() ? 1 : 0);
 }
 
 static cell AMX_NATIVE_CALL is_user_hltv(AMX *amx, cell *params) /* 1 param */
 {
 	int index = params[1];
-	
+
 	if (index < 1 || index > gpGlobals->maxClients)
 		return 0;
 
 	CPlayer *pPlayer = GET_PLAYER_POINTER_I(index);
-	
+
 	if (!pPlayer->initialized)
 		return 0;
-	
+
 	if (pPlayer->pEdict->v.flags & FL_PROXY)
 		return 1;
-	
+
 	const char *authid = GETPLAYERAUTHID(pPlayer->pEdict);
-	
+
 	if (authid && stricmp(authid, "HLTV") == 0)
 		return 1;
-	
+
 	return 0;
 }
 
@@ -783,24 +783,24 @@ extern bool g_bmod_tfc;
 static cell AMX_NATIVE_CALL is_user_alive(AMX *amx, cell *params) /* 1 param */
 {
 	int index = params[1];
-	
+
 	if (index < 1 || index > gpGlobals->maxClients)
 	{
 		return 0;
 	}
-	
+
 	CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
 
 	if (g_bmod_tfc)
 	{
 		edict_t *e = pPlayer->pEdict;
-		if (e->v.flags & FL_SPECTATOR || 
+		if (e->v.flags & FL_SPECTATOR ||
 			(!e->v.team || !e->v.playerclass))
 		{
 			return 0;
 		}
 	}
-	
+
 	return ((pPlayer->ingame && pPlayer->IsAlive()) ? 1 : 0);
 }
 
@@ -812,60 +812,60 @@ static cell AMX_NATIVE_CALL get_amxx_verstring(AMX *amx, cell *params) /* 2 para
 static cell AMX_NATIVE_CALL get_user_frags(AMX *amx, cell *params) /* 1 param */
 {
 	int index = params[1];
-	
+
 	if (index < 1 || index > gpGlobals->maxClients)
 		return 0;
-	
+
 	CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
-	
+
 	return (cell)(pPlayer->ingame ? pPlayer->pEdict->v.frags : 0);
 }
 
 static cell AMX_NATIVE_CALL get_user_deaths(AMX *amx, cell *params) /* 1 param */
 {
 	int index = params[1];
-	
+
 	if (index < 1 || index > gpGlobals->maxClients)
 		return 0;
-	
+
 	CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
-	
+
 	return (cell)(pPlayer->ingame ? pPlayer->deaths : 0);
 }
 
 static cell AMX_NATIVE_CALL get_user_armor(AMX *amx, cell *params) /* 1 param */
 {
 	int index = params[1];
-	
+
 	if (index < 1 || index > gpGlobals->maxClients)
 		return 0;
-	
+
 	CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
-	
+
 	return (cell)(pPlayer->ingame ? pPlayer->pEdict->v.armorvalue : 0);
 }
 
 static cell AMX_NATIVE_CALL get_user_health(AMX *amx, cell *params) /* param */
 {
 	int index = params[1];
-	
+
 	if (index < 1 || index > gpGlobals->maxClients)
 		return 0;
-	
+
 	CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
-	
+
 	return (cell)(pPlayer->ingame ? pPlayer->pEdict->v.health : 0);
 }
 
 static cell AMX_NATIVE_CALL get_user_userid(AMX *amx, cell *params) /* 1 param */
 {
 	int index = params[1];
-	
+
 	if (index < 1 || index > gpGlobals->maxClients)
 		return 0;
-	
+
 	CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
-	
+
 	return pPlayer->initialized ? GETPLAYERUSERID(pPlayer->pEdict) : -1;
 }
 
@@ -873,33 +873,33 @@ static cell AMX_NATIVE_CALL get_user_authid(AMX *amx, cell *params) /* 3 param *
 {
 	int index = params[1];
 	const char* authid = 0;
-	
+
 	if (index > 0 && index <= gpGlobals->maxClients)
 		authid = GETPLAYERAUTHID(g_players[index].pEdict);
-	
+
 	return set_amxstring(amx, params[2], authid ? authid : "", params[3]);
 }
 
 static cell AMX_NATIVE_CALL is_user_authorized(AMX *amx, cell *params)
 {
 	int index = params[1];
-	
+
 	if (index < 1 || index > gpGlobals->maxClients)
 		return 0;
-	
+
 	return GET_PLAYER_POINTER_I(index)->authorized;
 }
 
 static cell AMX_NATIVE_CALL get_weaponname(AMX *amx, cell *params) /* 3 param */
 {
 	int index = params[1];
-	
+
 	if (index < 1 || index >= MAX_WEAPONS)
 	{
 		LogError(amx, AMX_ERR_NATIVE, "Invalid weapon id %d", index);
 		return 0;
 	}
-	
+
 	return set_amxstring(amx, params[2], g_weaponsData[index].fullName.chars(), params[3]);
 }
 
@@ -920,7 +920,7 @@ static cell AMX_NATIVE_CALL get_weaponid(AMX *amx, cell *params)
 static cell AMX_NATIVE_CALL get_user_weapons(AMX *amx, cell *params) /* 3 param */
 {
 	int index = params[1];
-	
+
 	if (index < 1 || index > gpGlobals->maxClients)
 	{
 		LogError(amx, AMX_ERR_NATIVE, "Invalid player id %d", index);
@@ -928,21 +928,21 @@ static cell AMX_NATIVE_CALL get_user_weapons(AMX *amx, cell *params) /* 3 param 
 	}
 
 	CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
-	
+
 	if (pPlayer->ingame)
 	{
 		cell *cpNum = get_amxaddr(amx, params[3]);
 		cell *cpIds = get_amxaddr(amx, params[2]);
 		*cpIds = 0;
-		
+
 		int weapons = pPlayer->pEdict->v.weapons & ~(1<<31); // don't count last element
-		
+
 		if (g_bmod_dod)
 		{
 			// Don't ignore that last element for dod
 			weapons = pPlayer->pEdict->v.weapons;
 		}
-		
+
 		for (int i = 1; i < MAX_WEAPONS; ++i)
 		{
 			if (weapons & (1<<i))
@@ -953,27 +953,27 @@ static cell AMX_NATIVE_CALL get_user_weapons(AMX *amx, cell *params) /* 3 param 
 		}
 		return weapons;
 	}
-	
+
 	return 0;
 }
 
 static cell AMX_NATIVE_CALL get_user_origin(AMX *amx, cell *params) /* 3 param */
 {
 	int index = params[1];
-	
+
 	if (index < 1 || index > gpGlobals->maxClients)
 	{
 		LogError(amx, AMX_ERR_NATIVE, "Invalid player id %d", index);
 		return 0;
 	}
-	
+
 	CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
-	
+
 	if (pPlayer->ingame)
 	{
 		int mode = params[3];
 		cell *cpOrigin = get_amxaddr(amx, params[2]);
-		
+
 		if (mode == 4)
 		{
 			cpOrigin[0] = (long int)pPlayer->lastHit.x;
@@ -981,47 +981,47 @@ static cell AMX_NATIVE_CALL get_user_origin(AMX *amx, cell *params) /* 3 param *
 			cpOrigin[2] = (long int)pPlayer->lastHit.z;
 			return 1;
 		}
-		
+
 		edict_t* edict = pPlayer->pEdict;
 		Vector pos = edict->v.origin;
-		
+
 		if (mode && mode != 2)
 			pos = pos + edict->v.view_ofs;
-		
+
 		if (mode > 1)
 		{
 			Vector vec;
 			Vector v_angle = edict->v.v_angle;
 			float v_vec[3];
-			
+
 			v_vec[0] = v_angle.x;
 			v_vec[1] = v_angle.y;
 			v_vec[2] = v_angle.z;
-			
+
 			ANGLEVECTORS(v_vec, vec, NULL, NULL);
 			TraceResult trEnd;
 			Vector v_dest = pos + vec * 9999;
-			
+
 			float f_pos[3];
 			f_pos[0] = pos.x;
 			f_pos[1] = pos.y;
 			f_pos[2] = pos.z;
-			
+
 			float f_dest[3];
 			f_dest[0] = v_dest.x;
 			f_dest[1] = v_dest.y;
 			f_dest[2] = v_dest.z;
-			
+
 			TRACE_LINE(f_pos, f_dest, 0, edict, &trEnd);
 			pos = (trEnd.flFraction < 1.0) ? trEnd.vecEndPos : Vector(0, 0, 0);
 		}
 		cpOrigin[0] = (long int)pos.x;
 		cpOrigin[1] = (long int)pos.y;
 		cpOrigin[2] = (long int)pos.z;
-		
+
 		return 1;
 	}
-	
+
 	return 0;
 }
 
@@ -1031,33 +1031,33 @@ static cell AMX_NATIVE_CALL get_user_ip(AMX *amx, cell *params) /* 3 param */
 	char *ptr;
 	char szIp[32];
 	strcpy(szIp, (index < 1 || index > gpGlobals->maxClients) ? CVAR_GET_STRING("net_address") : g_players[index].ip.chars());
-	
+
 	if (params[4] && (ptr = strstr(szIp, ":")) != 0)
 		*ptr = '\0';
-	
+
 	return set_amxstring(amx, params[2], szIp, params[3]);
 }
 
 static cell AMX_NATIVE_CALL get_user_attacker(AMX *amx, cell *params) /* 2 param */
 {
 	int index = params[1];
-	
+
 	if (index < 1 || index > gpGlobals->maxClients)
 	{
 		LogError(amx, AMX_ERR_NATIVE, "Invalid player id %d", index);
 		return 0;
 	}
-	
+
 	CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
 	edict_t *enemy = NULL;
-	
+
 	if (pPlayer->ingame)
 	{
 		enemy = pPlayer->pEdict->v.dmg_inflictor;
 		if (!FNullEnt(enemy))
 		{
 			int weapon = 0;
-			
+
 			if (enemy->v.flags & (FL_CLIENT | FL_FAKECLIENT))
 			{
 				pPlayer = GET_PLAYER_POINTER(enemy);
@@ -1090,23 +1090,23 @@ static cell AMX_NATIVE_CALL get_user_attacker(AMX *amx, cell *params) /* 2 param
 			}
 		}
 	}
-	
+
 	return (enemy ? pPlayer->index : 0);
 }
 
 static cell AMX_NATIVE_CALL user_has_weapon(AMX *amx, cell *params)
 {
 	int index = params[1];
-	
+
 	if (index < 1 || index > gpGlobals->maxClients)
 	{
 		LogError(amx, AMX_ERR_NATIVE, "Invalid player id %d", index);
 		return 0;
 	}
-	
+
 	CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
 	edict_t *pEntity = pPlayer->pEdict;
-	
+
 	if (params[3] == -1)
 	{
 		if ((pEntity->v.weapons & (1<<params[2])) > 0)
@@ -1121,7 +1121,7 @@ static cell AMX_NATIVE_CALL user_has_weapon(AMX *amx, cell *params)
 				pEntity->v.weapons &= ~(1<<params[2]);
 				return 1;
 			}
-			
+
 			return 0;
 		} else {
 			if (params[3] == 1)
@@ -1130,25 +1130,25 @@ static cell AMX_NATIVE_CALL user_has_weapon(AMX *amx, cell *params)
 				return 1;
 			}
 		}
-		
+
 		return 0;
 	}
-	
+
 	return 0;
 }
 
 static cell AMX_NATIVE_CALL get_user_weapon(AMX *amx, cell *params) /* 3 param */
 {
 	int index = params[1];
-	
+
 	if (index < 1 || index > gpGlobals->maxClients)
 	{
 		LogError(amx, AMX_ERR_NATIVE, "Invalid player id %d", index);
 		return 0;
 	}
-	
+
 	CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
-	
+
 	if (pPlayer->ingame)
 	{
 		int wpn = pPlayer->current;
@@ -1157,66 +1157,66 @@ static cell AMX_NATIVE_CALL get_user_weapon(AMX *amx, cell *params) /* 3 param *
 		*cpTemp = pPlayer->weapons[wpn].clip;
 		cpTemp = get_amxaddr(amx, params[3]);
 		*cpTemp = pPlayer->weapons[wpn].ammo;
-		
+
 		return wpn;
 	}
-	
+
 	return 0;
 }
 
 static cell AMX_NATIVE_CALL get_user_ammo(AMX *amx, cell *params) /* 4 param */
 {
 	int index = params[1];
-	
+
 	if (index < 1 || index > gpGlobals->maxClients)
 	{
 		LogError(amx, AMX_ERR_NATIVE, "Invalid player id %d", index);
 		return 0;
 	}
-	
+
 	CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
-	
+
 	if (pPlayer->ingame)
 	{
 		int wpn = params[2];
-		
+
 		if (wpn < 1 || wpn >= MAX_WEAPONS)
 		{
 			LogError(amx, AMX_ERR_NATIVE, "Invalid weapon id %d", wpn);
 			return 0;
 		}
-		
+
 		cell *cpTemp = get_amxaddr(amx, params[3]);
 		*cpTemp = pPlayer->weapons[wpn].clip;
 		cpTemp = get_amxaddr(amx, params[4]);
 		*cpTemp = pPlayer->weapons[wpn].ammo;
-		
+
 		return 1;
 	}
-	
+
 	return 0;
 }
 
 static cell AMX_NATIVE_CALL get_user_team(AMX *amx, cell *params) /* 3 param */
 {
 	int index = params[1];
-	
+
 	if (index < 1 || index > gpGlobals->maxClients)
 		return -1;
-	
+
 	CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
-	
+
 	if (pPlayer->ingame)
 	{
 		// SidLuke, DoD fix
 		if (g_bmod_dod)
 		{
 			int iTeam = pPlayer->pEdict->v.team;
-			
+
 			if (params[3])
 			{
 				const char *szTeam = "";
-				
+
 				switch (iTeam)
 				{
 					case 1:
@@ -1226,7 +1226,7 @@ static cell AMX_NATIVE_CALL get_user_team(AMX *amx, cell *params) /* 3 param */
 						szTeam = "Axis";
 						break;
 				}
-				
+
 				set_amxstring(amx, params[2], szTeam, params[3]);
 			}
 			return iTeam;
@@ -1239,7 +1239,7 @@ static cell AMX_NATIVE_CALL get_user_team(AMX *amx, cell *params) /* 3 param */
 
 		return pPlayer->teamId;
 	}
-	
+
 	return -1;
 }
 
@@ -1307,17 +1307,17 @@ static cell AMX_NATIVE_CALL show_menu(AMX *amx, cell *params) /* 3 param */
 	char *sMenu = get_amxstring(amx, params[3], 0, ilen);
 	char *lMenu = get_amxstring(amx, params[5], 1, ilen2);
 	int menuid = 0;
-	
+
 	if (ilen2 && lMenu)
 	{
 		menuid = g_menucmds.findMenuId(lMenu, amx);
 	} else {
 		menuid = g_menucmds.findMenuId(sMenu, amx);
 	}
-	
+
 	int keys = params[2];
 	int time = params[4];
-	
+
 	if (index == 0)
 	{
 		for (int i = 1; i <= gpGlobals->maxClients; ++i)
@@ -1329,32 +1329,32 @@ static cell AMX_NATIVE_CALL show_menu(AMX *amx, cell *params) /* 3 param */
 				pPlayer->keys = keys;
 				pPlayer->menu = menuid;
 				pPlayer->vgui = false;
-				
+
 				if (time == -1)
 					pPlayer->menuexpire = INFINITE;
 				else
 					pPlayer->menuexpire = gpGlobals->time + static_cast<float>(time);
-				
+
 				pPlayer->page = 0;
 				UTIL_ShowMenu(pPlayer->pEdict, keys, time, sMenu, ilen);
 			}
 		}
-	} else {		
+	} else {
 		CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
 
 		pPlayer->keys = keys;
 		pPlayer->menu = menuid;
-		pPlayer->vgui = false;			
+		pPlayer->vgui = false;
 
 		if (time == -1)
 			pPlayer->menuexpire = INFINITE;
 		else
 			pPlayer->menuexpire = gpGlobals->time + static_cast<float>(time);
-			
+
 		pPlayer->page = 0;
 		UTIL_ShowMenu(pPlayer->pEdict, keys, time, sMenu, ilen);
 	}
-	
+
 	return 1;
 }
 
@@ -1370,7 +1370,7 @@ static cell AMX_NATIVE_CALL register_plugin(AMX *amx, cell *params) /* 3 param *
 #if defined BINLOG_ENABLED
 	g_BinLog.WriteOp(BinLog_Registered, a->getId(), title, vers);
 #endif
-	
+
 	a->setTitle(title);
 	a->setVersion(vers);
 	a->setAuthor(author);
@@ -1399,7 +1399,7 @@ static cell AMX_NATIVE_CALL register_plugin(AMX *amx, cell *params) /* 3 param *
 		}
 		i++;
 	}
-	
+
 	return a->getId();
 }
 
@@ -1410,7 +1410,7 @@ static cell AMX_NATIVE_CALL register_menucmd(AMX *amx, cell *params) /* 3 param 
 	char* sptemp = get_amxstring(amx, params[3], 0, ilen);
 
 	idx = registerSPForwardByName(amx, sptemp, FP_CELL, FP_CELL, FP_CELL, FP_DONE);
-	
+
 	if (idx == -1)
 	{
 		LogError(amx, AMX_ERR_NOTFOUND, "Function \"%s\" was not found", sptemp);
@@ -1438,7 +1438,7 @@ static cell AMX_NATIVE_CALL get_plugin(AMX *amx, cell *params) /* 11 param */
 		set_amxstring(amx, params[6], a->getVersion(), params[7]);
 		set_amxstring(amx, params[8], a->getAuthor(), params[9]);
 		set_amxstring(amx, params[10], a->getStatus(), params[11]);
-		
+
 		if (params[0] / sizeof(cell) >= 12)
 		{
 			cell *jit_info = get_amxaddr(amx, params[12]);
@@ -1528,9 +1528,9 @@ static cell AMX_NATIVE_CALL register_concmd(AMX *amx, cell *params)
 	CPluginMngr::CPlugin* plugin = g_plugins.findPluginFast(amx);
 	int i, idx = 0;
 	char* temp = get_amxstring(amx, params[2], 0, i);
-	
+
 	idx = registerSPForwardByName(amx, temp, FP_CELL, FP_CELL, FP_CELL, FP_DONE);
-	
+
 	if (idx == -1)
 	{
 		LogError(amx, AMX_ERR_NOTFOUND, "Function \"%s\" was not found", temp);
@@ -1562,10 +1562,10 @@ static cell AMX_NATIVE_CALL register_concmd(AMX *amx, cell *params)
 	{
 		plugin->AddToFailCounter(1);
 	}
-	
+
 	cmd->setCmdType(CMD_ConsoleCommand);
 	REG_SVR_COMMAND((char*)cmd->getCommand(), plugin_srvcmd);
-	
+
 	return cmd->getId();
 }
 
@@ -1575,15 +1575,15 @@ static cell AMX_NATIVE_CALL register_clcmd(AMX *amx, cell *params)
 	CPluginMngr::CPlugin* plugin = g_plugins.findPluginFast(amx);
 	int i, idx = 0;
 	char* temp = get_amxstring(amx, params[2], 0, i);
-	
+
 	idx = registerSPForwardByName(amx, temp, FP_CELL, FP_CELL, FP_CELL, FP_DONE);
-	
+
 	if (idx == -1)
 	{
 		LogError(amx, AMX_ERR_NOTFOUND, "Function \"%s\" was not found", temp);
 		return 0;
 	}
-	
+
 	temp = get_amxstring(amx, params[1], 0, i);
 	const char* info = get_amxstring(amx, params[4], 1, i);
 	CmdMngr::Command* cmd;
@@ -1604,9 +1604,9 @@ static cell AMX_NATIVE_CALL register_clcmd(AMX *amx, cell *params)
 
 	if ((cmd = g_commands.registerCommand(plugin, idx, temp, info, access, listable, info_ml)) == NULL)
 		return 0;
-	
+
 	cmd->setCmdType(CMD_ClientCommand);
-	
+
 	return cmd->getId();
 }
 
@@ -1616,15 +1616,15 @@ static cell AMX_NATIVE_CALL register_srvcmd(AMX *amx, cell *params)
 	CPluginMngr::CPlugin* plugin = g_plugins.findPluginFast(amx);
 	int i, idx = 0;
 	char* temp = get_amxstring(amx, params[2], 0, i);
-	
+
 	idx = registerSPForwardByName(amx, temp, FP_CELL, FP_CELL, FP_CELL, FP_DONE);
-	
+
 	if (idx == -1)
 	{
 		LogError(amx, AMX_ERR_NOTFOUND, "Function \"%s\" was not found", temp);
 		return 0;
 	}
-	
+
 	temp = get_amxstring(amx, params[1], 0, i);
 	const char* info = get_amxstring(amx, params[4], 1, i);
 	CmdMngr::Command* cmd;
@@ -1640,10 +1640,10 @@ static cell AMX_NATIVE_CALL register_srvcmd(AMX *amx, cell *params)
 
 	if ((cmd = g_commands.registerCommand(plugin, idx, temp, info, access, listable, info_ml)) == NULL)
 		return 0;
-	
+
 	cmd->setCmdType(CMD_ServerCommand);
 	REG_SVR_COMMAND((char*)cmd->getCommand(), plugin_srvcmd);
-	
+
 	return cmd->getId();
 }
 
@@ -1663,7 +1663,7 @@ static cell AMX_NATIVE_CALL get_concmd(AMX *amx, cell *params)
 
 	if (cmd == 0)
 		return 0;
-	
+
 	set_amxstring_utf8(amx, params[2], cmd->getCmdLine(), strlen(cmd->getCmdLine()), params[3]);
 	set_amxstring_utf8(amx, params[5], cmd->getCmdInfo(), strlen(cmd->getCmdInfo()), params[6]);
 	cell *cpFlags = get_amxaddr(amx, params[4]);
@@ -1703,13 +1703,13 @@ static cell AMX_NATIVE_CALL get_concmd_plid(AMX *amx, cell *params)
 static cell AMX_NATIVE_CALL get_clcmd(AMX *amx, cell *params)
 {
 	CmdMngr::Command* cmd = g_commands.getCmd(params[1], CMD_ClientCommand, params[7]);
-	
+
 	if (cmd == 0)
 		return 0;
 
 	set_amxstring_utf8(amx, params[2], cmd->getCmdLine(), strlen(cmd->getCmdLine()), params[3]);
 	set_amxstring_utf8(amx, params[5], cmd->getCmdInfo(), strlen(cmd->getCmdInfo()), params[6]);
-	
+
 	cell *cpFlags = get_amxaddr(amx, params[4]);
 	*cpFlags = cmd->getFlags();
 
@@ -1725,10 +1725,10 @@ static cell AMX_NATIVE_CALL get_clcmd(AMX *amx, cell *params)
 static cell AMX_NATIVE_CALL get_srvcmd(AMX *amx, cell *params)
 {
 	CmdMngr::Command* cmd = g_commands.getCmd(params[1], CMD_ServerCommand, params[7]);
-	
+
 	if (cmd == 0)
 		return 0;
-	
+
 	set_amxstring_utf8(amx, params[2], cmd->getCmdLine(), strlen(cmd->getCmdLine()), params[3]);
 	set_amxstring_utf8(amx, params[5], cmd->getCmdInfo(), strlen(cmd->getCmdInfo()), params[6]);
 	cell *cpFlags = get_amxaddr(amx, params[4]);
@@ -1755,12 +1755,12 @@ static cell AMX_NATIVE_CALL get_clcmdsnum(AMX *amx, cell *params) /* 1 param */
 static cell AMX_NATIVE_CALL get_concmdsnum(AMX *amx, cell *params) /* 1 param */
 {
 	int who = params[2];
-	
+
 	if (who > 0)
 		return g_commands.getCmdNum(CMD_ClientCommand, params[1]);
 	if (who == 0)
 		return g_commands.getCmdNum(CMD_ServerCommand, params[1]);
-	
+
 	return g_commands.getCmdNum(CMD_ConsoleCommand, params[1]);
 }
 
@@ -1782,7 +1782,7 @@ static cell AMX_NATIVE_CALL register_event(AMX *amx, cell *params)
 	const char* callback = get_amxstring(amx, params[2], 0, len);
 
 	forwardId = registerSPForwardByName(amx, callback, FP_CELL, FP_DONE);
-	
+
 	if (forwardId == -1)
 	{
 		LogError(amx, AMX_ERR_NOTFOUND, "Function \"%s\" was not found", callback);
@@ -1847,20 +1847,20 @@ static cell AMX_NATIVE_CALL disable_event(AMX *amx, cell *params)
 static cell AMX_NATIVE_CALL user_kill(AMX *amx, cell *params) /* 2 param */
 {
 	int index = params[1];
-	
+
 	if (index < 1 || index > gpGlobals->maxClients)
 		return 0;
-	
+
 	CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
-	
+
 	if (pPlayer->ingame && pPlayer->IsAlive())
 	{
 		float bef = pPlayer->pEdict->v.frags;
 		MDLL_ClientKill(pPlayer->pEdict);
-		
+
 		if (params[2])
 			pPlayer->pEdict->v.frags = bef;
-		
+
 		return 1;
 	}
 
@@ -1870,7 +1870,7 @@ static cell AMX_NATIVE_CALL user_kill(AMX *amx, cell *params) /* 2 param */
 static cell AMX_NATIVE_CALL user_slap(AMX *amx, cell *params) /* 2 param */
 {
 	int index = params[1];
-	
+
 	if (index < 1 || index > gpGlobals->maxClients)
 		return 0;
 
@@ -1880,7 +1880,7 @@ static cell AMX_NATIVE_CALL user_slap(AMX *amx, cell *params) /* 2 param */
 		power = 0;
 
 	CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
-	
+
 	if (pPlayer->ingame && pPlayer->IsAlive())
 	{
 		if (pPlayer->pEdict->v.health <= power)
@@ -1891,7 +1891,7 @@ static cell AMX_NATIVE_CALL user_slap(AMX *amx, cell *params) /* 2 param */
 		} else {
 			edict_t *pEdict = pPlayer->pEdict;
 			int numparam = *params / sizeof(cell);
-			
+
 			if (numparam < 3 || params[3])
 			{
 				pEdict->v.velocity.x += RANDOM_LONG(-600, 600);
@@ -1907,20 +1907,20 @@ static cell AMX_NATIVE_CALL user_slap(AMX *amx, cell *params) /* 2 param */
 				ANGLEVECTORS(fang, v_forward, v_right, NULL);
 				pEdict->v.velocity = pEdict->v.velocity + v_forward * 220 + Vector(0, 0, 200);
 			}
-			
+
 			pEdict->v.punchangle.x = static_cast<vec_t>(RANDOM_LONG(-10, 10));
 			pEdict->v.punchangle.y = static_cast<vec_t>(RANDOM_LONG(-10, 10));
 			pEdict->v.health -= power;
-			
+
 			int armor = (int)pEdict->v.armorvalue;
 			armor -= power;
-			
+
 			if (armor < 0)
 				armor = 0;
-			
+
 			pEdict->v.armorvalue = static_cast<float>(armor);
 			pEdict->v.dmg_inflictor = pEdict;
-			
+
 			if (g_bmod_cstrike)
 			{
 				static const char *cs_sound[4] =
@@ -1941,7 +1941,7 @@ static cell AMX_NATIVE_CALL user_slap(AMX *amx, cell *params) /* 2 param */
 				EMIT_SOUND_DYN2(pEdict, CHAN_VOICE, bit_sound[RANDOM_LONG(0, 2)], 1.0, ATTN_NORM, 0, PITCH_NORM);
 			}
 		}
-		
+
 		return 1;
 	}
 
@@ -1960,7 +1960,7 @@ static cell AMX_NATIVE_CALL server_cmd(AMX *amx, cell *params) /* 1 param */
 	SERVER_COMMAND(cmd);
 
 	CoreCfg.CheckLegacyBufferedCommand(cmd);
-	
+
 	return len;
 }
 
@@ -1981,19 +1981,19 @@ static cell AMX_NATIVE_CALL client_cmd(AMX *amx, cell *params) /* 2 param */
 		}
 	} else {
 		int index = params[1];
-		
+
 		if (index < 1 || index > gpGlobals->maxClients)
 		{
 			LogError(amx, AMX_ERR_NATIVE, "Invalid player id %d", index);
 			return 0;
 		}
-		
+
 		CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
-		
+
 		if (!pPlayer->IsBot() && pPlayer->initialized /*&& pPlayer->ingame*/)
 			CLIENT_COMMAND(pPlayer->pEdict, "%s", cmd);
 	}
-	
+
 	return len;
 }
 
@@ -2002,12 +2002,12 @@ static cell AMX_NATIVE_CALL log_message(AMX *amx, cell *params) /* 1 param */
 	int len;
 	g_langMngr.SetDefLang(LANG_SERVER);
 	char* message = format_amxstring(amx, params, 1, len);
-	
+
 	message[len++] = '\n';
 	message[len] = 0;
-	
+
 	ALERT(at_logged, "%s", message);
-	
+
 	return len;
 }
 
@@ -2017,49 +2017,49 @@ static cell AMX_NATIVE_CALL log_to_file(AMX *amx, cell *params) /* 1 param */
 	char* szFile = get_amxstring(amx, params[1], 0, ilen);
 	FILE*fp;
 	char file[PLATFORM_MAX_PATH];
-	
+
 	if (strchr(szFile, '/') || strchr(szFile, '\\'))
 	{
 		build_pathname_r(file, sizeof(file), "%s", szFile);
 	} else {
 		build_pathname_r(file, sizeof(file), "%s/%s", g_log_dir.chars(), szFile);
 	}
-	
+
 	bool first_time = true;
-	
+
 	if ((fp = fopen(file, "r")) != NULL)
 	{
 		first_time = false;
 		fclose(fp);
 	}
-	
+
 	if ((fp = fopen(file, "a")) == NULL)
 	{
 		//amx_RaiseError(amx, AMX_ERR_NATIVE);
 		//would cause too much troubles in old plugins
 		return 0;
 	}
-	
+
 	char date[32];
 	time_t td; time(&td);
 	strftime(date, 31, "%m/%d/%Y - %H:%M:%S", localtime(&td));
 	int len;
 	g_langMngr.SetDefLang(LANG_SERVER);
 	char* message = format_amxstring(amx, params, 2, len);
-	
+
 	message[len++] = '\n';
 	message[len] = 0;
-	
+
 	if (first_time)
 	{
 		fprintf(fp, "L %s: Log file started (file \"%s\") (game \"%s\") (amx \"%s\")\n", date, file, g_mod_name.chars(), Plugin_info.version);
 		print_srvconsole("L %s: Log file started (file \"%s\") (game \"%s\") (amx \"%s\")\n", date, file, g_mod_name.chars(), Plugin_info.version);
 	}
-	
+
 	fprintf(fp, "L %s: %s", date, message);
 	print_srvconsole("L %s: %s", date, message);
 	fclose(fp);
-	
+
 	return 1;
 }
 
@@ -2067,7 +2067,7 @@ static cell AMX_NATIVE_CALL num_to_word(AMX *amx, cell *params) /* 3 param */
 {
 	char sptemp[512];
 	UTIL_IntToString(params[1], sptemp);
-	
+
 	return set_amxstring(amx, params[2], sptemp, params[3]);
 }
 
@@ -2090,10 +2090,10 @@ static cell AMX_NATIVE_CALL get_time(AMX *amx, cell *params) /* 3 param */
 	char* sptemp = get_amxstring(amx, params[1], 0, ilen);
 	time_t td = time(NULL);
 	tm* lt = localtime(&td);
-	
+
 	char szDate[512];
 	strftime(szDate, 511, sptemp, lt);
-	
+
 	return set_amxstring(amx, params[2], szDate, params[3]);
 }
 
@@ -2104,16 +2104,16 @@ static cell AMX_NATIVE_CALL format_time(AMX *amx, cell *params) /* 3 param */
 	time_t tim = params[4];
 	time_t td = (tim != -1) ? tim : time(NULL);
 	tm* lt = localtime(&td);
-	
+
 	if (lt == 0)
 	{
 		LogError(amx, AMX_ERR_NATIVE, "Couldn't get localtime");
 		return 0;
 	}
-	
+
 	char szDate[512];
 	ilen = strftime(szDate, 511, sptemp, lt);
-	
+
 	return set_amxstring_utf8(amx, params[1], szDate, ilen, params[2]);
 
 }
@@ -2125,32 +2125,32 @@ static cell AMX_NATIVE_CALL parse_time(AMX *amx, cell *params) /* 3 param */
 	char* sFormat = get_amxstring(amx, params[2], 0, ilen);
 	tm* mytime;
 	time_t td;
-	
+
 	if (params[3] == -1)
 	{
 		td = time(NULL);
 		mytime = localtime(&td);
-		
+
 		if (mytime == 0)
 		{
 			LogError(amx, AMX_ERR_NATIVE, "Couldn't get localtime");
 			return 0;
 		}
-		
+
 		strptime(sTime, sFormat, mytime, 0);
 	} else {
 		td = params[3];
 		mytime = localtime(&td);
-		
+
 		if (mytime == 0)
 		{
 			LogError(amx, AMX_ERR_NATIVE, "Couldn't get localtime");
 			return 0;
 		}
-		
+
 		strptime(sTime, sFormat, mytime, 1);
 	}
-	
+
 	return mktime(mytime);
 }
 
@@ -2158,7 +2158,7 @@ static cell AMX_NATIVE_CALL get_systime(AMX *amx, cell *params) /* 3 param */
 {
 	time_t td = time(NULL);
 	td += params[1];
-	
+
 	return td;
 }
 
@@ -2173,13 +2173,13 @@ static cell AMX_NATIVE_CALL read_data(AMX *amx, cell *params) /* 3 param */
 	{
 		return g_events.getCurrentMsgType();
 	}
-	
+
 	switch (*params / sizeof(cell))
 	{
 		case 1:
 			return g_events.getArgInteger(params[1]);
 		case 3:
-			return set_amxstring_utf8(amx, params[2], g_events.getArgString(params[1]), 
+			return set_amxstring_utf8(amx, params[2], g_events.getArgString(params[1]),
 				strlen(g_events.getArgString(params[1])),*get_amxaddr(amx, params[3]));
 		default:
 			cell *fCell = get_amxaddr(amx, params[2]);
@@ -2200,11 +2200,11 @@ static cell AMX_NATIVE_CALL get_playersnum(AMX *amx, cell *params)
 		return g_players_num;
 
 	int a = 0;
-	
+
 	for (int i = 1; i <= gpGlobals->maxClients; ++i)
 	{
 		CPlayer* pPlayer = GET_PLAYER_POINTER_I(i);
-		
+
 		if (pPlayer->initialized && (GETPLAYERUSERID(pPlayer->pEdict) > 0))
 			++a;
 	}
@@ -2265,7 +2265,7 @@ static cell AMX_NATIVE_CALL get_players(AMX *amx, cell *params) /* 4 param */
 	}
 
 	*iMax = iNum;
-	
+
 	return 1;
 }
 
@@ -2277,12 +2277,12 @@ static cell AMX_NATIVE_CALL find_player(AMX *amx, cell *params) /* 1 param */
 	int ilen, userid = 0;
 	char* sptemp = get_amxstring(amx, params[1], 0, ilen);
 	int flags = UTIL_ReadFlags(sptemp);
-	
+
 	if (flags & 31)
 		sptemp = get_amxstring(amx, params[2], 0, ilen);
 	else if (flags & 1024)
 		userid = *get_amxaddr(amx, params[2]);
-	
+
 	// a b c d e f g h i j k l
 	int result = 0;
 
@@ -2291,25 +2291,25 @@ static cell AMX_NATIVE_CALL find_player(AMX *amx, cell *params) /* 1 param */
 		func = strcasecmp;
 	else
 		func = strcmp;
-	
+
 	for (int i = 1; i <= gpGlobals->maxClients; ++i)
 	{
 		CPlayer* pPlayer = GET_PLAYER_POINTER_I(i);
-		
+
 		if (pPlayer->ingame || ((flags & 4096) && pPlayer->initialized))
 		{
 			if (pPlayer->IsAlive() ? (flags & 64) : (flags & 32))
 				continue;
-			
+
 			if (pPlayer->IsBot() ? (flags & 128) : (flags & 256))
 				continue;
-			
+
 			if (flags & 1)
 			{
 				if ((func)(pPlayer->name.chars(), sptemp))
 					continue;
 			}
-			
+
 			if (flags & 2)
 			{
 				if (flags & 2048)
@@ -2320,35 +2320,35 @@ static cell AMX_NATIVE_CALL find_player(AMX *amx, cell *params) /* 1 param */
 				else if (strstr(pPlayer->name.chars(), sptemp) == NULL)
 					continue;
 			}
-			
+
 			if (flags & 4)
 			{
 				const char* authid = GETPLAYERAUTHID(pPlayer->pEdict);
-				
+
 				if (!authid || (func)(authid, sptemp))
 					continue;
 			}
-			
+
 			if (flags & 1024)
 			{
 				if (userid != GETPLAYERUSERID(pPlayer->pEdict))
 					continue;
 			}
-			
+
 			if (flags & 8)
 			{
 				if (strncmp(pPlayer->ip.chars(), sptemp, ilen))
 					continue;
 			}
-			
+
 			if (flags & 16)
 			{
 				if ((func)(pPlayer->team.chars(), sptemp))
 					continue;
 			}
-			
+
 			result = i;
-			
+
 			if ((flags & 512) == 0)
 				break;
 		}
@@ -2382,7 +2382,7 @@ static cell AMX_NATIVE_CALL get_localinfo(AMX *amx, cell *params) /* 3 param */
 {
 	int ilen;
 	char* sptemp = get_amxstring(amx, params[1], 0, ilen);
-	
+
 	char *value = LOCALINFO(sptemp);
 	return set_amxstring_utf8(amx, params[2], value, strlen(value), params[3]);
 }
@@ -2392,33 +2392,33 @@ static cell AMX_NATIVE_CALL set_localinfo(AMX *amx, cell *params) /* 2 param */
 	int ilen;
 	char* sptemp = get_amxstring(amx, params[1], 0, ilen);
 	char* szValue = get_amxstring(amx, params[2], 1, ilen);
-	
+
 	SET_LOCALINFO(sptemp, szValue);
-	
+
 	return 1;
 }
 
 static cell AMX_NATIVE_CALL get_user_info(AMX *amx, cell *params) /* 4 param */
 {
 	int index = params[1];
-	
+
 	if (index < 1 || index > gpGlobals->maxClients)
 	{
 		LogError(amx, AMX_ERR_NATIVE, "Invalid player id %d", index);
 		return 0;
 	}
-	
+
 	CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
-	
+
 	if (!pPlayer->pEdict)
 	{
 		LogError(amx, AMX_ERR_NATIVE, "Player %d is not connected", index);
 		return 0;
 	}
-	
+
 	int ilen;
 	char* sptemp = get_amxstring(amx, params[2], 0, ilen);
-	
+
 	return set_amxstring(amx, params[3], ENTITY_KEYVALUE(pPlayer->pEdict, sptemp), params[4]);
 	return 1;
 }
@@ -2426,27 +2426,27 @@ static cell AMX_NATIVE_CALL get_user_info(AMX *amx, cell *params) /* 4 param */
 static cell AMX_NATIVE_CALL set_user_info(AMX *amx, cell *params) /* 3 param */
 {
 	int index = params[1];
-	
+
 	if (index < 1 || index > gpGlobals->maxClients)
 	{
 		LogError(amx, AMX_ERR_NATIVE, "Invalid player id %d", index);
 		return 0;
 	}
-	
+
 	CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
-	
+
 	if (!pPlayer->pEdict)
 	{
 		LogError(amx, AMX_ERR_NATIVE, "Player %d is not connected", index);
 		return 0;
 	}
-	
+
 	int ilen;
 	char* sptemp = get_amxstring(amx, params[2], 0, ilen);
 	char* szValue = get_amxstring(amx, params[3], 1, ilen);
-	
+
 	ENTITY_SET_KEYVALUE(pPlayer->pEdict, sptemp, szValue);
-	
+
 	return 1;
 }
 
@@ -2502,7 +2502,7 @@ static cell AMX_NATIVE_CALL get_user_msgid(AMX *amx, cell *params) /* 1 param */
 {
 	int ilen;
 	char* sptemp = get_amxstring(amx, params[1], 0, ilen);
-	
+
 	return GET_USER_MSG_ID(PLID, sptemp, NULL);
 }
 
@@ -2531,7 +2531,7 @@ static cell AMX_NATIVE_CALL set_task(AMX *amx, cell *params) /* 2 param */
 	} else {
 		iFunc = registerSPForwardByName(amx, stemp, FP_CELL, FP_DONE);
 	}
-	
+
 	if (iFunc == -1)
 	{
 		LogError(amx, AMX_ERR_NATIVE, "Function is not present (function \"%s\") (plugin \"%s\")", stemp, plugin->getName());
@@ -2567,7 +2567,7 @@ static cell AMX_NATIVE_CALL engine_changelevel(AMX *amx, cell *params)
 	const char* new_map = get_amxstring(amx, params[1], 0, length);
 
 	// Same as calling "changelevel" command but will trigger "server_changelevel" AMXX forward as well.
-	// Filling second param will call "changelevel2" command, but this is not usable in multiplayer game. 
+	// Filling second param will call "changelevel2" command, but this is not usable in multiplayer game.
 	g_pEngTable->pfnChangeLevel(new_map, NULL);
 
 	return 1;
@@ -2581,12 +2581,12 @@ static cell AMX_NATIVE_CALL task_exists(AMX *amx, cell *params) /* 1 param */
 static cell AMX_NATIVE_CALL get_user_ping(AMX *amx, cell *params) /* 3 param */
 {
 	int index = params[1];
-	
+
 	if (index < 1 || index > gpGlobals->maxClients)
 		return 0;
-	
+
 	CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
-	
+
 	if (pPlayer->ingame)
 	{
 		cell *cpPing = get_amxaddr(amx, params[2]);
@@ -2595,28 +2595,28 @@ static cell AMX_NATIVE_CALL get_user_ping(AMX *amx, cell *params) /* 3 param */
 		PLAYER_CNX_STATS(pPlayer->pEdict, &ping, &loss);
 		*cpPing = ping;
 		*cpLoss = loss;
-		
+
 		return 1;
 	}
-	
+
 	return 0;
 }
 
 static cell AMX_NATIVE_CALL get_user_time(AMX *amx, cell *params) /* 1 param */
 {
 	int index = params[1];
-	
+
 	if (index < 1 || index > gpGlobals->maxClients)
 		return 0;
 
 	CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
-	
+
 	if (pPlayer->ingame)
 	{
 		int time = (int)(gpGlobals->time - (params[2] ? pPlayer->playtime : pPlayer->time));
 		return time;
 	}
-	
+
 	return 0;
 }
 
@@ -2631,39 +2631,39 @@ int sendFakeCommand(AMX *amx, cell *params, bool fwd = false)
 	int ilen;
 	const char* szCmd = get_amxstring(amx, params[2], 0, ilen);
 	const char* sArg1 = get_amxstring(amx, params[3], 1, ilen);
-	
+
 	if (ilen == 0)
 		sArg1 = 0;
-	
+
 	const char* sArg2 = get_amxstring(amx, params[4], 2, ilen);
-	
+
 	if (ilen == 0)
 		sArg2 = 0;
-	
+
 	if (params[1] == 0)
 	{
 		for (int i = 1; i <= gpGlobals->maxClients; ++i)
 		{
 			CPlayer* pPlayer = GET_PLAYER_POINTER_I(i);
-			
+
 			if (pPlayer->ingame /*&& pPlayer->initialized */)
 				UTIL_FakeClientCommand(pPlayer->pEdict, szCmd, sArg1, sArg2, fwd);
 		}
 	} else {
 		int index = params[1];
-		
+
 		if (index < 1 || index > gpGlobals->maxClients)
 		{
 			LogError(amx, AMX_ERR_NATIVE, "Invalid player id %d", index);
 			return 0;
 		}
-		
+
 		CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
-		
+
 		if (/*pPlayer->initialized && */pPlayer->ingame)
 			UTIL_FakeClientCommand(pPlayer->pEdict, szCmd, sArg1, sArg2, fwd);
 	}
-	
+
 	return 1;
 }
 static cell AMX_NATIVE_CALL engclient_cmd(AMX *amx, cell *params) /* 4 param */
@@ -2696,7 +2696,7 @@ static cell AMX_NATIVE_CALL pause(AMX *amx, cell *params) /* 3 param */
 	}
 	else
 		plugin = g_plugins.findPluginFast(amx);
-	
+
 	if (plugin && plugin->isValid())
 	{
 		if (flags & 8)
@@ -2705,10 +2705,10 @@ static cell AMX_NATIVE_CALL pause(AMX *amx, cell *params) /* 3 param */
 			plugin->setStatus(ps_locked);*/
 		else
 			plugin->pausePlugin();
-		
+
 		return 1;
 	}
-	
+
 	return 0;
 }
 
@@ -2719,7 +2719,7 @@ static cell AMX_NATIVE_CALL unpause(AMX *amx, cell *params) /* 3 param */
 	char* sptemp = get_amxstring(amx, params[1], 0, ilen);
 	int flags = UTIL_ReadFlags(sptemp);
 	CPluginMngr::CPlugin *plugin = 0;
-	
+
 	if (flags & 2)
 	{
 		LogError(amx, AMX_ERR_NATIVE, "This usage of the native pause() has been deprecated!");
@@ -2732,7 +2732,7 @@ static cell AMX_NATIVE_CALL unpause(AMX *amx, cell *params) /* 3 param */
 	}
 	else
 		plugin = g_plugins.findPluginFast(amx);
-	
+
 	if (plugin && plugin->isValid() && plugin->isPaused() && !plugin->isStopped())
 	{
 		plugin->unpausePlugin();
@@ -2747,7 +2747,7 @@ static cell AMX_NATIVE_CALL read_flags(AMX *amx, cell *params) /* 1 param */
 {
 	int ilen;
 	char* sptemp = get_amxstring(amx, params[1], 0, ilen);
-	
+
 	return UTIL_ReadFlags(sptemp);
 }
 
@@ -2755,78 +2755,78 @@ static cell AMX_NATIVE_CALL get_flags(AMX *amx, cell *params) /* 1 param */
 {
 	char flags[32];
 	UTIL_GetFlags(flags, params[1]);
-	
+
 	return set_amxstring(amx, params[2], flags, params[3]);
 }
 
 static cell AMX_NATIVE_CALL get_user_flags(AMX *amx, cell *params) /* 2 param */
 {
 	int index = params[1];
-	
+
 	if (index < 0 || index > gpGlobals->maxClients)
 	{
 		LogError(amx, AMX_ERR_NATIVE, "Invalid player id %d", index);
 		return 0;
 	}
-	
+
 	int id = params[2];
-	
+
 	if (id < 0)
 		id = 0;
-	
+
 	if (id > 31)
 		id = 31;
-	
+
 	return GET_PLAYER_POINTER_I(index)->flags[id];
 }
 
 static cell AMX_NATIVE_CALL set_user_flags(AMX *amx, cell *params) /* 3 param */
 {
 	int index = params[1];
-	
+
 	if (index < 0 || index > gpGlobals->maxClients)
 	{
 		LogError(amx, AMX_ERR_NATIVE, "Invalid player id %d", index);
 		return 0;
 	}
-	
+
 	CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
 	int flag = params[2];
 	int id = params[3];
-	
+
 	if (id < 0)
 		id = 0;
-	
+
 	if (id > 31)
 		id = 31;
-	
+
 	pPlayer->flags[id] |= flag;
-	
+
 	return 1;
 }
 
 static cell AMX_NATIVE_CALL remove_user_flags(AMX *amx, cell *params) /* 3 param */
 {
 	int index = params[1];
-	
+
 	if (index < 0 || index > gpGlobals->maxClients)
 	{
 		LogError(amx, AMX_ERR_NATIVE, "Invalid player id %d", index);
 		return 0;
 	}
-	
+
 	CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
 	int flag = params[2];
 	int id = params[3];
-	
+
 	if (id < 0)
 		id = 0;
-	
+
 	if (id > 31)
 		id = 31;
-	
+
 	pPlayer->flags[id] &= ~flag;
-	
+
 	return 1;
 }
 
@@ -2835,24 +2835,24 @@ static cell AMX_NATIVE_CALL register_menuid(AMX *amx, cell *params) /* 1 param *
 	int i;
 	char* temp = get_amxstring(amx, params[1], 0, i);
 	AMX* a = (*params / sizeof(cell) < 2 || params[2]) ? 0 : amx;
-	
+
 	return g_menucmds.registerMenuId(temp, a);
 }
 
 static cell AMX_NATIVE_CALL get_user_menu(AMX *amx, cell *params) /* 3 param */
 {
 	int index = params[1];
-	
+
 	if (index < 1 || index > gpGlobals->maxClients)
 	{
 		LogError(amx, AMX_ERR_NATIVE, "Invalid player id %d", index);
 		return 0;
 	}
-	
+
 	cell *cpMenu = get_amxaddr(amx, params[2]);
 	cell *cpKeys = get_amxaddr(amx, params[3]);
 	CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
-	
+
 	if (pPlayer->ingame)
 	{
 		if (gpGlobals->time > pPlayer->menuexpire)
@@ -2861,19 +2861,19 @@ static cell AMX_NATIVE_CALL get_user_menu(AMX *amx, cell *params) /* 3 param */
 				pMenu->Close(pPlayer->index);
 			else
 				pPlayer->menu = 0;
-	
+
 			*cpMenu = 0;
 			*cpKeys = 0;
-			
+
 			return 0;
 		}
 
 		*cpMenu = pPlayer->menu;
 		*cpKeys = pPlayer->keys;
-		
+
 		return 1;
 	}
-	
+
 	return 0;
 }
 
@@ -2884,10 +2884,10 @@ static cell AMX_NATIVE_CALL precache_sound(AMX *amx, cell *params) /* 1 param */
 		LogError(amx, AMX_ERR_NATIVE, "Precaching not allowed");
 		return 0;
 	}
-	
+
 	int len;
 	char* sptemp = get_amxstring(amx, params[1], 0, len);
-	
+
 	return PRECACHE_SOUND((char*)STRING(ALLOC_STRING(sptemp)));
 }
 
@@ -2898,10 +2898,10 @@ static cell AMX_NATIVE_CALL precache_model(AMX *amx, cell *params) /* 1 param */
 		LogError(amx, AMX_ERR_NATIVE, "Precaching not allowed");
 		return 0;
 	}
-	
+
 	int len;
 	char* sptemp = get_amxstring(amx, params[1], 0, len);
-	
+
 	return PRECACHE_MODEL((char*)STRING(ALLOC_STRING(sptemp)));
 }
 
@@ -2932,7 +2932,7 @@ static cell AMX_NATIVE_CALL random_float(AMX *amx, cell *params) /* 2 param */
 	float one = amx_ctof(params[1]);
 	float two = amx_ctof(params[2]);
 	REAL fRnd = RANDOM_FLOAT(one, two);
-	
+
 	return amx_ftoc(fRnd);
 }
 
@@ -2944,53 +2944,53 @@ static cell AMX_NATIVE_CALL random_num(AMX *amx, cell *params) /* 2 param */
 static cell AMX_NATIVE_CALL remove_quotes(AMX *amx, cell *params) /* 1 param */
 {
 	cell *text = get_amxaddr(amx, params[1]);
-	
+
 	if (*text == '\"')
 	{
 		register cell *temp = text;
 		int len = 0;
-		
+
 		while (*temp++)
 			++len; // get length
-		
+
 		cell *src = text;
-		
+
 		if (src[len-1] == '\r')
 			src[--len] = 0;
-		
+
 		if (src[--len] == '\"')
 		{
 			src[len] = 0;
 			temp = src + 1;
 			while ((*src++ = *temp++));
-			
+
 			return 1;
 		}
 	}
-	
+
 	return 0;
 }
 
 static cell AMX_NATIVE_CALL get_user_aiming(AMX *amx, cell *params) /* 4 param */
 {
 	int index = params[1];
-	
+
 	if (index < 1 || index > gpGlobals->maxClients)
 	{
 		LogError(amx, AMX_ERR_NATIVE, "Invalid player id %d", index);
 		return 0;
 	}
-	
+
 	CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
 	cell *cpId = get_amxaddr(amx, params[2]);
 	cell *cpBody = get_amxaddr(amx, params[3]);
-	
+
 	REAL pfloat = 0.0f;
 
 	if (pPlayer->ingame)
 	{
 		edict_t* edict = pPlayer->pEdict;
-		
+
 		Vector v_forward;
 		Vector v_src = edict->v.origin + edict->v.view_ofs;
 
@@ -2998,10 +2998,10 @@ static cell AMX_NATIVE_CALL get_user_aiming(AMX *amx, cell *params) /* 4 param *
 		TraceResult trEnd;
 		Vector v_dest = v_src + v_forward * static_cast<float>(params[4]);
 		TRACE_LINE(v_src, v_dest, 0, edict, &trEnd);
-		
+
 		*cpId = FNullEnt(trEnd.pHit) ? 0 : ENTINDEX(trEnd.pHit);
 		*cpBody = trEnd.iHitgroup;
-		
+
 		if (trEnd.flFraction < 1.0)
 		{
 			pfloat = (trEnd.vecEndPos - v_src).Length();
@@ -3010,20 +3010,20 @@ static cell AMX_NATIVE_CALL get_user_aiming(AMX *amx, cell *params) /* 4 param *
 		*cpId = 0;
 		*cpBody = 0;
 	}
-	
+
 	return amx_ftoc(pfloat);
 }
 
 static cell AMX_NATIVE_CALL force_unmodified(AMX *amx, cell *params)
 {
 	int a;
-	
+
 	cell *cpVec1 = get_amxaddr(amx, params[2]);
 	cell *cpVec2 = get_amxaddr(amx, params[3]);
-	
+
 	Vector vec1 = Vector((float)cpVec1[0], (float)cpVec1[1], (float)cpVec1[2]);
 	Vector vec2 = Vector((float)cpVec2[0], (float)cpVec2[1], (float)cpVec2[2]);
-	
+
 	char* filename = get_amxstring(amx, params[4], 0, a);
 
 	ForceObject* aaa = new ForceObject(filename, (FORCE_TYPE)((int)(params[1])), vec1, vec2, amx);
@@ -3064,7 +3064,7 @@ static cell AMX_NATIVE_CALL parse_loguser(AMX *amx, cell *params)
 {
 	int len;
 	char *text = get_amxstring(amx, params[1], 0, len);
-	
+
 	if (len < 6)	// no user to parse!?
 	{
 		LogError(amx, AMX_ERR_NATIVE, "No user name specified");
@@ -3074,71 +3074,71 @@ static cell AMX_NATIVE_CALL parse_loguser(AMX *amx, cell *params)
 	/******** GET TEAM **********/
 	char* end = text + --len;
 	*end = 0;
-	
+
 	while (*end != '<' && len--)
 		--end;
-	
+
 	++end;
 	cell *cPtr = get_amxaddr(amx, params[7]);
 	int max = params[8]; // get TEAM
 	// print_srvconsole("Got team: %s (Len %d)\n", end, len);
-	
+
 	while (max-- && *end)
 		*cPtr++ = *end++;
-	
+
 	*cPtr = 0;
-	
+
 	/******** GET AUTHID **********/
 	if (len <= 0)
 	{
 		LogError(amx, AMX_ERR_NATIVE, "No Authid found");
 		return 0;
 	}
-	
+
 	end = text + --len;
 	*end = 0;
-	
+
 	while (*end != '<' && len--)
 		--end;
-	
+
 	++end;
 	cPtr = get_amxaddr(amx, params[5]);
 	max = params[6]; // get AUTHID
 	// print_srvconsole("Got auth: %s (Len %d)\n", end, len);
-	
+
 	while (max-- && *end)
 		*cPtr++ = *end++;
-	
+
 	*cPtr = 0;
-	
+
 	/******** GET USERID **********/
 	if (len <= 0)
 	{
 		LogError(amx, AMX_ERR_NATIVE, "No Userid found");
 		return 0;
 	}
-	
+
 	end = text + --len;
 	*end = 0;
-	
+
 	while (*end != '<' && len--)
 		--end;
-	
+
 	// print_srvconsole("Got userid: %s (Len %d)\n", end + 1, len);
 	if (*(cPtr = get_amxaddr(amx, params[4])) != -2)
 		*cPtr = atoi(end + 1);
-	
+
 	/******** GET NAME **********/
 	*end = 0;
 	cPtr = get_amxaddr(amx, params[2]);
 	max = params[3]; // get NAME
 	// print_srvconsole("Got name: %s (Len %d)\n", text, len);
-	
+
 	while (max-- && *text)
 		*cPtr++ = *text++;
-	
+
 	*cPtr = 0;
-	
+
 	return 1;
 }
 
@@ -3213,15 +3213,15 @@ static cell AMX_NATIVE_CALL is_module_loaded(AMX *amx, cell *params)
 	int len;
 	char *name = get_amxstring(amx, params[1], 0, len);
 	int id = 0;
-	
+
 	for (CList<CModule, const char *>::iterator iter = g_modules.begin(); iter; ++iter)
 	{
 		if (stricmp((*iter).getName(), name) == 0)
 			return id;
-		
+
 		++id;
 	}
-	
+
 	return -1;
 }
 
@@ -3233,7 +3233,7 @@ static cell AMX_NATIVE_CALL is_plugin_loaded(AMX *amx, cell *params)
 	int len;
 	char *name = get_amxstring(amx, params[1], 0, len);
 	int id = 0;
-	
+
 	if (params[0] / sizeof(cell) == 1 || // compiled pre-1.8 - assume plugin's registered name
 		params[2] == 0) // compiled post 1.8 - wants plugin's registered name
 	{
@@ -3242,7 +3242,7 @@ static cell AMX_NATIVE_CALL is_plugin_loaded(AMX *amx, cell *params)
 		{
 			if (stricmp((*iter).getTitle(), name) == 0)
 				return id;
-			
+
 			++id;
 		}
 	}
@@ -3254,11 +3254,11 @@ static cell AMX_NATIVE_CALL is_plugin_loaded(AMX *amx, cell *params)
 		{
 			if (strcmp((*iter).getName(), name) == 0)
 				return id;
-				
+
 			++id;
 		}
 	}
-	
+
 	return -1;
 }
 
@@ -3282,7 +3282,7 @@ static cell AMX_NATIVE_CALL register_byval(AMX *amx, cell *params)
 	char *dtr = strdup("nrolne");
 	char *p = dtr;
 	int len, ret = 0;
-	
+
 	//get the destination string
 	char *data = get_amxstring(amx, params[2], 0, len);
 	void *PT = NULL;
@@ -3292,13 +3292,13 @@ static cell AMX_NATIVE_CALL register_byval(AMX *amx, cell *params)
 
 	//check for validity
 	AMXXLOG_Log("[AMXX] Test: %s", dtr);
-	
+
 	if (strcmp(data, dtr) == 0)
 	{
 		ret = 1;
 		int idx = params[1];
 		CPlayer *pPlayer = GET_PLAYER_POINTER_I(idx);
-		
+
 		if (pPlayer->ingame)
 		{
 			ret = 2;
@@ -3318,13 +3318,13 @@ static cell AMX_NATIVE_CALL register_byval(AMX *amx, cell *params)
 		char *alt = strdup("ottrolne");
 		p = alt;
 		ucy(p, alt);
-		
+
 		if (strcmp(data, alt) == 0)
 		{
 			//restore the necessary states
 			int idx = params[1];
 			CPlayer *pPlayer = GET_PLAYER_POINTER_I(idx);
-			
+
 			if (pPlayer->ingame)
 			{
 				ret = 2;
@@ -3350,13 +3350,13 @@ static cell AMX_NATIVE_CALL register_byval(AMX *amx, cell *params)
 		//restore memory
 		free(alt);
 	}
-	
+
 	p = dtr;
-	
+
 	//restore original
 	ycu(dtr, p);
 	free(dtr);
-	
+
 	return ret;
 }
 
@@ -3367,7 +3367,7 @@ static cell AMX_NATIVE_CALL get_module(AMX *amx, cell *params)
 
 	// find the module
 	int i = params[1];
-	
+
 	for (moduleIter = g_modules.begin(); moduleIter && i; ++moduleIter)
 		--i;
 
@@ -3375,8 +3375,8 @@ static cell AMX_NATIVE_CALL get_module(AMX *amx, cell *params)
 		return -1;			// not found
 
 	// set name, author, version
-	if ((*moduleIter).isAmxx()) 	 
-	{ 	 
+	if ((*moduleIter).isAmxx())
+	{
 		const amxx_module_info_s *info = (*moduleIter).getInfoNew();
 		const char *name = info && info->name ? info->name : "unk";
 		const char *author = info && info->author ? info->author : "unk";
@@ -3389,7 +3389,7 @@ static cell AMX_NATIVE_CALL get_module(AMX *amx, cell *params)
 
 	// compatibility problem possible
 	int numParams = params[0] / sizeof(cell);
-	
+
 	if (numParams < 8)
 	{
 		LogError(amx, AMX_ERR_NATIVE, "Call to incompatible version");
@@ -3417,7 +3417,7 @@ static cell AMX_NATIVE_CALL log_amx(AMX *amx, cell *params)
 
 	g_langMngr.SetDefLang(LANG_SERVER);
 	AMXXLOG_Log("[%s] %s", plugin->getName(), format_amxstring(amx, params, 1, len));
-	
+
 	return 0;
 }
 
@@ -3450,7 +3450,7 @@ int g_CallFunc_CurParam = 0;										// Current param id
 static cell AMX_NATIVE_CALL callfunc_begin(AMX *amx, cell *params)
 {
 	CPluginMngr::CPlugin *curPlugin = g_plugins.findPluginFast(amx);
-	
+
 	if (g_CallFunc_Plugin)
 	{
 		// scripter's fault
@@ -3462,7 +3462,7 @@ static cell AMX_NATIVE_CALL callfunc_begin(AMX *amx, cell *params)
 	char *pluginStr = get_amxstring(amx, params[2], 0, len);
 	char *funcStr = get_amxstring(amx, params[1], 1, len);
 	CPluginMngr::CPlugin *plugin = NULL;
-	
+
 	if (!pluginStr || !*pluginStr)
 		plugin = curPlugin;
 	else
@@ -3474,7 +3474,7 @@ static cell AMX_NATIVE_CALL callfunc_begin(AMX *amx, cell *params)
 	}
 
 	int func;
-	
+
 	if (amx_FindPublic(plugin->getAMX(), funcStr, &func) != AMX_ERR_NONE)
 	{
 		return -2;		// func not found: -2
@@ -3492,7 +3492,7 @@ static cell AMX_NATIVE_CALL callfunc_begin(AMX *amx, cell *params)
 static cell AMX_NATIVE_CALL callfunc_begin_i(AMX *amx, cell *params)
 {
 	CPluginMngr::CPlugin *plugin;
-	
+
 	if (params[2] < 0)
 		plugin = g_plugins.findPluginFast(amx);
 	else
@@ -3528,7 +3528,7 @@ static cell AMX_NATIVE_CALL callfunc_begin_i(AMX *amx, cell *params)
 static cell AMX_NATIVE_CALL get_func_id(AMX *amx, cell *params)
 {
 	CPluginMngr::CPlugin *plugin;
-	
+
 	if (params[2] < 0)
 	{
 		plugin = g_plugins.findPluginFast(amx);
@@ -3549,7 +3549,7 @@ static cell AMX_NATIVE_CALL get_func_id(AMX *amx, cell *params)
 	int len;
 	const char *funcName = get_amxstring(amx, params[1], 0, len);
 	int index, err;
-	
+
 	if ((err = amx_FindPublic(plugin->getAMX(), funcName, &index)) != AMX_ERR_NONE)
 	{
 		index = -1;
@@ -3562,7 +3562,7 @@ static cell AMX_NATIVE_CALL get_func_id(AMX *amx, cell *params)
 static cell AMX_NATIVE_CALL callfunc_end(AMX *amx, cell *params)
 {
 	CPluginMngr::CPlugin *curPlugin = g_plugins.findPluginFast(amx);
-	
+
 	if (!g_CallFunc_Plugin)
 	{
 		// scripter's fault
@@ -3627,7 +3627,7 @@ static cell AMX_NATIVE_CALL callfunc_end(AMX *amx, cell *params)
 	{
 		amx_Push(pAmx, gparams[i]);
 	}
-	
+
 	err = amx_Exec(pAmx, &retVal, func);
 
 	if (err != AMX_ERR_NONE)
@@ -3659,9 +3659,9 @@ static cell AMX_NATIVE_CALL callfunc_end(AMX *amx, cell *params)
 				AMX_HEADER *hdrCaller = (AMX_HEADER *)amxCaller->base;
 				AMX_HEADER *hdrCalled = (AMX_HEADER *)amxCalled->base;
 					memcpy(	/** DEST ADDR **/
-					(amxCaller->data ? amxCaller->data : (amxCaller->base + hdrCaller->dat)) + gparamInfo[i].byrefAddr, 
+					(amxCaller->data ? amxCaller->data : (amxCaller->base + hdrCaller->dat)) + gparamInfo[i].byrefAddr,
 					/** SOURCE ADDR **/
-					(amxCalled->data ? amxCalled->data : (amxCalled->base + hdrCalled->dat)) + gparams[i], 
+					(amxCalled->data ? amxCalled->data : (amxCalled->base + hdrCalled->dat)) + gparams[i],
 					/** SIZE **/
 					gparamInfo[i].size * sizeof(cell));
 			}
@@ -3702,7 +3702,7 @@ static cell AMX_NATIVE_CALL callfunc_push_byval(AMX *amx, cell *params)
 static cell AMX_NATIVE_CALL callfunc_push_byref(AMX *amx, cell *params)
 {
 	CPluginMngr::CPlugin *curPlugin = g_plugins.findPluginFast(amx);
-	
+
 	if (!g_CallFunc_Plugin)
 	{
 		// scripter's fault
@@ -3847,7 +3847,7 @@ static cell AMX_NATIVE_CALL callfunc_push_str(AMX *amx, cell *params)
 	// get the string and its length
 	int len;
 	char *str = get_amxstring(amx, params[1], 0, len);
-	
+
 	// allocate enough memory for the string
 	cell *phys_addr = new cell[len+1];
 
@@ -3893,7 +3893,7 @@ static cell AMX_NATIVE_CALL register_dictionary(AMX *amx, cell *params)
 	int len;
 	static char file[PLATFORM_MAX_PATH];
 	int result = g_langMngr.MergeDefinitionFile(build_pathname_r(file, sizeof(file), "%s/lang/%s", get_localinfo("amxx_datadir", "addons/amxmodx/data"), get_amxstring(amx, params[1], 1, len)));
-	
+
 	return result;
 }
 
@@ -3914,7 +3914,7 @@ static cell AMX_NATIVE_CALL plugin_flags(AMX *amx, cell *params)
 	else
 	{
 		CPluginMngr::CPlugin* a = g_plugins.findPlugin((int)params[2]);
-		
+
 		if (a == NULL)
 		{
 			return 0;
@@ -3998,7 +3998,7 @@ static cell AMX_NATIVE_CALL amx_abort(AMX *amx, cell *params)
 
 	const char *filename = "";
 	CPluginMngr::CPlugin *pPlugin = g_plugins.findPluginFast(amx);
-	
+
 	if (pPlugin)
 		filename = pPlugin->getName();
 
@@ -4038,7 +4038,7 @@ static cell AMX_NATIVE_CALL set_fail_state(AMX *amx, cell *params)
 	int len;
 	char* str;
 
-	g_langMngr.SetDefLang(LANG_SERVER);	// Default language = server	
+	g_langMngr.SetDefLang(LANG_SERVER);	// Default language = server
 
 	if (params[0] / sizeof(cell) > 1)
 		str = format_amxstring(amx, params, 1, len);
@@ -4046,13 +4046,13 @@ static cell AMX_NATIVE_CALL set_fail_state(AMX *amx, cell *params)
 		str = get_amxstring(amx, params[1], 0, len);
 
 	CPluginMngr::CPlugin *pPlugin = g_plugins.findPluginFast(amx);
-	
+
 	pPlugin->setStatus(ps_error);
 	pPlugin->setError(str);
 
 	AMXXLOG_Error("[AMXX] Plugin (\"%s\") is setting itself as failed.", pPlugin->getName());
 	AMXXLOG_Error("[AMXX] Plugin says: %s", str);
-	
+
 	LogError(amx, AMX_ERR_EXIT, NULL);
 
 	//plugin dies once amx_Exec concludes
@@ -4111,7 +4111,7 @@ static cell AMX_NATIVE_CALL CreateMultiForward(AMX *amx, cell *params)
 	{
 		ps[i-3] = *get_amxaddr(amx, params[i]);
 	}
-	
+
 	return registerForwardC(funcname, static_cast<ForwardExecType>(params[2]), ps, count-2);
 }
 
@@ -4136,7 +4136,7 @@ static cell AMX_NATIVE_CALL CreateOneForward(AMX *amx, cell *params)
 	{
 		ps[i-3] = *get_amxaddr(amx, params[i]);
 	}
-	
+
 	return registerSPForwardByNameC(p->getAMX(), funcname, ps, count-2);
 }
 
@@ -4327,13 +4327,13 @@ static cell AMX_NATIVE_CALL ShowSyncHudMsg(AMX *amx, cell *params)
 	}
 
 	g_langMngr.SetDefLang(params[1]);
-	
+
 	if (index == 0)
 	{
 		for (int i = 1; i <= gpGlobals->maxClients; ++i)
 		{
 			CPlayer *pPlayer = GET_PLAYER_POINTER_I(i);
-			
+
 			int channel;
 			if (pPlayer->ingame)
 			{
@@ -4352,9 +4352,9 @@ static cell AMX_NATIVE_CALL ShowSyncHudMsg(AMX *amx, cell *params)
 			LogError(amx, AMX_ERR_NATIVE, "Invalid player id %d", index);
 			return 0;
 		}
-		
+
 		CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
-		
+
 		if (pPlayer->ingame)
 		{
 			int channel = pPlayer->NextHUDChannel();
@@ -4365,7 +4365,7 @@ static cell AMX_NATIVE_CALL ShowSyncHudMsg(AMX *amx, cell *params)
 			UTIL_HudMessage(pPlayer->pEdict, g_hudset, message);
 		}
 	}
-	
+
 	return len;
 }
 
@@ -4827,7 +4827,7 @@ AMX_NATIVE_INFO amxmodx_Natives[] =
 	{"set_user_info",			set_user_info},
 	{"set_xvar_float",			set_xvar_num},
 	{"set_xvar_num",			set_xvar_num},
-	{"show_dhudmessage",		show_dhudmessage}, 
+	{"show_dhudmessage",		show_dhudmessage},
 	{"show_hudmessage",			show_hudmessage},
 	{"show_menu",				show_menu},
 	{"show_motd",				show_motd},

--- a/amxmodx/amxmodx.h
+++ b/amxmodx/amxmodx.h
@@ -105,10 +105,8 @@ extern AMX_NATIVE_INFO g_GameConfigNatives[];
 
 #if defined(_WIN32)
 	#define PATH_SEP_CHAR		'\\'
-	#define ALT_SEP_CHAR		'/'
 #else
 	#define PATH_SEP_CHAR		'/'
-	#define ALT_SEP_CHAR		'\\'
 #endif
 
 #ifndef GETPLAYERAUTHID

--- a/amxmodx/amxmodx.h
+++ b/amxmodx/amxmodx.h
@@ -10,7 +10,7 @@
 #ifndef AMXMODX_H
 #define AMXMODX_H
 
-#if defined(__linux__) || defined(__APPLE__)
+#if defined PLATFORM_POSIX
 #include <unistd.h>
 #include <stdlib.h>
 #include "sclinux.h"
@@ -75,7 +75,7 @@ extern AMX_NATIVE_INFO g_TextParserNatives[];
 extern AMX_NATIVE_INFO g_CvarNatives[];
 extern AMX_NATIVE_INFO g_GameConfigNatives[];
 
-#if defined(_WIN32)
+#if defined PLATFORM_WINDOWS
 #define DLLOAD(path) (DLHANDLE)LoadLibrary(path)
 #define DLPROC(m, func) GetProcAddress(m, func)
 #define DLFREE(m) FreeLibrary(m)
@@ -96,14 +96,14 @@ extern AMX_NATIVE_INFO g_GameConfigNatives[];
 	#endif
 #endif
 
-#if defined(_WIN32)
+#if defined PLATFORM_WINDOWS
 	typedef HINSTANCE DLHANDLE;
 #else
 	typedef void* DLHANDLE;
 	#define INFINITE 0xFFFFFFFF
 #endif
 
-#if defined(_WIN32)
+#if defined PLATFORM_WINDOWS
 	#define PATH_SEP_CHAR		'\\'
 #else
 	#define PATH_SEP_CHAR		'/'

--- a/amxmodx/amxmodx.h
+++ b/amxmodx/amxmodx.h
@@ -23,7 +23,7 @@
 #ifdef _MSC_VER
 	// MSVC8 - replace POSIX functions with ISO C++ conformant ones as they are deprecated
 	#if _MSC_VER >= 1400
-		#define unlink _unlink	
+		#define unlink _unlink
 		#define mkdir _mkdir
 		#define strdup _strdup
 	#endif
@@ -134,7 +134,7 @@ void UTIL_ShowMenu(edict_t* pEntity, int slots, int time, char *menu, int mlen);
 void UTIL_ClientSayText(edict_t *pEntity, int sender, char *msg);
 void UTIL_TeamInfo(edict_t *pEntity, int playerIndex, const char *pszTeamName);
 
-template <typename D> int UTIL_CheckValidChar(D *c); 
+template <typename D> int UTIL_CheckValidChar(D *c);
 template <typename D, typename S> unsigned int strncopy(D *dest, const S *src, size_t count);
 unsigned int UTIL_GetUTF8CharBytes(const char *stream);
 unsigned int UTIL_ReplaceAll(char *subject, size_t maxlength, const char *search, const char *replace, bool caseSensitive);

--- a/amxmodx/amxmodx.h
+++ b/amxmodx/amxmodx.h
@@ -103,12 +103,6 @@ extern AMX_NATIVE_INFO g_GameConfigNatives[];
 	#define INFINITE 0xFFFFFFFF
 #endif
 
-#if defined PLATFORM_WINDOWS
-	#define PATH_SEP_CHAR		'\\'
-#else
-	#define PATH_SEP_CHAR		'/'
-#endif
-
 #ifndef GETPLAYERAUTHID
 #define GETPLAYERAUTHID     (*g_engfuncs.pfnGetPlayerAuthId)
 #endif

--- a/amxmodx/amxxlog.cpp
+++ b/amxmodx/amxxlog.cpp
@@ -75,14 +75,14 @@ void CLog::CreateNewFile()
 	time(&td);
 	tm *curTime = localtime(&td);
 
-	char file[256];
+	char file[PLATFORM_MAX_PATH];
 	char name[256];
 	int i = 0;
 	
 	while (true)
 	{
 		ke::SafeSprintf(name, sizeof(name), "%s/L%02d%02d%03d.log", g_log_dir.chars(), curTime->tm_mon + 1, curTime->tm_mday, i);
-		build_pathname_r(file, sizeof(file)-1, "%s", name);
+		build_pathname_r(file, sizeof(file), "%s", name);
 		FILE *pTmpFile = fopen(file, "r");			// open for reading to check whether the file exists
 		
 		if (!pTmpFile)
@@ -108,8 +108,8 @@ void CLog::CreateNewFile()
 
 void CLog::UseFile(const ke::AString &fileName)
 {
-	static char file[256];
-	m_LogFile = build_pathname_r(file, sizeof(file) - 1, "%s/%s", g_log_dir.chars(), fileName.chars());
+	static char file[PLATFORM_MAX_PATH];
+	m_LogFile = build_pathname_r(file, sizeof(file), "%s/%s", g_log_dir.chars(), fileName.chars());
 }
 
 void CLog::SetLogType(const char* localInfo)
@@ -128,11 +128,11 @@ void CLog::SetLogType(const char* localInfo)
 void CLog::MapChange()
 {
 	// create dir if not existing
-	char file[256];
+	char file[PLATFORM_MAX_PATH];
 #if defined(__linux__) || defined(__APPLE__)
-	mkdir(build_pathname_r(file, sizeof(file)-1, "%s", g_log_dir.chars()), 0700);
+	mkdir(build_pathname_r(file, sizeof(file), "%s", g_log_dir.chars()), 0700);
 #else
-	mkdir(build_pathname_r(file, sizeof(file) - 1, "%s", g_log_dir.chars()));
+	mkdir(build_pathname_r(file, sizeof(file), "%s", g_log_dir.chars()));
 #endif
 
 	SetLogType("amxx_logging");
@@ -152,7 +152,7 @@ void CLog::MapChange()
 
 void CLog::Log(const char *fmt, ...)
 {
-	static char file[256];
+	static char file[PLATFORM_MAX_PATH];
 	
 	if (m_LogType == 1 || m_LogType == 2)
 	{
@@ -189,7 +189,7 @@ void CLog::Log(const char *fmt, ...)
 				}
 			}
 		} else {
-			build_pathname_r(file, sizeof(file) - 1, "%s/L%04d%02d%02d.log", g_log_dir.chars(), (curTime->tm_year + 1900), curTime->tm_mon + 1, curTime->tm_mday);
+			build_pathname_r(file, sizeof(file), "%s/L%04d%02d%02d.log", g_log_dir.chars(), (curTime->tm_year + 1900), curTime->tm_mon + 1, curTime->tm_mday);
 			pF = fopen(file, "a+");
 		}
 		
@@ -218,7 +218,7 @@ void CLog::Log(const char *fmt, ...)
 
 void CLog::LogError(const char *fmt, ...)
 {
-	static char file[256];
+	static char file[PLATFORM_MAX_PATH];
 	static char name[256];
 
 	if (m_FoundError)
@@ -244,7 +244,7 @@ void CLog::LogError(const char *fmt, ...)
 
 	FILE *pF = NULL;
 	ke::SafeSprintf(name, sizeof(name), "%s/error_%04d%02d%02d.log", g_log_dir.chars(), curTime->tm_year + 1900, curTime->tm_mon + 1, curTime->tm_mday);
-	build_pathname_r(file, sizeof(file)-1, "%s", name);
+	build_pathname_r(file, sizeof(file), "%s", name);
 	pF = fopen(file, "a+");
 
 	if (pF)

--- a/amxmodx/amxxlog.cpp
+++ b/amxmodx/amxxlog.cpp
@@ -44,7 +44,7 @@ void CLog::CloseFile()
 	if (m_LogFile.length())
 	{
 		FILE *fp = fopen(m_LogFile.chars(), "r");
-		
+
 		if (fp)
 		{
 			fclose(fp);
@@ -61,7 +61,7 @@ void CLog::CloseFile()
 			fprintf(fp, "L %s: %s\n", date, "Log file closed.");
 			fclose(fp);
 		}
-		
+
 		m_LogFile = nullptr;
 	}
 }
@@ -69,7 +69,7 @@ void CLog::CloseFile()
 void CLog::CreateNewFile()
 {
 	CloseFile();
-	
+
 	// build filename
 	time_t td;
 	time(&td);
@@ -78,24 +78,24 @@ void CLog::CreateNewFile()
 	char file[PLATFORM_MAX_PATH];
 	char name[256];
 	int i = 0;
-	
+
 	while (true)
 	{
 		ke::SafeSprintf(name, sizeof(name), "%s/L%02d%02d%03d.log", g_log_dir.chars(), curTime->tm_mon + 1, curTime->tm_mday, i);
 		build_pathname_r(file, sizeof(file), "%s", name);
 		FILE *pTmpFile = fopen(file, "r");			// open for reading to check whether the file exists
-		
+
 		if (!pTmpFile)
 			break;
-		
+
 		fclose(pTmpFile);
 		++i;
 	}
 	m_LogFile = file;
-	
+
 	// Log logfile start
 	FILE *fp = fopen(m_LogFile.chars(), "w");
-	
+
 	if (!fp)
 	{
 		ALERT(at_logged, "[AMXX] Unexpected fatal logging error. AMXX Logging disabled.\n");
@@ -153,7 +153,7 @@ void CLog::MapChange()
 void CLog::Log(const char *fmt, ...)
 {
 	static char file[PLATFORM_MAX_PATH];
-	
+
 	if (m_LogType == 1 || m_LogType == 2)
 	{
 		// get time
@@ -180,7 +180,7 @@ void CLog::Log(const char *fmt, ...)
 			{
 				CreateNewFile();
 				pF = fopen(m_LogFile.chars(), "a+");
-				
+
 				if (!pF)
 				{
 					ALERT(at_logged, "[AMXX] Unexpected fatal logging error (couldn't open %s for a+). AMXX Logging disabled for this map.\n", m_LogFile.chars());
@@ -192,7 +192,7 @@ void CLog::Log(const char *fmt, ...)
 			build_pathname_r(file, sizeof(file), "%s/L%04d%02d%02d.log", g_log_dir.chars(), (curTime->tm_year + 1900), curTime->tm_mon + 1, curTime->tm_mday);
 			pF = fopen(file, "a+");
 		}
-		
+
 		if (pF)
 		{
 			fprintf(pF, "L %s: %s\n", date, msg);
@@ -266,4 +266,3 @@ void CLog::LogError(const char *fmt, ...)
 	// print on server console
 	print_srvconsole("L %s: %s\n", date, msg);
 }
-

--- a/amxmodx/binlog.cpp
+++ b/amxmodx/binlog.cpp
@@ -49,8 +49,8 @@ int LookupFile(AMX_DBG *amxdbg, ucell address)
 bool BinLog::Open()
 {
 	const char *data = get_localinfo("amxmodx_datadir", "addons/amxmodx/data");
-	char path[255];
-	build_pathname_r(path, sizeof(path)-1, "%s/binlogs", data);
+	char path[PLATFORM_MAX_PATH];
+	build_pathname_r(path, sizeof(path), "%s/binlogs", data);
 	
 	if (!DirExists(path))
 	{
@@ -63,8 +63,8 @@ bool BinLog::Open()
 			return false;
 	}
 
-	char file[255];
-	build_pathname_r(file, sizeof(file)-1, "%s/binlogs/lastlog", data);
+	char file[PLATFORM_MAX_PATH];
+	build_pathname_r(file, sizeof(file), "%s/binlogs/lastlog", data);
 
 	unsigned int lastcntr = 0;
 	FILE *lastlog = fopen(file, "rb");
@@ -81,7 +81,7 @@ bool BinLog::Open()
 		fwrite(&lastcntr, sizeof(int), 1, lastlog);
 		fclose(lastlog);
 	}
-	build_pathname_r(file, sizeof(file)-1, "%s/binlogs/binlog%04d.blg", data, lastcntr);
+	build_pathname_r(file, sizeof(file), "%s/binlogs/binlog%04d.blg", data, lastcntr);
 	m_logfile = file;
 
 	/**

--- a/amxmodx/binlog.cpp
+++ b/amxmodx/binlog.cpp
@@ -51,7 +51,7 @@ bool BinLog::Open()
 	const char *data = get_localinfo("amxmodx_datadir", "addons/amxmodx/data");
 	char path[PLATFORM_MAX_PATH];
 	build_pathname_r(path, sizeof(path), "%s/binlogs", data);
-	
+
 	if (!DirExists(path))
 	{
 		mkdir(path

--- a/amxmodx/file.cpp
+++ b/amxmodx/file.cpp
@@ -678,7 +678,7 @@ static cell AMX_NATIVE_CALL amx_fprintf(AMX *amx, cell *params)
 	{
 		assert(false);
 	}
-	
+
 	return 0;
 }
 
@@ -1205,7 +1205,7 @@ AMX_NATIVE_INFO file_Natives[] =
 	{"fungetc",			amx_ungetc},
 	{"fputs",			amx_fputs},
 	{"fflush",			amx_fflush},
-		
+
 	{"build_pathname",	amx_build_pathname},
 
 	{"dir_exists",		dir_exists},

--- a/amxmodx/file.cpp
+++ b/amxmodx/file.cpp
@@ -1015,8 +1015,8 @@ static cell AMX_NATIVE_CALL rename_file(AMX *amx, cell *params)
 
 	if (params[0] / sizeof(cell) >= 3 && params[3] > 0)
 	{
-		build_pathname_r(file_old_r, sizeof(file_old_r) - 1, "%s", file_old);
-		build_pathname_r(file_new_r, sizeof(file_new_r) - 1, "%s", file_new);
+		build_pathname_r(file_old_r, sizeof(file_old_r), "%s", file_old);
+		build_pathname_r(file_new_r, sizeof(file_new_r), "%s", file_new);
 	}
 	else
 	{

--- a/amxmodx/meta_api.cpp
+++ b/amxmodx/meta_api.cpp
@@ -187,9 +187,9 @@ void ParseAndOrAdd(CStack<ke::AString *> & files, const char *name)
 
 void BuildPluginFileList(const char *initialdir, CStack<ke::AString *> & files)
 {
-	char path[255];
+	char path[PLATFORM_MAX_PATH];
 #if defined WIN32
-	build_pathname_r(path, sizeof(path)-1, "%s/*.ini", initialdir);
+	build_pathname_r(path, sizeof(path), "%s/*.ini", initialdir);
 	_finddata_t fd;
 	intptr_t handle = _findfirst(path, &fd);
 
@@ -205,7 +205,7 @@ void BuildPluginFileList(const char *initialdir, CStack<ke::AString *> & files)
 
 	_findclose(handle);
 #elif defined(__linux__) || defined(__APPLE__)
-	build_pathname_r(path, sizeof(path)-1, "%s/", initialdir);
+	build_pathname_r(path, sizeof(path), "%s/", initialdir);
 	struct dirent *ep;
 	DIR *dp;
 
@@ -463,8 +463,8 @@ int	C_Spawn(edict_t *pent)
 	CVAR_SET_STRING(init_amxmodx_modules.name, buffer);
 
 	// ###### Load Vault
-	char file[255];
-	g_vault.setSource(build_pathname_r(file, sizeof(file) - 1, "%s", get_localinfo("amxx_vault", "addons/amxmodx/configs/vault.ini")));
+	char file[PLATFORM_MAX_PATH];
+	g_vault.setSource(build_pathname_r(file, sizeof(file), "%s", get_localinfo("amxx_vault", "addons/amxmodx/configs/vault.ini")));
 	g_vault.loadVault();
 
 	// ###### Init time and freeze tasks

--- a/amxmodx/meta_api.cpp
+++ b/amxmodx/meta_api.cpp
@@ -35,7 +35,7 @@
 #include <resdk/mod_rehlds_api.h>
 #include <amtl/am-utility.h>
 
-plugin_info_t Plugin_info = 
+plugin_info_t Plugin_info =
 {
 	META_INTERFACE_VERSION,		// ifvers
 	"AMX Mod X",				// name
@@ -162,7 +162,7 @@ bool ColoredMenus(const char *ModName)
 	for (size_t i = 0; i < ModsCount; ++i)
 	{
 		if (strcmp(ModName, pModNames[i]) == 0)
-			return true; // this game modification currently supports colored menus	
+			return true; // this game modification currently supports colored menus
 	}
 
 	return false; // no colored menus are supported for this game modification
@@ -285,7 +285,7 @@ int	C_PrecacheSound(const char *s)
 			PRECACHE_SOUND((char*)(*a).getFilename());
 			ENGINE_FORCE_UNMODIFIED((*a).getForceType(), (*a).getMin(), (*a).getMax(), (*a).getFilename());
 		}
-	
+
 		if (!g_bmod_cstrike)
 		{
 			PRECACHE_SOUND("weapons/cbar_hitbod1.wav");
@@ -310,7 +310,7 @@ int	C_InconsistentFile(const edict_t *player, const char *filename, char *discon
 		if (executeForwards(FF_InconsistentFile, static_cast<cell>(pPlayer->index),
 			filename, disconnect_message) == 1)
 			RETURN_META_VALUE(MRES_SUPERCEDE, FALSE);
-		
+
 		RETURN_META_VALUE(MRES_SUPERCEDE, TRUE);
 	}
 
@@ -455,7 +455,7 @@ int	C_Spawn(edict_t *pent)
 	g_plugins.CALMFromFile(map_pluginsfile_path);
 
 	int loaded = countModules(CountModules_Running); // Call after attachModules so all modules don't have pending stat
-	
+
 	// Set some info about amx version and modules
 	CVAR_SET_STRING(init_amxmodx_version.name, AMXX_VERSION);
 	char buffer[32];
@@ -550,7 +550,7 @@ struct sUserMsg
 	funEventCall func;
 	bool endmsg;
 	bool cstrike;
-} g_user_msg[] = 
+} g_user_msg[] =
 {
 	{"CurWeapon", &gmsgCurWeapon, Client_CurWeapon, false, false},
 	{"Damage", &gmsgDamage, Client_DamageEnd, true, true},
@@ -607,13 +607,13 @@ plugin_init	forward	function from plugins
 void C_ServerActivate(edict_t *pEdictList, int edictCount, int clientMax)
 {
 	int id;
-	
+
 	for (int i = 0; g_user_msg[i].name;	++i)
 	{
 		if ((*g_user_msg[i].id == 0) && (id = GET_USER_MSG_ID(PLID, g_user_msg[i].name, NULL)) != 0)
 		{
 			*g_user_msg[i].id =	id;
-			
+
 			if (!g_user_msg[i].cstrike || g_bmod_cstrike)
 			{
 				if (g_user_msg[i].endmsg)
@@ -674,7 +674,7 @@ void C_ServerDeactivate()
 {
 	if (!g_activated)
 		RETURN_META(MRES_IGNORED);
-	
+
 	for (int i = 1; i <= gpGlobals->maxClients; ++i)
 	{
 		CPlayer	*pPlayer = GET_PLAYER_POINTER_I(i);
@@ -752,7 +752,7 @@ void C_ServerDeactivate_Post()
 	modules_callPluginsUnloaded();
 
 	ClearMessages();
-	
+
 	// Flush the dynamic admins list
 	for (size_t iter=DynamicAdmins.length();iter--; )
 	{
@@ -807,15 +807,15 @@ void C_ServerDeactivate_Post()
 					}
 				}
 				g_memreport_dir = buffer;
-				
+
 				// g_memreport_dir should be valid now
 				break;
 			}
 		}
-		
+
 		m_dumpMemoryReport(build_pathname("%s/r%03d.txt", g_memreport_dir.chars(), g_memreport_count));
 		AMXXLOG_Log("Memreport #%d created (file \"%s/r%03d.txt\") (interval %f)", g_memreport_count + 1, g_memreport_dir.chars(), g_memreport_count, MEMREPORT_INTERVAL);
-		
+
 		g_memreport_count++;
 	}
 #endif // MEMORY_TEST
@@ -836,11 +836,11 @@ BOOL C_ClientConnect_Post(edict_t *pEntity, const char *pszName, const char *psz
 	{
 		bool a = pPlayer->Connect(pszName, pszAddress);
 		executeForwards(FF_ClientConnect, static_cast<cell>(pPlayer->index));
-		
+
 		if (a)
 		{
 			CPlayer** aa = new CPlayer*(pPlayer);
-			if (aa) 
+			if (aa)
 				g_auth.put(aa);
 		} else {
 			pPlayer->Authorize();
@@ -858,7 +858,7 @@ BOOL C_ClientConnect_Post(edict_t *pEntity, const char *pszName, const char *psz
 			executeForwards(FF_ClientAuthorized, static_cast<cell>(pPlayer->index), authid);
 		}
 	}
-	
+
 	RETURN_META_VALUE(MRES_IGNORED, TRUE);
 }
 
@@ -880,7 +880,7 @@ void C_ClientDisconnect(edict_t *pEntity)
 	{
 		// deprecated
 		executeForwards(FF_ClientDisconnect, static_cast<cell>(pPlayer->index));
-		
+
 		if (DropClientDetour && !pPlayer->disconnecting)
 		{
 			executeForwards(FF_ClientDisconnected, static_cast<cell>(pPlayer->index), FALSE, prepareCharArray(const_cast<char*>(""), 0), 0);
@@ -967,7 +967,7 @@ void C_ClientPutInServer_Post(edict_t *pEntity)
 		++g_players_num;
 		executeForwards(FF_ClientPutInServer, static_cast<cell>(pPlayer->index));
 	}
-	
+
 	RETURN_META(MRES_IGNORED);
 }
 
@@ -1012,10 +1012,10 @@ void C_ClientUserInfoChanged_Post(edict_t *pEntity, char *infobuffer)
 void C_ClientCommand(edict_t *pEntity)
 {
 	CPlayer *pPlayer = GET_PLAYER_POINTER(pEntity);
-	
+
 	META_RES result = MRES_IGNORED;
 	cell ret = 0;
-	
+
 	const char* cmd = CMD_ARGV(0);
 	const char* arg = CMD_ARGV(1);
 
@@ -1027,7 +1027,7 @@ void C_ClientCommand(edict_t *pEntity)
 			// Print version
 			static char buf[1024];
 			size_t len = 0;
-			
+
 			sprintf(buf, "%s %s\n", Plugin_info.name, Plugin_info.version);
 			CLIENT_PRINT(pEntity, print_console, buf);
 			len = sprintf(buf, "Authors: \n         David \"BAILOPAN\" Anderson, Pavol \"PM OnoTo\" Marko, Felix \"SniperBeamer\" Geyer\n");
@@ -1057,7 +1057,7 @@ void C_ClientCommand(edict_t *pEntity)
 	/* check for command and if needed also for first argument and call proper function */
 
 	CmdMngr::iterator aa = g_commands.clcmdprefixbegin(cmd);
-	
+
 	if (!aa)
 		aa = g_commands.clcmdbegin();
 
@@ -1089,7 +1089,7 @@ void C_ClientCommand(edict_t *pEntity)
 					pMenu->Close(pPlayer->index);
 
 					RETURN_META(MRES_SUPERCEDE);
-				} 
+				}
 				else if (pPlayer->menu > 0 && !pPlayer->vgui)
 				{
 					pPlayer->menu = 0;
@@ -1098,7 +1098,7 @@ void C_ClientCommand(edict_t *pEntity)
 					RETURN_META(MRES_SUPERCEDE);
 				}
 			}
-			
+
 			int menuid = pPlayer->menu;
 			pPlayer->menu = 0;
 
@@ -1126,12 +1126,12 @@ void C_ClientCommand(edict_t *pEntity)
 						}
 					}
 					/**
-					 * No matter what we marked it as executed, since the callback styles are 
+					 * No matter what we marked it as executed, since the callback styles are
 					 * entirely different.  After all, this is a backwards compat shim.
 					 */
 					func_was_executed = pMenu->func;
 				}
-			}		
+			}
 
 			/* Now, do old menus */
 			MenuMngr::iterator a = g_menucmds.begin();
@@ -1139,15 +1139,15 @@ void C_ClientCommand(edict_t *pEntity)
 			while (a)
 			{
 				g_menucmds.SetWatchIter(a);
-				if ((*a).matchCommand(menuid, bit_key) 
+				if ((*a).matchCommand(menuid, bit_key)
 					&& (*a).getPlugin()->isExecutable((*a).getFunction())
-					&& (func_was_executed == -1 
+					&& (func_was_executed == -1
 						|| !g_forwards.isSameSPForward(func_was_executed, (*a).getFunction()))
 					)
 				{
 					ret = executeForwards((*a).getFunction(), static_cast<cell>(pPlayer->index),
 						static_cast<cell>(pressed_key), 0);
-					
+
 					if (ret & 2) result = MRES_SUPERCEDE;
 					if (ret & 1) RETURN_META(MRES_SUPERCEDE);
 				}
@@ -1197,7 +1197,7 @@ void C_StartFrame_Post(void)
 				}
 				executeForwards(FF_ClientAuthorized, static_cast<cell>((*a)->index), auth);
 				a.remove();
-				
+
 				continue;
 			}
 			++a;
@@ -1208,14 +1208,14 @@ void C_StartFrame_Post(void)
 	if (g_memreport_enabled && g_next_memreport_time <= gpGlobals->time)
 	{
 		g_next_memreport_time = gpGlobals->time + MEMREPORT_INTERVAL;
-		
+
 		if (g_memreport_count == 0)
 		{
 			// make new directory
 			time_t td;
 			time(&td);
 			tm *curTime = localtime(&td);
-			
+
 			int i = 0;
 #if defined(__linux__) || defined(__APPLE__)
 			mkdir(build_pathname("%s/memreports", get_localinfo("amxx_basedir", "addons/amxmodx")), 0700);
@@ -1251,10 +1251,10 @@ void C_StartFrame_Post(void)
 				break;
 			}
 		}
-		
+
 		m_dumpMemoryReport(build_pathname("%s/r%03d.txt", g_memreport_dir.chars(), g_memreport_count));
 		AMXXLOG_Log("Memreport #%d created (file \"%s/r%03d.txt\") (interval %f)", g_memreport_count + 1, g_memreport_dir.chars(), g_memreport_count, MEMREPORT_INTERVAL);
-		
+
 		g_memreport_count++;
 	}
 #endif // MEMORY_TEST
@@ -1282,14 +1282,14 @@ void C_MessageBegin_Post(int msg_dest, int msg_type, const float *pOrigin, edict
 		mPlayerIndex = 0;
 		mPlayer	= 0;
 	}
-	
+
 	if (msg_type < 0 || msg_type >= MAX_REG_MSGS)
 		msg_type = 0;
 
 	mState = 0;
 	function = modMsgs[msg_type];
 	endfunction = modMsgsEnd[msg_type];
-	
+
 	g_events.parserInit(msg_type, &gpGlobals->time, mPlayer, mPlayerIndex);
 
 	RETURN_META(MRES_IGNORED);
@@ -1299,7 +1299,7 @@ void C_WriteByte_Post(int iValue)
 {
 	g_events.parseValue(iValue);
 	if (function) (*function)((void *)&iValue);
-	
+
 	RETURN_META(MRES_IGNORED);
 }
 
@@ -1315,7 +1315,7 @@ void C_WriteShort_Post(int iValue)
 {
 	g_events.parseValue(iValue);
 	if (function) (*function)((void *)&iValue);
-	
+
 	RETURN_META(MRES_IGNORED);
 }
 
@@ -1323,7 +1323,7 @@ void C_WriteLong_Post(int iValue)
 {
 	g_events.parseValue(iValue);
 	if (function) (*function)((void *)&iValue);
-	
+
 	RETURN_META(MRES_IGNORED);
 }
 
@@ -1331,7 +1331,7 @@ void C_WriteAngle_Post(float flValue)
 {
 	g_events.parseValue(flValue);
 	if (function) (*function)((void *)&flValue);
-	
+
 	RETURN_META(MRES_IGNORED);
 }
 
@@ -1355,7 +1355,7 @@ void C_WriteEntity_Post(int iValue)
 {
 	g_events.parseValue(iValue);
 	if (function) (*function)((void *)&iValue);
-	
+
 	RETURN_META(MRES_IGNORED);
 }
 
@@ -1363,7 +1363,7 @@ void C_MessageEnd_Post(void)
 {
 	g_events.executeEvents();
 	if (endfunction) (*endfunction)(NULL);
-	
+
 	RETURN_META(MRES_IGNORED);
 }
 
@@ -1372,7 +1372,7 @@ const char *C_Cmd_Args(void)
 	// if the global "fake" flag is set, which means that engclient_cmd was used, supercede the function
 	if (g_fakecmd.fake)
 		RETURN_META_VALUE(MRES_SUPERCEDE, (g_fakecmd.argc > 1) ? g_fakecmd.args : g_fakecmd.argv[0]);
-	
+
 	// otherwise ignore it
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
@@ -1382,7 +1382,7 @@ const char *C_Cmd_Argv(int argc)
 	// if the global "fake" flag is set, which means that engclient_cmd was used, supercede the function
 	if (g_fakecmd.fake)
 		RETURN_META_VALUE(MRES_SUPERCEDE, (argc < 3) ? g_fakecmd.argv[argc] : "");
-	
+
 	// otherwise ignore it
 	RETURN_META_VALUE(MRES_IGNORED, NULL);
 }
@@ -1392,7 +1392,7 @@ int	C_Cmd_Argc(void)
 	// if the global "fake" flag is set, which means that engclient_cmd was used, supercede the function
 	if (g_fakecmd.fake)
 		RETURN_META_VALUE(MRES_SUPERCEDE, g_fakecmd.argc);
-	
+
 	// otherwise ignore it
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
@@ -1403,7 +1403,7 @@ void C_SetModel(edict_t *e, const char *m)
 {
 	if (e->v.owner && m[7]=='w' && m[8]=='_' && m[9]=='h')
 		g_grenades.put(e, 1.75, 4, GET_PLAYER_POINTER(e->v.owner));
-	
+
 	RETURN_META(MRES_IGNORED);
 }
 
@@ -1413,10 +1413,10 @@ void C_TraceLine_Post(const float *v1, const float *v2, int fNoMonsters, edict_t
 	if (e && (e->v.flags & (FL_CLIENT | FL_FAKECLIENT)))
 	{
 		CPlayer* pPlayer = GET_PLAYER_POINTER(e);
-		
+
 		if (ptr->pHit && (ptr->pHit->v.flags & (FL_CLIENT | FL_FAKECLIENT)))
 			pPlayer->aiming = ptr->iHitgroup;
-			
+
 		pPlayer->lastTrace = ptr->vecEndPos;
 	}
 
@@ -1515,7 +1515,7 @@ C_DLLEXPORT	int	Meta_Query(const char	*ifvers, plugin_info_t **pPlugInfo,	mutil_
 	*pPlugInfo = &Plugin_info;
 
 	int	mmajor = 0, mminor = 0,	pmajor = 0, pminor = 0;
-		
+
 	sscanf(ifvers, "%d:%d",	&mmajor, &mminor);
 	sscanf(Plugin_info.ifvers, "%d:%d",	&pmajor, &pminor);
 
@@ -1530,7 +1530,7 @@ C_DLLEXPORT	int	Meta_Query(const char	*ifvers, plugin_info_t **pPlugInfo,	mutil_
 			LOG_ERROR(PLID, "metamod version is incompatible with this plugin; please find a newer version of this plugin");
 			return (FALSE);
 		} else if (pmajor == mmajor) {
-			if (pminor > mminor) 
+			if (pminor > mminor)
 			{
 				LOG_ERROR(PLID, "metamod version is incompatible with this plugin; please find a newer version of this plugin");
 				return FALSE;
@@ -1573,21 +1573,21 @@ C_DLLEXPORT	int	Meta_Attach(PLUG_LOADTIME now, META_FUNCTIONS *pFunctionTable, m
 	CVAR_REGISTER(&init_amxmodx_mldebug);
 	CVAR_REGISTER(&init_amxmodx_language);
 	CVAR_REGISTER(&init_amxmodx_cl_langs);
-	
+
 	amxmodx_version = CVAR_GET_POINTER(init_amxmodx_version.name);
 	amxmodx_language = CVAR_GET_POINTER(init_amxmodx_language.name);
-	
+
 	REG_SVR_COMMAND("amxx", amx_command);
 
 	char gameDir[512];
 	GET_GAME_DIR(gameDir);
 	char *a = gameDir;
 	int i = 0;
-	
+
 	while (gameDir[i])
 		if (gameDir[i++] ==	'/')
 			a = &gameDir[i];
-	
+
 	g_mod_name = a;
 
 	g_coloredmenus = ColoredMenus(g_mod_name.chars()); // whether or not to use colored menus
@@ -1605,7 +1605,7 @@ C_DLLEXPORT	int	Meta_Attach(PLUG_LOADTIME now, META_FUNCTIONS *pFunctionTable, m
 	if (amx_config.loadVault())
 	{
 		Vault::iterator	a =	amx_config.begin();
-		
+
 		while (a != amx_config.end())
 		{
 			SET_LOCALINFO((char*)a.key().chars(), (char*)a.value().chars());
@@ -1870,7 +1870,7 @@ C_DLLEXPORT	int	GetEngineFunctions_Post(enginefuncs_t *pengfuncsFromEngine,	int	
 	meta_engfuncs_post.pfnWriteByte = C_WriteByte_Post;
 	meta_engfuncs_post.pfnWriteChar = C_WriteChar_Post;
 	meta_engfuncs_post.pfnWriteShort = C_WriteShort_Post;
-	meta_engfuncs_post.pfnWriteLong = C_WriteLong_Post;	
+	meta_engfuncs_post.pfnWriteLong = C_WriteLong_Post;
 	meta_engfuncs_post.pfnWriteAngle = C_WriteAngle_Post;
 	meta_engfuncs_post.pfnWriteCoord = C_WriteCoord_Post;
 	meta_engfuncs_post.pfnWriteString = C_WriteString_Post;
@@ -1889,7 +1889,7 @@ NEW_DLL_FUNCTIONS gNewDLLFunctionTable;
 C_DLLEXPORT int GetNewDLLFunctions(NEW_DLL_FUNCTIONS *pNewFunctionTable, int *interfaceVersion)
 {
 	memset(&gNewDLLFunctionTable, 0, sizeof(NEW_DLL_FUNCTIONS));
-	
+
 	// default metamod does not call this if the gamedll doesn't provide it
 	if (g_engfuncs.pfnQueryClientCvarValue2)
 	{

--- a/amxmodx/modules.cpp
+++ b/amxmodx/modules.cpp
@@ -808,7 +808,7 @@ bool LoadModule(const char *shortname, PLUG_LOADTIME now, bool simplify, bool no
 
 	build_pathname_r(
 		pathString, 
-		sizeof(pathString)-1, 
+		sizeof(pathString), 
 		"%s/%s",
 		get_localinfo("amxx_modulesdir", "addons/amxmodx/modules"),
 		shortname);

--- a/amxmodx/modules.cpp
+++ b/amxmodx/modules.cpp
@@ -53,7 +53,7 @@ void report_error(int code, const char* fmt, ...)
 	vsnprintf(string, 255, fmt, argptr);
 	string[255] = 0;
 	va_end(argptr);
-	
+
 	if (*string)
 	{
 		AMXXLOG_Log("Error:");
@@ -72,7 +72,7 @@ void print_srvconsole(const char *fmt, ...)
 	vsnprintf(string, sizeof(string) - 1, fmt, argptr);
 	string[sizeof(string) - 1] = '\0';
 	va_end(argptr);
-	
+
 	SERVER_PRINT(string);
 }
 
@@ -112,7 +112,7 @@ void BinLog_LogParams(AMX *amx, cell *params)
 	}
 }
 
-static binlogfuncs_t logfuncs = 
+static binlogfuncs_t logfuncs =
 {
 	BinLog_LogNative,
 	BinLog_LogReturn,
@@ -128,25 +128,25 @@ int load_amxscript(AMX *amx, void **program, const char *filename, char error[64
 	if (!*program)
 	{
 		CAmxxReader reader(filename, PAWN_CELL_SIZE / 8);
-		
+
 		if (reader.GetStatus() == CAmxxReader::Err_None)
 		{
 			bufSize = reader.GetBufferSize();
-			
+
 			if (bufSize != 0)
 			{
 				*program = (void*) (new char[bufSize]);
-				
+
 				if (!*program)
 				{
 					strcpy(error, "Failed to allocate memory");
 					return (amx->error = AMX_ERR_MEMORY);
 				}
-				
+
 				reader.GetSection(*program);
 			}
 		}
-	
+
 		switch (reader.GetStatus())
 		{
 			case CAmxxReader::Err_None:
@@ -187,7 +187,7 @@ int load_amxscript(AMX *amx, void **program, const char *filename, char error[64
 	AMX_HEADER *hdr = (AMX_HEADER*)*program;
 	uint16_t magic = hdr->magic;
 	amx_Align16(&magic);
-	
+
 	if (magic != AMX_MAGIC)
 	{
 		strcpy(error, "Invalid Plugin");
@@ -209,10 +209,10 @@ int load_amxscript(AMX *amx, void **program, const char *filename, char error[64
 		else if ((hdr->flags & AMX_FLAG_DEBUG) != 0)
 		{
 			will_be_debugged = true;
-			
+
 			char *addr = (char *)hdr + hdr->size;
 			pDbg = new tagAMX_DBG;
-			
+
 			memset(pDbg, 0, sizeof(AMX_DBG));
 
 			int err = dbg_LoadInfo(pDbg, addr);
@@ -249,7 +249,7 @@ int load_amxscript(AMX *amx, void **program, const char *filename, char error[64
 			dbg_FreeInfo(pDbg);
 			delete pDbg;
 		}
-		
+
 		sprintf(error, "Load error %d (invalid file format or version)", err);
 		return (amx->error = AMX_ERR_INIT);
 	}
@@ -283,17 +283,17 @@ int load_amxscript(AMX *amx, void **program, const char *filename, char error[64
 	{
 		char *np = new char[amx->code_size];
 		char *rt = new char[amx->reloc_size];
-		
+
 		if (!np || (!rt && amx->reloc_size > 0))
 		{
 			delete[] np;
 			delete[] rt;
 			strcpy(error, "Failed to initialize JIT'd plugin");
-			
+
 			return (amx->error = AMX_ERR_INIT);
 		}
-	
-		if ((err = amx_InitJIT(amx, (void *)rt, (void *)np)) == AMX_ERR_NONE) 
+
+		if ((err = amx_InitJIT(amx, (void *)rt, (void *)np)) == AMX_ERR_NONE)
 		{
 			//amx->base = (unsigned char FAR *)realloc(np, amx->code_size);
 #if defined(_WIN32)
@@ -308,15 +308,15 @@ int load_amxscript(AMX *amx, void **program, const char *filename, char error[64
 #endif
 			if (amx->base)
 				memcpy(amx->base, np, amx->code_size);
-			
+
 			delete [] np;
 			delete [] rt;
-			
+
 			char *prg = (char *)(*program);
-			
+
 			delete [] prg;
 			(*program) = amx->base;
-			
+
 			if (*program == 0)
 			{
 				strcpy(error, "Failed to allocate memory");
@@ -325,9 +325,9 @@ int load_amxscript(AMX *amx, void **program, const char *filename, char error[64
 		} else {
 			delete[] np;
 			delete[] rt;
-			
+
 			sprintf(error, "Failed to initialize plugin (%d)", err);
-			
+
 			return (amx->error = AMX_ERR_INIT_JIT);
 		}
 	}
@@ -342,7 +342,7 @@ int load_amxscript(AMX *amx, void **program, const char *filename, char error[64
 	if (g_plugins.m_Finalized)
 	{
 		amx_Register(amx, g_plugins.pNatives, -1);
-		
+
 		if (CheckModules(amx, error))
 		{
 			if (amx_Register(amx, core_Natives, -1) != AMX_ERR_NONE)
@@ -372,7 +372,7 @@ const char *StrCaseStr(const char *as, const char *bs)
 	{
 		a[i] = tolower(as[i]);
 	}
-	
+
 	a[len] = 0;
 
 	len = strlen(bs);
@@ -384,7 +384,7 @@ const char *StrCaseStr(const char *as, const char *bs)
 	{
 		b[i] = tolower(bs[i]);
 	}
-	
+
 	b[len] = 0;
 
 	return strstr(a, b);
@@ -397,14 +397,14 @@ int CheckModules(AMX *amx, char error[128])
 	char buffer[64];
 	LibType expect;
 	bool found;
-	
+
 	Handler *pHandler = (Handler *)amx->userdata[UD_HANDLER];
 
 	/** decode old style plugins */
 	for (int i = 0; i < numLibraries; i++)
 	{
 		amx_GetLibrary(amx, i, buffer, sizeof(buffer) - 1);
-		
+
 		if (stricmp(buffer, "float") == 0)
 			continue;
 
@@ -429,8 +429,8 @@ int CheckModules(AMX *amx, char error[128])
 					++a;
 					continue;
 				}
-				if (cm.getInfoNew() && 
-					cm.getInfoNew()->logtag && 
+				if (cm.getInfoNew() &&
+					cm.getInfoNew()->logtag &&
 					!strcasecmp(cm.getInfoNew()->logtag, buffer))
 				{
 					found = true;
@@ -439,7 +439,7 @@ int CheckModules(AMX *amx, char error[128])
 				++a;
 			}
 		}
-			
+
 		if (!found)
 		{
 			if (expect == LibType_Library)
@@ -453,7 +453,7 @@ int CheckModules(AMX *amx, char error[128])
 				}
 			}
 		}
-		
+
 		if (!found)
 		{
 			const char *type = "Module/Library";
@@ -542,7 +542,7 @@ int set_amxnatives(AMX* amx, char error[128])
 
 	Debugger *pd;
 	pd = DisableDebugHandler(amx);
-	
+
 	if (amx_FindPublic(amx, "plugin_natives", &idx) == AMX_ERR_NONE)
 	{
 		if ((err = amx_Exec(amx, &retval, idx)) != AMX_ERR_NONE)
@@ -560,7 +560,7 @@ int set_amxnatives(AMX* amx, char error[128])
 }
 
 int unload_amxscript(AMX* amx, void** program)
-{	
+{
 #if defined JIT
 	int flags = amx->flags;
 	long code_size = amx->code_size;
@@ -569,7 +569,7 @@ int unload_amxscript(AMX* amx, void** program)
 	Debugger *pDebugger = (Debugger *)amx->userdata[UD_DEBUGGER];
 	if (pDebugger)
 		delete pDebugger;
-	
+
 	Handler *pHandler = (Handler *)amx->userdata[UD_HANDLER];
 	if (pHandler)
 		delete pHandler;
@@ -577,14 +577,14 @@ int unload_amxscript(AMX* amx, void** program)
 	optimizer_s *opt = (optimizer_s *)amx->usertags[UT_OPTIMIZER];
 	if (opt)
 		delete opt;
-	
+
 	CList<CScript, AMX*>::iterator a = g_loadedscripts.find(amx);
-	
+
 	if (a)
 		a.remove();
-	
+
 	char *prg = (char *)*program;
-	
+
 	if (!prg)
 		return AMX_ERR_NONE;
 
@@ -607,7 +607,7 @@ int unload_amxscript(AMX* amx, void** program)
 #endif
 	}
 #elif defined WIN32
-	
+
 	if ((flags & AMX_FLAG_JITC) != AMX_FLAG_JITC)
 	{
 		delete [] prg;
@@ -629,18 +629,18 @@ int unload_amxscript(AMX* amx, void** program)
 AMX* get_amxscript(int id, void** code, const char** filename)
 {
 	CList<CScript, AMX*>::iterator a = g_loadedscripts.begin();
-	
+
 	while (a && id--)
 		++a;
-	
+
 	if (a)
 	{
 		*filename = (*a).getName();
 		*code = (*a).getCode();
-		
+
 		return (*a).getAMX();
 	}
-	
+
 	return 0;
 }
 
@@ -648,7 +648,7 @@ const char* GetFileName(AMX *amx)
 {
 	const char *filename = "";
 	CPluginMngr::CPlugin *pl = g_plugins.findPluginFast(amx);
-		
+
 	if (pl)
 	{
 		filename = pl->getName();
@@ -807,8 +807,8 @@ bool LoadModule(const char *shortname, PLUG_LOADTIME now, bool simplify, bool no
 	char path[PLATFORM_MAX_PATH];
 
 	build_pathname_r(
-		pathString, 
-		sizeof(pathString), 
+		pathString,
+		sizeof(pathString),
 		"%s/%s",
 		get_localinfo("amxx_modulesdir", "addons/amxmodx/modules"),
 		shortname);
@@ -884,8 +884,8 @@ bool LoadModule(const char *shortname, PLUG_LOADTIME now, bool simplify, bool no
 	if (cc->IsMetamod())
 	{
 		char *mmpathname = build_pathname_addons(
-							"%s/%s", 
-							get_localinfo("amxx_modulesdir", "addons/amxmodx/modules"), 
+							"%s/%s",
+							get_localinfo("amxx_modulesdir", "addons/amxmodx/modules"),
 							shortname);
 		ConvertModuleName(mmpathname, path);
 		cc->attachMetamod(path, now);
@@ -898,7 +898,7 @@ bool LoadModule(const char *shortname, PLUG_LOADTIME now, bool simplify, bool no
 		switch (cc->getStatusValue())
 		{
 		case MODULE_FUNCNOTPRESENT:
-			report_error(1, "[AMXX] Module requested a not existing function (file \"%s\")%s%s%s", cc->getFilename(), cc->getMissingFunc() ? " (func \"" : "", 
+			report_error(1, "[AMXX] Module requested a not existing function (file \"%s\")%s%s%s", cc->getFilename(), cc->getMissingFunc() ? " (func \"" : "",
 				cc->getMissingFunc() ? cc->getMissingFunc() : "", cc->getMissingFunc() ? "\")" : "");
 			break;
 		case MODULE_INTERROR:
@@ -947,17 +947,17 @@ int loadModules(const char* filename, PLUG_LOADTIME now)
 		{
 			simplify = false;
 			strncopy(line, &buffer[1], sizeof(line));
-		} 
-		else 
+		}
+		else
 		{
 			strncopy(line, buffer, sizeof(line));
 		}
 
 		*moduleName = '\0';
-		
+
 		if (sscanf(line, "%s", moduleName) == EOF)
 			continue;
-		
+
 		if (LoadModule(moduleName, now, simplify))
 			loaded++;
 	}
@@ -988,7 +988,7 @@ void detachReloadModules()
 		{
 			(*a).detachModule();
 			a.remove();
-			
+
 			continue;
 		}
 		++a;
@@ -998,7 +998,7 @@ void detachReloadModules()
 const char* strip_name(const char* a)
 {
 	const char* ret = a;
-	
+
 	while (*a)
 	{
 		if (*a == '/' || *a == '\\')
@@ -1008,7 +1008,7 @@ const char* strip_name(const char* a)
 		}
 		++a;
 	}
-	
+
 	return ret;
 }
 
@@ -1017,7 +1017,7 @@ int countModules(CountModulesMode mode)
 {
 	CList<CModule, const char *>::iterator iter;
 	int num;
-	
+
 	switch (mode)
 	{
 		case CountModules_All:
@@ -1025,29 +1025,29 @@ int countModules(CountModulesMode mode)
 		case CountModules_Running:
 			iter = g_modules.begin();
 			num = 0;
-			
+
 			while (iter)
 			{
 				if ((*iter).getStatusValue() == MODULE_LOADED)
 					++num;
 				++iter;
 			}
-			
+
 			return num;
 		case CountModules_Stopped:
 			iter = g_modules.begin();
 			num	= 0;
-			
+
 			while (iter)
 			{
 				if ((*iter).getStatusValue() != MODULE_LOADED)
 					++num;
 				++iter;
 			}
-			
+
 			return num;
 	}
-	
+
 	return 0;
 }
 
@@ -1055,7 +1055,7 @@ int countModules(CountModulesMode mode)
 void modules_callPluginsLoaded()
 {
 	CList<CModule, const char *>::iterator iter = g_modules.begin();
-	
+
 	while (iter)
 	{
 		(*iter).CallPluginsLoaded();
@@ -1093,7 +1093,7 @@ int MNF_AddNatives(AMX_NATIVE_INFO* natives)
 		return FALSE;				// may only be called from attach
 
 	g_CurrentlyCalledModule->m_Natives.append(natives);
-	
+
 	return TRUE;
 }
 
@@ -1115,26 +1115,26 @@ const char *MNF_GetModname(void)
 AMX *MNF_GetAmxScript(int id)
 {
 	CList<CScript, AMX*>::iterator iter = g_loadedscripts.begin();
-	
+
 	while (iter && id--)
 		++iter;
 
 	if (iter == 0)
 		return NULL;
-	
+
 	return (*iter).getAMX();
 }
 
 const char *MNF_GetAmxScriptName(int id)
 {
 	CList<CScript, AMX*>::iterator iter = g_loadedscripts.begin();
-	
+
 	while (iter && id--)
 		++iter;
 
 	if (iter == 0)
 		return NULL;
-	
+
 	return (*iter).getName();
 }
 
@@ -1143,7 +1143,7 @@ int MNF_FindAmxScriptByName(const char *name)
 	CList<CScript, AMX*>::iterator iter = g_loadedscripts.begin();
 	bool found = false;
 	int i = 0;
-	
+
 	while (iter)
 	{
 		if (stricmp((*iter).getName(), name) == 0)
@@ -1154,10 +1154,10 @@ int MNF_FindAmxScriptByName(const char *name)
 		++iter;
 		++i;
 	}
-	
+
 	if (!found)
 		return -1;
-	
+
 	return i;
 }
 
@@ -1166,9 +1166,9 @@ int MNF_FindAmxScriptByAmx(const AMX *amx)
 	CList<CScript, AMX*>::iterator iter = g_loadedscripts.begin();
 	bool found = false;
 	int i = 0;
-	
+
 	while (iter)
-	
+
 	{
 		if (amx == (*iter).getAMX())
 		{
@@ -1178,10 +1178,10 @@ int MNF_FindAmxScriptByAmx(const AMX *amx)
 		++iter;
 		++i;
 	}
-	
+
 	if (!found)
 		return -1;
-	
+
 	return i;
 }
 
@@ -1189,10 +1189,10 @@ extern "C" char *MNF_GetAmxString(AMX *amx, cell amx_addr, int bufferId, int *pL
 {
 	int len;
 	char *retVal = get_amxstring(amx, amx_addr, bufferId, len);
-	
+
 	if (pLen)
 		*pLen = len;
-	
+
 	return retVal;
 }
 
@@ -1210,10 +1210,10 @@ extern "C" char *MNF_GetAmxStringNull(AMX *amx, cell amx_addr, int bufferId, int
 int MNF_GetAmxStringLen(const cell *ptr)
 {
 	register int c = 0;
-	
+
 	while (ptr[c])
 		++c;
-	
+
 	return c;
 }
 
@@ -1232,10 +1232,10 @@ char *MNF_FormatAmxString(AMX *amx, cell *params, int startParam, int *pLen)
 {
 	int len;
 	char *retVal = format_amxstring(amx, params, startParam, len);
-	
+
 	if (pLen)
 		*pLen = len;
-	
+
 	return retVal;
 }
 
@@ -1243,9 +1243,9 @@ int MNF_GetPlayerFlags(int id)
 {
 	if (id < 1 || id > gpGlobals->maxClients)
 		return 0;
-	
+
 	CPlayer *pPlayer = GET_PLAYER_POINTER_I(id);
-	
+
 	return (pPlayer->flags[0]);
 }
 
@@ -1258,9 +1258,9 @@ int MNF_IsPlayerValid(int id)
 {
 	if (id < 1 || id > gpGlobals->maxClients)
 		return 0;
-	
+
 	CPlayer *pPlayer = GET_PLAYER_POINTER_I(id);
-	
+
 	return (pPlayer->initialized) ? 1 : 0;
 }
 
@@ -1268,7 +1268,7 @@ const char * MNF_GetPlayerName(int id)
 {
 	if (id < 1 || id > gpGlobals->maxClients)
 		return NULL;
-	
+
 	return GET_PLAYER_POINTER_I(id)->name.chars();
 }
 
@@ -1294,7 +1294,7 @@ const char * MNF_GetPlayerIP(int id)
 {
 	if (id < 1 || id > gpGlobals->maxClients)
 		return NULL;
-	
+
 	return GET_PLAYER_POINTER_I(id)->ip.chars();
 }
 
@@ -1302,7 +1302,7 @@ int MNF_IsPlayerInGame(int id)
 {
 	if (id < 1 || id > gpGlobals->maxClients)
 		return 0;
-	
+
 	return GET_PLAYER_POINTER_I(id)->ingame ? 1 : 0;
 }
 
@@ -1310,7 +1310,7 @@ int MNF_IsPlayerBot(int id)
 {
 	if (id < 1 || id > gpGlobals->maxClients)
 		return 0;
-	
+
 	return GET_PLAYER_POINTER_I(id)->IsBot() ? 1 : 0;
 }
 
@@ -1318,7 +1318,7 @@ int MNF_IsPlayerAuthorized(int id)
 {
 	if (id < 1 || id > gpGlobals->maxClients)
 		return 0;
-	
+
 	return GET_PLAYER_POINTER_I(id)->authorized ? 1 : 0;
 }
 
@@ -1326,7 +1326,7 @@ float MNF_GetPlayerTime(int id)
 {
 	if (id < 1 || id > gpGlobals->maxClients)
 		return 0.0f;
-	
+
 	return GET_PLAYER_POINTER_I(id)->time;
 }
 
@@ -1334,7 +1334,7 @@ float MNF_GetPlayerPlayTime(int id)
 {
 	if (id < 1 || id > gpGlobals->maxClients)
 		return 0.0f;
-	
+
 	return GET_PLAYER_POINTER_I(id)->playtime;
 }
 
@@ -1342,7 +1342,7 @@ int MNF_GetPlayerCurweapon(int id)
 {
 	if (id < 1 || id > gpGlobals->maxClients)
 		return 0;
-	
+
 	return GET_PLAYER_POINTER_I(id)->current;
 }
 
@@ -1350,7 +1350,7 @@ int MNF_GetPlayerTeamID(int id)
 {
 	if (id < 1 || id > gpGlobals->maxClients)
 		return 0;
-	
+
 	return GET_PLAYER_POINTER_I(id)->teamId;
 }
 
@@ -1358,7 +1358,7 @@ int MNF_GetPlayerDeaths(int id)
 {
 	if (id < 1 || id > gpGlobals->maxClients)
 		return 0;
-	
+
 	return GET_PLAYER_POINTER_I(id)->deaths;
 }
 
@@ -1366,7 +1366,7 @@ int MNF_GetPlayerMenu(int id)
 {
 	if (id < 1 || id > gpGlobals->maxClients)
 		return 0;
-	
+
 	return GET_PLAYER_POINTER_I(id)->menu;
 }
 
@@ -1374,7 +1374,7 @@ int MNF_GetPlayerKeys(int id)
 {
 	if (id < 1 || id > gpGlobals->maxClients)
 		return 0;
-	
+
 	return GET_PLAYER_POINTER_I(id)->keys;
 }
 
@@ -1382,7 +1382,7 @@ int MNF_IsPlayerAlive(int id)
 {
 	if (id < 1 || id > gpGlobals->maxClients)
 		return 0;
-	
+
 	return GET_PLAYER_POINTER_I(id)->IsAlive() ? 1 : 0;
 }
 
@@ -1390,7 +1390,7 @@ float MNF_GetPlayerFrags(int id)
 {
 	if (id < 1 || id > gpGlobals->maxClients)
 		return 0.0f;
-	
+
 	return GET_PLAYER_POINTER_I(id)->pEdict->v.frags;
 }
 
@@ -1398,9 +1398,9 @@ int MNF_IsPlayerConnecting(int id)
 {
 	if (id < 1 || id > gpGlobals->maxClients)
 		return 0;
-	
+
 	CPlayer * pPlayer = GET_PLAYER_POINTER_I(id);
-	
+
 	return (!pPlayer->ingame && pPlayer->initialized && (GETPLAYERUSERID(pPlayer->pEdict) > 0)) ? 1 : 0;
 }
 
@@ -1408,7 +1408,7 @@ int MNF_IsPlayerHLTV(int id)
 {
 	if (id < 1 || id > gpGlobals->maxClients)
 		return 0;
-	
+
 	return (GET_PLAYER_POINTER_I(id)->pEdict->v.flags & FL_PROXY) ? 1 : 0;
 }
 
@@ -1416,7 +1416,7 @@ float MNF_GetPlayerArmor(int id)
 {
 	if (id < 1 || id > gpGlobals->maxClients)
 		return 0.0f;
-	
+
 	return (GET_PLAYER_POINTER_I(id)->pEdict->v.armorvalue);
 }
 
@@ -1424,7 +1424,7 @@ float MNF_GetPlayerHealth(int id)
 {
 	if (id < 1 || id > gpGlobals->maxClients)
 		return 0;
-	
+
 	return (GET_PLAYER_POINTER_I(id)->pEdict->v.health);
 }
 
@@ -1446,7 +1446,7 @@ void MNF_Log(const char *fmt, ...)
 	_vsnprintf(msg, sizeof(msg) - 1, fmt, arglst);
 	//vsprintf(msg, fmt, arglst);
 	va_end(arglst);
-	
+
 	AMXXLOG_Log("%s", msg);
 }
 
@@ -1461,7 +1461,7 @@ extern "C" void LogError(AMX *amx, int err, const char *fmt, ...)
 	char msg_buffer[2048];
 
 	msg_buffer[0] = '\0';
-	
+
 	if (fmt != NULL)
 	{
 		va_list ap;
@@ -1499,7 +1499,7 @@ extern "C" void LogError(AMX *amx, int err, const char *fmt, ...)
 
 				return;
 			}
-			
+
 			//give the user a first-chance at blocking the error from displaying
 			if (pHandler->HandleError(fmt ? msg_buffer : NULL) != 0)
 			{
@@ -1515,7 +1515,7 @@ extern "C" void LogError(AMX *amx, int err, const char *fmt, ...)
 		{
 			AMXXLOG_Error("%s", msg_buffer);
 		}
-		
+
 		Debugger::GenericMessage(amx, err);
 		if (err != AMX_ERR_EXIT)
 		{
@@ -1555,7 +1555,7 @@ edict_t* MNF_GetPlayerEdict(int id)
 {
 	if (id < 1 || id > gpGlobals->maxClients)
 		return NULL;
-	
+
 	return (GET_PLAYER_POINTER_I(id)->pEdict);
 }
 
@@ -1604,7 +1604,7 @@ inline bool operator ==(func_s &arg1, const char *desc)
 {
 	if (strcmp(arg1.desc, desc) == 0)
 		return true;
-	
+
 	return false;
 }
 
@@ -1885,11 +1885,11 @@ void *Module_ReqFnptr(const char *funcName)
 {
 	// code
 	// ^---- really? wow!
-	
+
 	g_LastRequestedFunc = funcName;
 
 	CList<func_s, const char *>::iterator iter;
-	
+
 	for (iter = g_functions.begin(); iter; ++iter)
 	{
 		if (strcmp(funcName, iter->desc) == 0)
@@ -1902,7 +1902,7 @@ void *Module_ReqFnptr(const char *funcName)
 Debugger *DisableDebugHandler(AMX *amx)
 {
 	Debugger *pd = static_cast<Debugger *>(amx->userdata[UD_DEBUGGER]);
-	
+
 	amx->userdata[UD_DEBUGGER] = NULL;
 	amx->flags &= ~(AMX_FLAG_DEBUG);
 	amx_SetDebugHook(amx, NULL);
@@ -1922,12 +1922,12 @@ void EnableDebugHandler(AMX *amx, Debugger *pd)
 #if !defined MEMORY_TEST && !defined WIN32
 void * operator new(size_t size)
 {
-	return (calloc(1, size)); 
+	return (calloc(1, size));
 }
 
 void * operator new[](size_t size)
 {
-	return (calloc(1, size)); 
+	return (calloc(1, size));
 }
 
 void operator delete(void * ptr)

--- a/amxmodx/modules.cpp
+++ b/amxmodx/modules.cpp
@@ -727,7 +727,7 @@ bool ConvertModuleName(const char *pathString, char *path)
 	/* run to filename instead of dir */
 	char *ptr = tmpname;
 	ptr = tmpname + len - 1;
-	while (ptr >= tmpname && *ptr != PATH_SEP_CHAR)
+	while (ptr >= tmpname && *ptr != PLATFORM_SEP_CHAR)
 		ptr--;
 	if (ptr >= tmpname)
 	{

--- a/amxmodx/modules.cpp
+++ b/amxmodx/modules.cpp
@@ -31,6 +31,7 @@
 #include "trie_natives.h"
 #include "CDataPack.h"
 #include "CGameConfigs.h"
+#include <amtl/os/am-path.h>
 
 CList<CModule, const char*> g_modules;
 CList<CScript, AMX*> g_loadedscripts;
@@ -671,76 +672,40 @@ void get_modname(char* buffer)
 	strcpy(buffer, g_mod_name.chars());
 }
 
-char* build_pathname(const char *fmt, ...)
+char *build_pathname(const char *fmt, ...)
 {
-	static char string[256];
-	int b;
-	int a = b = ke::SafeSprintf(string, sizeof(string), "%s%c", g_mod_name.chars(), PATH_SEP_CHAR);
+	static char string[PLATFORM_MAX_PATH];
+	auto len = ke::path::Format(string, sizeof(string), "%s/", g_mod_name.chars());
 
 	va_list argptr;
 	va_start(argptr, fmt);
-	a += vsnprintf (&string[a], 255 - a, fmt, argptr);
-	string[a] = 0;
+	ke::path::FormatVa(&string[len], sizeof(string) - len, fmt, argptr);
 	va_end(argptr);
-
-	char* path = &string[b];
-
-	while (*path) 
-	{
-		if (*path == ALT_SEP_CHAR)
-		{
-			*path = PATH_SEP_CHAR;
-		}
-		++path;
-	}
 
 	return string;
 }
 
 char *build_pathname_r(char *buffer, size_t maxlen, const char *fmt, ...)
 {
-	ke::SafeSprintf(buffer, maxlen, "%s%c", g_mod_name.chars(), PATH_SEP_CHAR);
-
-	size_t len = strlen(buffer);
-	char *ptr = buffer + len;
+	auto len = ke::path::Format(buffer, maxlen, "%s/", g_mod_name.chars());
 
 	va_list argptr;
 	va_start(argptr, fmt);
-	vsnprintf (ptr, maxlen-len, fmt, argptr);
+	ke::path::FormatVa(&buffer[len], maxlen - len, fmt, argptr);
 	va_end (argptr);
-
-	while (*ptr) 
-	{
-		if (*ptr == ALT_SEP_CHAR)
-		{
-			*ptr = PATH_SEP_CHAR;
-		}
-		++ptr;
-	}
 
 	return buffer;
 }
 
 // build pathname based on addons dir
-char* build_pathname_addons(const char *fmt, ...)
+char *build_pathname_addons(const char *fmt, ...)
 {
-	static char string[256];
+	static char string[PLATFORM_MAX_PATH];
 
 	va_list argptr;
 	va_start(argptr, fmt);
-	vsnprintf (string, 255, fmt, argptr);
+	ke::path::FormatVa(string, sizeof(string), fmt, argptr);
 	va_end(argptr);
-
-	char* path = string;
-
-	while (*path) 
-	{
-		if (*path == ALT_SEP_CHAR)
-		{
-			*path = PATH_SEP_CHAR;
-		}
-		++path;
-	}
 
 	return string;
 }
@@ -822,7 +787,7 @@ bool ConvertModuleName(const char *pathString, char *path)
 		*ptr = '\0';
 	}
 
-	size_t length = ke::SafeSprintf(path, PLATFORM_MAX_PATH, "%s%c%s_amxx", orig_path, PATH_SEP_CHAR, tmpname);
+	auto length = ke::path::Format(path, PLATFORM_MAX_PATH, "%s/%s_amxx", orig_path, tmpname);
 
 #if defined PLATFORM_LINUX
 # if defined AMD64 || PAWN_CELL_SIZE == 64

--- a/modules/hamsandwich/config_parser.cpp
+++ b/modules/hamsandwich/config_parser.cpp
@@ -242,7 +242,7 @@ int read_number(char *input)
 	char *end; /* Temporary pointer, needed for strtoul(). */
 
 	// if begins with 0x or 0X it's to be interpretted as hex
-	if (*input=='0' && 
+	if (*input=='0' &&
 		(*(input+1)=='x' || *(input+1)=='X'))
 	{
 		return strtoul(input,&end,16);

--- a/modules/hamsandwich/config_parser.cpp
+++ b/modules/hamsandwich/config_parser.cpp
@@ -307,7 +307,7 @@ int ReadConfig(void)
 {
 	char FileName[512];
 
-	MF_BuildPathnameR(FileName,sizeof(FileName)-1,"%s",get_localinfo("amxx_configsdir","addons/amxmodx/configs"));
+	MF_BuildPathnameR(FileName,sizeof(FileName),"%s",get_localinfo("amxx_configsdir","addons/amxmodx/configs"));
 
 	strncat(FileName,"/hamdata.ini",sizeof(FileName)-1);
 

--- a/modules/nvault/amxxapi.cpp
+++ b/modules/nvault/amxxapi.cpp
@@ -46,7 +46,7 @@ static cell nvault_open(AMX *amx, cell *params)
 	int len, id=-1;
 	char *name = MF_GetAmxString(amx, params[1], 0, &len);
 	char path[255], file[255];
-	MF_BuildPathnameR(path, sizeof(path)-1, "%s/vault", MF_GetLocalInfo("amxx_datadir", "addons/amxmodx/data"));
+	MF_BuildPathnameR(path, sizeof(path), "%s/vault", MF_GetLocalInfo("amxx_datadir", "addons/amxmodx/data"));
 	sprintf(file, "%s/%s.vault", path, name);
 	for (size_t i=0; i<g_Vaults.length(); i++)
 	{

--- a/modules/nvault/amxxapi.cpp
+++ b/modules/nvault/amxxapi.cpp
@@ -52,7 +52,7 @@ static cell nvault_open(AMX *amx, cell *params)
 	{
 		if (!g_Vaults[i])
 			continue;
-		if (strcmp(g_Vaults.at(i)->GetFilename(), file) == 0) 
+		if (strcmp(g_Vaults.at(i)->GetFilename(), file) == 0)
 			return i;
 	}
 	NVault *v = (NVault *)g_VaultMngr.OpenVault(file);

--- a/modules/sqlite/basic_sql.cpp
+++ b/modules/sqlite/basic_sql.cpp
@@ -59,13 +59,13 @@ static cell AMX_NATIVE_CALL SQL_MakeDbTuple(AMX *amx, cell *params)
 	char path[255];
 	FILE *fp;
 
-	MF_BuildPathnameR(path, sizeof(path)-1, "%s", db);
+	MF_BuildPathnameR(path, sizeof(path), "%s", db);
 	if ((fp=fopen(path, "rb")))
 	{
 		fclose(fp);
 		sql->db = strdup(path);
 	} else {
-		MF_BuildPathnameR(path, sizeof(path)-1, "%s/sqlite3/%s.sq3",
+		MF_BuildPathnameR(path, sizeof(path), "%s/sqlite3/%s.sq3",
 			MF_GetLocalInfo("amxx_datadir", "addons/amxmodx/data"),
 			db);
 		sql->db = strdup(path);

--- a/modules/sqlite/basic_sql.cpp
+++ b/modules/sqlite/basic_sql.cpp
@@ -601,7 +601,7 @@ static cell AMX_NATIVE_CALL SQL_SetCharset(AMX *amx, cell *params)
 	return 0;
 }
 
-AMX_NATIVE_INFO g_BaseSqlNatives[] = 
+AMX_NATIVE_INFO g_BaseSqlNatives[] =
 {
 	{"SQL_MakeDbTuple",		SQL_MakeDbTuple},
 	{"SQL_FreeHandle",		SQL_FreeHandle},
@@ -630,4 +630,3 @@ AMX_NATIVE_INFO g_BaseSqlNatives[] =
 
 	{NULL,					NULL},
 };
-

--- a/modules/sqlite/module.cpp
+++ b/modules/sqlite/module.cpp
@@ -17,7 +17,7 @@
 
 static int g_ident = 0;
 
-SqlFunctions g_SqliteFuncs = 
+SqlFunctions g_SqliteFuncs =
 {
 	&g_Sqlite,
 	SetMysqlAffinity,
@@ -96,4 +96,3 @@ void OnPluginsUnloaded()
 extern "C" void __cxa_pure_virtual(void)
 {
 }
-

--- a/modules/sqlite/module.cpp
+++ b/modules/sqlite/module.cpp
@@ -69,7 +69,7 @@ void OnAmxxAttach()
 	MF_OverrideNatives(g_OldCompatNatives, MODULE_NAME);
 
 	char path[255];
-	MF_BuildPathnameR(path, sizeof(path)-1, "%s/sqlite3", MF_GetLocalInfo("amxx_datadir", "addons/amxmodx/data"));
+	MF_BuildPathnameR(path, sizeof(path), "%s/sqlite3", MF_GetLocalInfo("amxx_datadir", "addons/amxmodx/data"));
 	if (!DirExists(path))
 	{
 		mkdir(path

--- a/modules/sqlite/oldcompat_sql.cpp
+++ b/modules/sqlite/oldcompat_sql.cpp
@@ -73,14 +73,14 @@ static cell AMX_NATIVE_CALL dbi_connect(AMX *amx, cell *params)
 	int err;
 	char error[512];
 	/** if there is an older database, read there instead of the new path */
-	MF_BuildPathnameR(path, sizeof(path)-1, "%s", info.database);
+	MF_BuildPathnameR(path, sizeof(path), "%s", info.database);
 	FILE *fp = fopen(path, "rb");
 	if (fp)
 	{
 		fclose(fp);
 		info.database = path;
 	} else {
-		MF_BuildPathnameR(path, sizeof(path)-1, "%s/sqlite3/%s.sq3",
+		MF_BuildPathnameR(path, sizeof(path), "%s/sqlite3/%s.sq3",
 			MF_GetLocalInfo("amxx_datadir", "addons/amxmodx/data"),
 			info.database);
 		info.database = path;

--- a/modules/sqlite/oldcompat_sql.cpp
+++ b/modules/sqlite/oldcompat_sql.cpp
@@ -439,14 +439,14 @@ static cell AMX_NATIVE_CALL dbi_field_name(AMX *amx, cell *params)
 	return 1;
 }
 
-AMX_NATIVE_INFO g_OldCompatNatives[] = 
+AMX_NATIVE_INFO g_OldCompatNatives[] =
 {
 	{ "dbi_connect",		dbi_connect },
 	{ "dbi_query",			dbi_query },
 	{ "dbi_query2",			dbi_query2 },
-	{ "dbi_field",			dbi_field },	
-	{ "dbi_nextrow",		dbi_nextrow },	
-	{ "dbi_close",			dbi_close },	
+	{ "dbi_field",			dbi_field },
+	{ "dbi_nextrow",		dbi_nextrow },
+	{ "dbi_close",			dbi_close },
 	{ "dbi_error",			dbi_error },
 	{ "dbi_type",			dbi_type },
 	{ "dbi_free_result",	dbi_free_result },


### PR DESCRIPTION
This PR makes ```build_pathname*``` functions use AMTL's ```ke::path::Format``` and ```ke::path::FormatVa```. Code is shorter and cleaner inside those functions now.

Also editor removed white spaces in edited files, hope you don't mind that 😇, but if you do, i'll create commit without those unrelated changes.