### PR TITLE
Fix amx_addban and amx_unban, make them safe

### DIFF
--- a/plugins/admincmd.sma
+++ b/plugins/admincmd.sma
@@ -221,6 +221,16 @@ public cmdKick(id, level, cid)
 	return PLUGIN_HANDLED
 }
 
+/**
+ * ';' and '\n' are command delimiters. If a command arg contains these 2
+ * it is not safe to be passed to server_cmd() as it may be trying to execute
+ * a command.
+ */
+isCommandArgSafe(const arg[])
+{
+	return contain(arg, ";") == -1 && contain(arg, "\n") == -1;
+}
+
 public cmdUnban(id, level, cid)
 {
 	if (!cmd_access(id, level, cid, 2))
@@ -247,7 +257,13 @@ public cmdUnban(id, level, cid)
 		server_cmd("removeip ^"%s^";writeip", arg)
 		console_print(id, "[AMXX] %L", id, "IP_REMOVED", arg)
 	} else {
-		server_cmd("removeid ^"%s^";writeid", arg)
+		if(!isCommandArgSafe(arg))
+		{
+			console_print(id, "%l", "CL_NOT_FOUND");
+			return PLUGIN_HANDLED;
+		}
+
+		server_cmd("removeid %s;writeid", arg)
 		console_print(id, "[AMXX] %L", id, "AUTHID_REMOVED", arg)
 	}
 
@@ -376,7 +392,13 @@ public cmdAddBan(id, level, cid)
 		server_cmd("addip ^"%s^" ^"%s^";wait;writeip", minutes, arg)
 		console_print(id, "[AMXX] Ip ^"%s^" added to ban list", arg)
 	} else {
-		server_cmd("banid ^"%s^" ^"%s^";wait;writeid", minutes, arg)
+		if(!isCommandArgSafe(arg))
+		{
+			console_print(id, "%l", "CL_NOT_FOUND");
+			return PLUGIN_HANDLED;
+		}
+
+		server_cmd("banid ^"%s^" %s;wait;writeid", minutes, arg)
 		console_print(id, "[AMXX] Authid ^"%s^" added to ban list", arg)
 	}
 


### PR DESCRIPTION
Related to: https://github.com/alliedmodders/amxmodx/commit/7589c6c5785d417a8b12b021e42c1b79d03601cf

That update broke `amx_addban` and `amx_unban` by trying to make them safe. However, for whatever reason, Valve made it so it's **required** that one does not put quotation marks around a Steam ID in `banid` and `removeid` commands.
In these commands, Steam IDs are treated as 5 arguments instead of 1 (`STEAM_X:Y:Z` = `STEAM_X`, `:`, `Y`, `:`, `Z`). We take a different approach by checking ourselves if the argument is safe, i.e: it doesn't contain `';'` and `'\n'` characters, because these are command delimiters.

Right now `CL_NOT_FOUND` is printed, but it may not be the most suitable message for this case. Suggestions are welcome.