### PR TITLE
Add new xs stocks

### DIFF
--- a/plugins/include/xs.inc
+++ b/plugins/include/xs.inc
@@ -369,6 +369,24 @@ stock xs_vec_sub(const Float:in1[], const Float:in2[], Float:out[])
 	out[2] = in1[2] - in2[2];
 }
 
+// Adds the second vector scaled by a scalar to the first
+// tested
+stock xs_vec_add_scaled(const Float:in1[], const Float:in2[], Float:scalar, Float:out[])
+{
+	out[0] = in1[0] + in2[0] * scalar;
+	out[1] = in1[1] + in2[1] * scalar;
+	out[2] = in1[2] + in2[2] * scalar;
+}
+
+// Subtracts the second vector scaled by a scalar to the first
+// tested
+stock xs_vec_sub_scaled(const Float:in1[], const Float:in2[], Float:scalar, Float:out[])
+{
+	out[0] = in1[0] - in2[0] * scalar;
+	out[1] = in1[1] - in2[1] * scalar;
+	out[2] = in1[2] - in2[2] * scalar;
+}
+
 // Are vectors equal?
 // untested, but should work
 stock bool:xs_vec_equal(const Float:vec1[], const Float:vec2[])
@@ -407,6 +425,30 @@ stock xs_vec_div_scalar(const Float:vec[], Float:scalar, Float:out[])
 stock Float:xs_vec_len(const Float:vec[])
 {
 	return xs_sqrt(vec[0]*vec[0] + vec[1]*vec[1] + vec[2]*vec[2]);
+}
+
+// Compute 2D vector length
+// tested
+stock Float:xs_vec_len_2d(const Float:vec[])
+{
+	return xs_sqrt(vec[0]*vec[0] + vec[1]*vec[1]);
+}
+
+// Compute distance between two vectors
+// tested
+stock Float:xs_vec_distance(const Float:vec1[], const Float:vec2[])
+{
+	return xs_sqrt((vec1[0]-vec2[0]) * (vec1[0]-vec2[0]) +
+	               (vec1[1]-vec2[1]) * (vec1[1]-vec2[1]) +
+	               (vec1[2]-vec2[2]) * (vec1[2]-vec2[2]));
+}
+
+// Compute distance between two 2D vectors
+// tested
+stock Float:xs_vec_distance_2d(const Float:vec1[], const Float:vec2[])
+{
+	return xs_sqrt((vec1[0]-vec2[0]) * (vec1[0]-vec2[0]) +
+	               (vec1[1]-vec2[1]) * (vec1[1]-vec2[1]));
 }
 
 // Normalize vec


### PR DESCRIPTION
```xs_vec_len_2d``` returns the length of a 2D vector

```xs_vec_distance``` returns the distance between two vectors
```xs_vec_distance_2d``` returns the distance between two 2D vectors

```xs_vec_add_scaled``` and ```xs_vec_sub_scaled``` do two operations
in one for convenience and performance. They add/subtract a vector
scaled by a scalar to another vector. Very useful when working with
unit vectors.

Slightly tested, although everything should be correct.

```C
new Float:v1[3], Float:v2[3];

xs_vec_set(v1, 0.0, 0.0, 0.0);
xs_vec_set(v2, 0.0, 1.0, 0.0);

// Test add/sub
xs_vec_add_scaled(v1, v2, 5.0, v1);
server_print("1: %f %f %f", v1[0], v1[1], v1[2]);

xs_vec_sub_scaled(v1, v2, 5.0, v1);
server_print("2: %f %f %f", v1[0], v1[1], v1[2]);

// Test len/distance
xs_vec_set(v2, 1.0, 2.0, 3.0);

server_print("3: %f", xs_vec_len_2d(v2));
server_print("4: %f", xs_vec_distance(v2, v1));
server_print("5: %f", xs_vec_distance_2d(v2, v1));

```

Server output
```
1: 0.000000 5.000000 0.000000
2: 0.000000 0.000000 0.000000
3: 2.236068
4: 3.741657
5: 2.236068
```

Rationale for add_scaled/sub_scaled stocks
```C
// Pos is some position, fwd a unit vector pointing forward
new Float:pos[3], Float:fwd[3];

// To advance 5 units you while conserving fwd
// you needed the following
new Float:offset[3];
xs_vec_mul_scalar(fwd, 5.0, offset);
xs_vec_add(pos, fwd, pos);

// Instead you can do in less lines and better performance
xs_vec_add_scaled(pos, fwd, 5.0, pos);
```