### PR TITLE
Fix #427, AMTL Code porting

### DIFF
--- a/amxmodx/CEvent.cpp
+++ b/amxmodx/CEvent.cpp
@@ -459,7 +459,7 @@ void EventsMngr::executeEvents()
 	m_ParseFun = nullptr;
 
 	auto lastSize = parseFun->length();
-	for(auto i = 0; i < lastSize; i++)
+	for(auto i = 0u; i < lastSize; i++)
 	{
 		auto &event = parseFun->at(i);
 

--- a/amxmodx/CEvent.cpp
+++ b/amxmodx/CEvent.cpp
@@ -458,8 +458,10 @@ void EventsMngr::executeEvents()
 	auto parseFun = m_ParseFun;
 	m_ParseFun = nullptr;
 
-	for (auto &event : *parseFun)
+	for(auto i = parseFun->length() - 1; i != 0; i--)
 	{
+		auto &event = parseFun->at(i);
+
 		if (event->m_Done) 
 		{
 			event->m_Done = false;

--- a/amxmodx/CEvent.cpp
+++ b/amxmodx/CEvent.cpp
@@ -458,7 +458,8 @@ void EventsMngr::executeEvents()
 	auto parseFun = m_ParseFun;
 	m_ParseFun = nullptr;
 
-	for(auto i = parseFun->length() - 1; i != 0; i--)
+	auto lastSize = parseFun->length();
+	for(auto i = 0; i < lastSize; i++)
 	{
 		auto &event = parseFun->at(i);
 

--- a/amxmodx/CTask.cpp
+++ b/amxmodx/CTask.cpp
@@ -270,7 +270,7 @@ bool CTaskMngr::taskExists(int iId, AMX *pAmx)
 void CTaskMngr::startFrame()
 {
 	auto lastSize = m_Tasks.length();
-	for(auto i = 0; i < lastSize; i++)
+	for(auto i = 0u; i < lastSize; i++)
 	{
 		auto &task = m_Tasks[i];
 

--- a/amxmodx/CTask.cpp
+++ b/amxmodx/CTask.cpp
@@ -269,7 +269,8 @@ bool CTaskMngr::taskExists(int iId, AMX *pAmx)
 
 void CTaskMngr::startFrame()
 {
-	for(auto i = m_Tasks.length() - 1; i != 0; i--)
+	auto lastSize = m_Tasks.length();
+	for(auto i = 0; i < lastSize; i++)
 	{
 		auto &task = m_Tasks[i];
 

--- a/amxmodx/CTask.cpp
+++ b/amxmodx/CTask.cpp
@@ -269,8 +269,10 @@ bool CTaskMngr::taskExists(int iId, AMX *pAmx)
 
 void CTaskMngr::startFrame()
 {
-	for (auto &task : m_Tasks)
+	for(auto i = m_Tasks.length() - 1; i != 0; i--)
 	{
+		auto &task = m_Tasks[i];
+
 		if (task->isFree())
 			continue;
 		task->executeIfRequired(*m_pTmr_CurrentTime, *m_pTmr_TimeLimit, *m_pTmr_TimeLeft);


### PR DESCRIPTION
# TODO:

- [x] Fix crash in `CTaskMngr::startFrame()`
- [x] Fix crash in `EventsMngr::executeEvents()`
- [x] ~Check other cases?~ Checked, I didn't find something suspicious

### Explanation:
`CTaskMngr::startFrame()` iterates through `m_Tasks` vector and executes forwards if necessary, but forwards can also create new tasks, same goes for `EventsMngr::executeEvents()`. Everything will be fine before reallocation occurs, but if address changed then we will have crash (or more precisely undefined behavior). 
[Comment](https://github.com/alliedmodders/amtl/blob/c91e8560fb00984465a1a916172123b80a76dd04/amtl/am-vector.h#L202-#L203)  inside am-vector.h