### PR TITLE
Fix temporary ban flags, add lang keys

### DIFF
--- a/plugins/admincmd.sma
+++ b/plugins/admincmd.sma
@@ -232,12 +232,12 @@ public cmdUnban(id, level, cid)
 
 	get_user_authid(id, authid, charsmax(authid))
 
-	if( ~get_user_flags(id) & ( ADMIN_BAN | ADMIN_RCON ) )
+	if( !(get_user_flags(id) & ( ADMIN_BAN | ADMIN_RCON )) )
 	{
 		new storedAdminAuth[32]
 		if( !TrieGetString(g_tempBans, arg, storedAdminAuth, charsmax(storedAdminAuth)) || !equal(storedAdminAuth, authid) )
 		{
-			console_print(id, "%L", id, "NO_ACC_COM"); // may be someone wants to create a new sentence and to translate it in all languages ?
+			console_print(id, "%L", id, "ADMIN_MUST_TEMPUNBAN");
 			return PLUGIN_HANDLED;
 		}
 	}
@@ -408,14 +408,15 @@ public cmdBan(id, level, cid)
 		return PLUGIN_HANDLED
 
 	new nNum = str_to_num(minutes)
+	new const tempBanMaxTime = get_pcvar_num(p_amx_tempban_maxtime);
 	if( nNum < 0 ) // since negative values result in permanent bans
 	{
 		nNum = 0;
 		minutes = "0";
 	}
-	if( ~get_user_flags(id) & ( ADMIN_BAN | ADMIN_RCON ) && (nNum <= 0 || nNum > get_pcvar_num(p_amx_tempban_maxtime)) )
+	if( !(get_user_flags(id) & ( ADMIN_BAN | ADMIN_RCON )) && (nNum <= 0 || nNum > tempBanMaxTime) )
 	{
-		console_print(id, "%L", id, "NO_ACC_COM"); // may be someone wants to create a new sentence and to translate it in all languages ?
+		console_print(id, "%L", id, "ADMIN_MUST_TEMPBAN", tempBanMaxTime);
 		return PLUGIN_HANDLED
 	}
 
@@ -494,14 +495,15 @@ public cmdBanIP(id, level, cid)
 		return PLUGIN_HANDLED
 
 	new nNum = str_to_num(minutes)
+	new const tempBanMaxTime = get_pcvar_num(p_amx_tempban_maxtime);
 	if( nNum < 0 ) // since negative values result in permanent bans
 	{
 		nNum = 0;
 		minutes = "0";
 	}
-	if( ~get_user_flags(id) & ( ADMIN_BAN | ADMIN_RCON ) && (nNum <= 0 || nNum > get_pcvar_num(p_amx_tempban_maxtime)) )
+	if( !(get_user_flags(id) & ( ADMIN_BAN | ADMIN_RCON )) && (nNum <= 0 || nNum > tempBanMaxTime) )
 	{
-		console_print(id, "%L", id, "NO_ACC_COM"); // may be someone wants to create a new sentence and to translate it in all languages ?
+		console_print(id, "%L", id, "ADMIN_MUST_TEMPBAN", tempBanMaxTime);
 		return PLUGIN_HANDLED
 	}
 	

--- a/plugins/lang/admincmd.txt
+++ b/plugins/lang/admincmd.txt
@@ -1,4 +1,4 @@
-[en]
+﻿[en]
 ADMIN_KICK_1 = ADMIN: kick %s
 ADMIN_KICK_2 = ADMIN %s: kick %s
 IP_REMOVED = Ip "%s" removed from ban list
@@ -72,6 +72,8 @@ CHANGED_NICK = Changed nick of %s to "%s"
 ADMIN_EXTEND_1 = ADMIN: extend map for %d minutes
 ADMIN_EXTEND_2 = ADMIN %s: extend map for %d minutes
 MAP_EXTENDED = Map "%s" has been extended for %d minutes
+ADMIN_MUST_TEMPBAN = You can only temporarily ban players, for up to %d minutes
+ADMIN_MUST_TEMPUNBAN = You can only unban players that you have recently banned
 
 [de]
 ADMIN_KICK_1 = ADMIN: kickt %s


### PR DESCRIPTION
There was a logic error the flag check expression. Instead of requiring an admin to have either BAN or RCON access, it required them to have both flags.
Also added a new lang key so it prints what actually is disallowing them to ban a player.

Related to: https://bugs.alliedmods.net/show_bug.cgi?id=3218