### PR TITLE
Allow value be empty in lang files

### DIFF
--- a/amxmodx/CLang.cpp
+++ b/amxmodx/CLang.cpp
@@ -395,9 +395,6 @@ bool CLangMngr::ReadINI_KeyValue(const char *key, const char *value, bool invali
 
 		if (colons_token || equal_token)
 		{
-			if(equal_token && !value) // Support empty value
-				value = "";
-
 			int iKey = GetKeyEntry(key);
 
 			if (iKey == -1)
@@ -407,7 +404,10 @@ bool CLangMngr::ReadINI_KeyValue(const char *key, const char *value, bool invali
 
 			if (equal_token)
 			{
-				strncopy(Data.valueBuffer, value, sizeof(Data.valueBuffer));
+				if(value == nullptr) // Support empty value
+					Data.valueBuffer[0] = '\0'; 
+				else
+					strncopy(Data.valueBuffer, value, sizeof(Data.valueBuffer));
 
 				reparse_newlines_and_color(Data.valueBuffer);
 

--- a/amxmodx/CLang.cpp
+++ b/amxmodx/CLang.cpp
@@ -393,8 +393,11 @@ bool CLangMngr::ReadINI_KeyValue(const char *key, const char *value, bool invali
 	{
 		Data.lastKey = key;
 
-		if (colons_token || (equal_token && value))
+		if (colons_token || equal_token)
 		{
+			if(equal_token && !value) // Support empty value
+				value = "";
+
 			int iKey = GetKeyEntry(key);
 
 			if (iKey == -1)


### PR DESCRIPTION
Prior 1.8.3 amxmodx was able to parse lang line with empty value like this
```
LANG_NAME = 
```
I have a few plugins that don't work correctly because amxmodx 1.8.3 consider  lang lines with empty value invalid. This commit should fix backward compatibility.