### PR TITLE
Make module loading more safe

### DIFF
--- a/amxmodx/amxmodx.h
+++ b/amxmodx/amxmodx.h
@@ -79,7 +79,7 @@ extern AMX_NATIVE_INFO g_GameConfigNatives[];
 #define DLPROC(m, func) GetProcAddress(m, func)
 #define DLFREE(m) FreeLibrary(m)
 #else
-#define DLLOAD(path) (DLHANDLE)dlopen(path, RTLD_NOW)
+#define DLLOAD(path) (DLHANDLE)dlopen(path, RTLD_NOW | RTLD_LOCAL | RTLD_DEEPBIND)
 #define DLPROC(m, func) dlsym(m, func)
 #define DLFREE(m) dlclose(m)
 #endif


### PR DESCRIPTION
Modules with static linked libstdc++ use already loaded symbols instead of linked if they are exporting them. (https://stackoverflow.com/questions/44783614/libstdc-static-linking-in-dynamic-library) `RTLD_DEEPBIND` should fix this.

> http://pubs.opengroup.org/onlinepubs/009695399/functions/dlopen.html
If neither RTLD_GLOBAL nor RTLD_LOCAL are specified, then the default behavior is unspecified.

`RTLD_LOCAL` currently is not specified explicitly (but it is set implicitly because it is equal 0), so now it is specified explicity.

But there are compatibility problems. `RTLD_DEEPBIND` requires glibc 2.3.4, but currently amxmodx requires 2.3. `RTLD_DEEPBIND` is not specified in POSIX.1-2001. (but `dladdr` too) And what about the modules which can rely on the old behaviour? (do they exist? will hlds libstdc++ work normally?)
What about windows dlls? Do they have similar problems?

P.S. Looks like amxmodx can safely link with libstdc++ statically using version script.