### PR TITLE
Fix inc/dec operators not returning an iEXPRESSION

### DIFF
--- a/compiler/libpc300/sc1.c
+++ b/compiler/libpc300/sc1.c
@@ -5334,7 +5334,7 @@ static void doreturn(void)
     /* "return <value>" */
     if ((rettype & uRETNONE)!=0)
       error(78);                        /* mix "return;" and "return value;" */
-    ident=doexpr(TRUE,FALSE,TRUE,TRUE,&tag,&sym,TRUE);
+    ident=doexpr(TRUE,FALSE,TRUE,FALSE,&tag,&sym,TRUE);
     needtoken(tTERM);
     if (ident == iARRAY && sym == NULL) {
       /* returning a literal string is not supported (it must be a variable) */
@@ -5495,7 +5495,7 @@ static void doexit(void)
   int tag=0;
 
   if (matchtoken(tTERM)==0){
-    doexpr(TRUE,FALSE,FALSE,TRUE,&tag,NULL,TRUE);
+    doexpr(TRUE,FALSE,FALSE,FALSE,&tag,NULL,TRUE);
     needtoken(tTERM);
   } else {
     ldconst(0,sPRI);
@@ -5511,7 +5511,7 @@ static void dosleep(void)
   int tag=0;
 
   if (matchtoken(tTERM)==0){
-    doexpr(TRUE,FALSE,FALSE,TRUE,&tag,NULL,TRUE);
+    doexpr(TRUE,FALSE,FALSE, FALSE,&tag,NULL,TRUE);
     needtoken(tTERM);
   } else {
     ldconst(0,sPRI);

--- a/compiler/libpc300/sc3.c
+++ b/compiler/libpc300/sc3.c
@@ -1160,6 +1160,7 @@ static int hier2(value *lval)
     if (!check_userop(user_inc,lval->tag,0,1,lval,&lval->tag))
       inc(lval);                /* increase variable first */
     rvalue(lval);               /* and read the result into PRI */
+    lval->ident = iEXPRESSION;
     sideeffect=TRUE;
     return FALSE;               /* result is no longer lvalue */
   case tDEC:                    /* --lval */
@@ -1171,6 +1172,7 @@ static int hier2(value *lval)
     if (!check_userop(user_dec,lval->tag,0,1,lval,&lval->tag))
       dec(lval);                /* decrease variable first */
     rvalue(lval);               /* and read the result into PRI */
+    lval->ident = iEXPRESSION;
     sideeffect=TRUE;
     return FALSE;               /* result is no longer lvalue */
   case '~':                     /* ~ (one's complement) */
@@ -1379,6 +1381,7 @@ static int hier2(value *lval)
           inc(lval);            /* increase variable afterwards */
         if (saveresult)
           popreg(sPRI);         /* restore PRI (result of rvalue()) */
+        lval->ident = iEXPRESSION;
         sideeffect=TRUE;
         return FALSE;           /* result is no longer lvalue */
       case tDEC:                /* lval-- */
@@ -1397,6 +1400,7 @@ static int hier2(value *lval)
           dec(lval);            /* decrease variable afterwards */
         if (saveresult)
           popreg(sPRI);         /* restore PRI (result of rvalue()) */
+        lval->ident = iEXPRESSION;
         sideeffect=TRUE;
         return FALSE;
       case tCHAR:               /* char (compute required # of cells */


### PR DESCRIPTION
Similar to https://github.com/alliedmodders/sourcepawn/pull/108.

### Code example
```PAWN
function()
{
    new someInt[MAX_PLAYERS + 1] = {123, ...};
    new client;

    server_print("%d", ++someInt[client]);
    server_print("%d", someInt[client]++);
    server_print("%d", someInt[client]--);
    server_print("%d", --someInt[client]);
}
```

### Actual result
```
82
82
1694498816
20992
```

### Expected result
```
124
124
125
123
```
___
Asking you @dvander because even though it works, code is not totally the same as SM, so just in case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alliedmodders/amxmodx/429)
<!-- Reviewable:end -->
