### PR TITLE
Added call optimization for functions that return array

### DIFF
--- a/compiler/libpc300/sc3.c
+++ b/compiler/libpc300/sc3.c
@@ -729,6 +729,8 @@ static cell array_levelsize(symbol *sym,int level)
  *  Global references: sc_intest        (reffered to only)
  *                     sc_allowproccall (modified)
  */
+static int g_isLValueArray = FALSE;
+static int g_isRValueArrayRetFunc = FALSE;
 static int hier14(value *lval1)
 {
   int lvalue;
@@ -740,6 +742,7 @@ static int hier14(value *lval1)
   int bwcount,leftarray;
   cell arrayidx1[sDIMEN_MAX],arrayidx2[sDIMEN_MAX];  /* last used array indices */
   cell *org_arrayidx;
+  int isRValueArrayRetFunc = FALSE;
 
   bwcount=bitwise_opercount;
   bitwise_opercount=0;
@@ -840,7 +843,11 @@ static int hier14(value *lval1)
       rvalue(lval1);
     } /* if */
     lval2.arrayidx=arrayidx2;
+    g_isLValueArray = TRUE;
     plnge2(oper,hier14,lval1,&lval2);
+    isRValueArrayRetFunc = g_isRValueArrayRetFunc;
+    g_isRValueArrayRetFunc = FALSE;
+    g_isLValueArray = FALSE;
     if (lval2.ident!=iARRAYCELL && lval2.ident!=iARRAYCHAR)
       lval2.arrayidx=NULL;
     if (oper)
@@ -967,7 +974,9 @@ static int hier14(value *lval1)
       error(6);         /* must be assigned to an array */
   } /* if */
   if (leftarray) {
-    memcopy(val*sizeof(cell));
+    if (!isRValueArrayRetFunc) {
+      memcopy(val*sizeof(cell));
+    }
   } else {
     check_userop(NULL,lval2.tag,lval3.tag,2,&lval3,&lval2.tag);
     store(&lval3);      /* now, store the expression result */
@@ -1859,7 +1868,9 @@ static int nesting=0;
   symbol *symret;
   cell lexval;
   char *lexstr;
+  int isLValueArray = g_isLValueArray;
 
+  g_isLValueArray = FALSE;
   assert(sym!=NULL);
   lval_result->ident=iEXPRESSION; /* preset, may be changed later */
   lval_result->constval=0;
@@ -1872,11 +1883,15 @@ static int nesting=0;
     /* allocate space on the heap for the array, and pass the pointer to the
      * reserved memory block as a hidden parameter
      */
-    retsize=(int)array_totalsize(symret);
-    assert(retsize>0);
-    modheap(retsize*sizeof(cell));/* address is in ALT */
-    pushreg(sALT);                /* pass ALT as the last (hidden) parameter */
-    decl_heap+=retsize;
+    if (isLValueArray) {
+      g_isRValueArrayRetFunc = TRUE;
+    } else {
+      retsize = (int)array_totalsize(symret);
+      assert(retsize > 0);
+      modheap(retsize * sizeof(cell));/* address is in ALT */
+      pushreg(sALT);                /* pass ALT as the last (hidden) parameter */
+      decl_heap += retsize;
+    }
     /* also mark the ident of the result as "array" */
     lval_result->ident=iREFARRAY;
     lval_result->sym=symret;
@@ -2255,7 +2270,7 @@ static int nesting=0;
   if ((sym->usage & uNATIVE)!=0 &&sym->x.lib!=NULL)
     sym->x.lib->value += 1;     /* increment "usage count" of the library */
   modheap(-heapalloc*sizeof(cell));
-  if (symret!=NULL)
+  if (symret!=NULL && !isLValueArray)
     popreg(sPRI);               /* pop hidden parameter as function result */
   sideeffect=TRUE;              /* assume functions carry out a side-effect */
   sc_allowproccall=FALSE;
@@ -2267,7 +2282,7 @@ static int nesting=0;
     long totalsize;
     totalsize=declared+decl_heap+1;   /* local variables & return value size,
                                        * +1 for PROC opcode */
-    if (lval_result->ident==iREFARRAY)
+    if (lval_result->ident==iREFARRAY && !isLValueArray)
       totalsize++;                    /* add hidden parameter (on the stack) */
     if ((sym->usage & uNATIVE)==0)
       totalsize++;                    /* add "call" opcode */


### PR DESCRIPTION
This code is very bad and only for demonstration. I hope someone will help to make it ok.
What's the problem? For example, we have this code:
```Pawn
new str[MAX_FMT_LENGTH];
str = fmt("%s", "something");
```
And its assembly:
```Asm
 0x14        STACK                -0x400
 0x1C        ZERO.pri  
 0x20        ADDR.alt             -0x400
 0x28        FILL                  0x400
 0x30        BREAK     
 0x34        ADDR.pri             -0x400
 0x3C        PUSH.pri  
 0x40        HEAP                  0x400
 0x48        PUSH.alt  
 0x4C        PUSH.C                  0xC   ; str_001
 0x54        PUSH.C                  0x0
 0x5C        PUSH.C                  0x8
 0x64        SYSREQ.C                fmt
 0x6C        STACK                   0xC
 0x74        POP.pri   
 0x78        POP.alt   
 0x7C        MOVS                  0x400
 0x84        HEAP                 -0x400
```
Instead of passing `str` to `fmt`, we are passing temporary heap allocated array. And then we copy temporary array into `str`. So I fixed that:
```Asm
 0x14        STACK                -0x400
 0x1C        ZERO.pri  
 0x20        ADDR.alt             -0x400
 0x28        FILL                  0x400
 0x30        BREAK     
 0x34        ADDR.pri             -0x400
 0x3C        PUSH.pri  
 0x40        PUSH.C                  0xC   ; str_001
 0x48        PUSH.C                  0x0
 0x50        PUSH.C                  0x8
 0x58        SYSREQ.C                fmt
 0x60        STACK                   0xC
 0x68        POP.alt   
```

What I want to do/see in future:
- [ ] `new str[MAX_FMT_LENGTH] = fmt("%s", "something")` syntax with `str` zeroing disabled (or this is very very very unsafe?). Yeah, to disable zeroing we can use static, like this:
```Pawn
static str[MAX_FMT_LENGTH];
str = fmt("%s", "something");
```
But `static` can be unsafe for recursions.
- [ ] `new str[] = fmt("%s", "something")`, like the previous one, but with deduced array size.
- [ ] Optimization for array returning:
```Pawn
GetPlayerName(player) {
	new/*static*/ name[MaxNameLength + 1];
	get_user_name(player, name, charsmax(name));
	return name;
}
```
```Asm
 0xCC        PROC                        ; GetPlayerName
 0xD0        BREAK     
 0xD4        BREAK     
 0xD8        STACK                 -0x80
 0xE0        ZERO.pri  
 0xE4        ADDR.alt              -0x80
 0xEC        FILL                   0x80
 0xF4        BREAK     
 0xF8        PUSH.C                 0x1F
 0x100       PUSHADDR              -0x80
 0x108       PUSH.S                  0xC
 0x110       PUSH.C                  0xC
 0x118       SYSREQ.C      get_user_name
 0x120       STACK                  0x10
 0x128       BREAK     
 0x12C       ADDR.pri              -0x80
 0x134       LOAD.S.alt             0x10
 0x13C       MOVS                   0x80
 0x144       STACK                  0x80
 0x14C       RETN      
```
Here we have redundant array zeroing and copying. As an optimization all `name` appearances should be replaced with hidden array parameter. I have done a trick with `emit`:
```Pawn
native get_user_name2(a, b, c) = get_user_name;
GetPlayerName(player) {
	static returnStringAddr;
#emit LOAD.S.PRI 0x10
#emit STOR.PRI returnStringAddr
	
	get_user_name2(player, returnStringAddr, MaxNameLength);
#emit RETN
	
	new name[MaxNameLength + 1];
	return name;
}
```
```Asm
 0xCC        PROC                        ; GetPlayerName
 0xD0        BREAK     
 0xD4        BREAK     
 0xD8        LOAD.S.pri             0x10
 0xE0        STOR.pri               0xF0   ; returnStringAddr
 0xE8        BREAK     
 0xEC        PUSH.C                 0x1F
 0xF4        PUSH                   0xF0   ; returnStringAddr
 0xFC        PUSH.S                  0xC
 0x104       PUSH.C                  0xC
 0x10C       SYSREQ.C      get_user_name
 0x114       STACK                  0x10
 0x11C       RETN      
 0x120       BREAK     
 0x124       STACK                 -0x80
 0x12C       ZERO.pri  
 0x130       ADDR.alt              -0x80
 0x138       FILL                   0x80
 0x140       BREAK     
 0x144       ADDR.pri              -0x80
 0x14C       LOAD.S.alt             0x10
 0x154       MOVS                   0x80
 0x15C       STACK                  0x80
 0x164       RETN      
```
```