### PR TITLE
Cstrike: Get offset for m_bMapHasBombTarget

### DIFF
--- a/gamedata/common.games/master.games.txt
+++ b/gamedata/common.games/master.games.txt
@@ -743,6 +743,25 @@
 		"game"  "czero"
 	}
 
+	"gamerules.games/cstrike/offsets-cgamerules.txt"
+	{
+		"game"  "cstrike"
+		"game"  "czero"
+	}
+
+	"gamerules.games/cstrike/offsets-chalflifemultiplay.txt"
+	{
+		"game"  "cstrike"
+		"game"  "czero"
+	}
+
+	"gamerules.games/cstrike/offsets-chalflifetraining.txt"
+	{
+		"game"  "cstrike"
+		"game"  "czero"
+	}
+
+
 
 	//
 	// Day Of Defeat
@@ -1533,6 +1552,16 @@
 		"game"  "dod"
 	}
 
+	"gamerules.games/dod/offsets-cdodteamplay.txt"
+	{
+		"game"  "dod"
+	}
+
+	"gamerules.games/dod/offsets-cspdodrules.txt"
+	{
+		"game"  "dod"
+	}
+
 
 	//
 	// Team Fortress Classic
@@ -2158,6 +2187,20 @@
 		"game"  "tfc"
 	}
 
+	"gamerules.games/tfc/offsets-chalflifemultiplay.txt"
+	{
+		"game"  "tfc"
+	}
+
+	"gamerules.games/tfc/offsets-chalflifeteamplay.txt"
+	{
+		"game"  "tfc"
+	}
+
+	"gamerules.games/tfc/offsets-cteamfortress.txt"
+	{
+		"game"  "tfc"
+	}
 
 	//
 	// Half-Life: Opposing Force
@@ -3338,6 +3381,25 @@
 		"game"  "gearbox"
 	}
 
+	"gamerules.games/gearbox/offsets-chalflifemultiplay.txt"
+	{
+		"game"  "gearbox"
+	}
+
+	"gamerules.games/gearbox/offsets-chalflifectfplay.txt"
+	{
+		"game"  "gearbox"
+	}
+
+	"gamerules.games/gearbox/offsets-chalflifecoopplay.txt"
+	{
+		"game"  "gearbox"
+	}
+
+	"gamerules.games/gearbox/offsets-chalflifeteamplay.txt"
+	{
+		"game"  "gearbox"
+	}
 
  	//
 	// Half-Life: Deathmatch
@@ -4032,4 +4094,15 @@
 	{
 		"game"  "valve"
 	}
+
+	"gamerules.games/valve/offsets-chalflifemultiplay.txt"
+	{
+		"game"  "valve"
+	}
+
+	"gamerules.games/valve/offsets-chalflifeteamplay.txt"
+	{
+		"game"  "valve"
+	}
+
 }

--- a/modules/cstrike/cstrike/CstrikeHacks.cpp
+++ b/modules/cstrike/cstrike/CstrikeHacks.cpp
@@ -735,6 +735,7 @@ void InitFuncsAddresses()
 
 void InitClassMembers()
 {
+	// CBasePlayer members.
 	CommonConfig->GetOffsetByClass("CBasePlayer", "m_iTeam"          , &TeamDesc   );
 	CommonConfig->GetOffsetByClass("CBasePlayer", "m_iMenu"          , &MenuDesc   );
 	CommonConfig->GetOffsetByClass("CBasePlayer", "m_bHasNightVision", &NvgsDesc   );
@@ -742,12 +743,16 @@ void InitClassMembers()
 	CommonConfig->GetOffsetByClass("CBasePlayer", "m_signals"        , &SignalsDesc);
 	CommonConfig->GetOffsetByClass("CBasePlayer", "m_iAccount"       , &MoneyDesc  );
 
+	// GameRules members.
+	CommonConfig->GetOffsetByClass("CHalfLifeMultiplay", "m_bMapHasBombTarget", &BombTargetDesc);
+
 	if (!TeamDesc.fieldOffset    ||
 		!MenuDesc.fieldOffset    ||
 		!NvgsDesc.fieldOffset    ||
 		!DefuserDesc.fieldOffset ||
 		!SignalsDesc.fieldOffset ||
-		!MoneyDesc.fieldOffset)
+		!MoneyDesc.fieldOffset   ||
+		!BombTargetDesc.fieldOffset)
 	{
 		MF_Log("Invalid or missing entity gamedata files - forwards CS_OnBuy[Attempt] have been disabled");
 		ToggleHook_BuyCommands(false);


### PR DESCRIPTION
I guess that @Arkshine forgot to initialize `BombTargetDesc` in a445e806ea45bd9c09e2121c68d8d5273891ffa1 . 

But I have one issue with this code. For some unknown reason the `CommonConfig->GetOffsetByClass("CHalfLifeMultiplay", "m_bMapHasBombTarget", &BombTargetDesc)` returns false for me. It seems that my code is wrong or [offset](https://github.com/alliedmodders/amxmodx/blob/f31e0e405f41d616c40feba04eadea37f3877897/gamedata/common.games/gamerules.games/cstrike/offsets-chalflifemultiplay.txt) is wrong. So I need additional help with this. Tested under linux (6132 cs.so) without ReGameDLL.