### PR TITLE
Fix a engclient_cmd and amxclient_cmd buffer issue

### DIFF
--- a/amxmodx/util.cpp
+++ b/amxmodx/util.cpp
@@ -476,9 +476,10 @@ unsigned int UTIL_ReplaceAll(char *subject, size_t maxlength, const char *search
 	return total;
 }
 
-template unsigned int strncopy<char, char>(char *, const char *src, size_t count);
-template unsigned int strncopy<cell, char>(cell *, const char *src, size_t count);
-template unsigned int strncopy<cell, cell>(cell *, const cell *src, size_t count);
+template unsigned int strncopy<char, char>(char *, const char *, size_t);
+template unsigned int strncopy<char, cell>(char *, const cell *, size_t);
+template unsigned int strncopy<cell, char>(cell *, const char *, size_t);
+template unsigned int strncopy<cell, cell>(cell *, const cell *, size_t);
 
 template <typename D, typename S>
 unsigned int strncopy(D *dest, const S *src, size_t count)


### PR DESCRIPTION
Related to 9c191949d80eb029431cdacefac59e70f7f80fe7.
Reported PartialCloning here: https://forums.alliedmods.net/showthread.php?t=296510.

This fixes a common static buffer issue where the original content is overwritten. It happens when a native relying on the static buffers calls a plugin callback, and inside that callback others natives relying on those static buffers are used as well.

Proposed fix is to copy the retrieved strings in order to not rely on the static buffers.
Since this is not a native called often, the use of AString should be fine.

.
