### PR TITLE
Fix broken cs_set_user_model update_index parameter for the default engine

### DIFF
--- a/modules/cstrike/cstrike/CstrikeMain.cpp
+++ b/modules/cstrike/cstrike/CstrikeMain.cpp
@@ -37,30 +37,6 @@ int AmxxCheckGame(const char *game)
 	return AMXX_GAME_BAD;
 }
 
-void SV_ActivateServer_RH(IRehldsHook_SV_ActivateServer *chain, int runPhysics)
-{
-	chain->callNext(runPhysics);
-
-	auto numResources = RehldsData->GetResourcesNum();
-
-	if (!numResources)
-	{
-		return;
-	}
-
-	ModelsList.clear();
-
-	for (auto i = 0; i < numResources; ++i) // Saves all the precached models into a list.
-	{
-		auto resource = RehldsData->GetResource(i);
-
-		if (resource->type == t_model)
-		{
-			ModelsList.insert(resource->szFileName, i);
-		}
-	}
-}
-
 void OnAmxxAttach()
 {
 	MF_AddNatives(CstrikeNatives);
@@ -85,11 +61,6 @@ void OnAmxxAttach()
 	}
 
 	InitializeHacks();
-
-	if (HasReHlds)
-	{
-		RehldsHookchains->SV_ActivateServer()->registerHook(SV_ActivateServer_RH);
-	}
 }
 
 void OnPluginsLoaded()
@@ -130,6 +101,8 @@ void OnServerActivate(edict_t *pEdictList, int edictCount, int clientMax)
 	ToggleHook_ClientCommands(HasInternalCommandForward || HasOnBuyAttemptForward || HasOnBuyForward);
 	ToggleHook_BuyCommands(HasOnBuyForward);
 	ToggleHook_GiveDefaultItems(false);
+
+	ModelsList.clear();
 
 	RETURN_META(MRES_IGNORED);
 }

--- a/modules/cstrike/cstrike/CstrikeNatives.cpp
+++ b/modules/cstrike/cstrike/CstrikeNatives.cpp
@@ -856,10 +856,28 @@ static cell AMX_NATIVE_CALL cs_set_user_model(AMX *amx, cell *params)
 
 	if (*params / sizeof(cell) >= 3 && params[3] != 0)
 	{
-		if (!Server)
+		if (!HasReHlds && !Server)
 		{
 			MF_Log("cs_set_user_model is disabled with update_index parameter set");
 			return 0;
+		}
+
+		if (!ModelsList.elements())
+		{
+			auto numResources = HasReHlds ? RehldsData->GetResourcesNum() : Server->num_resources;
+
+			if (numResources)
+			{
+				for (auto i = 0; i < numResources; ++i) // Saves all the precached models into a list.
+				{
+					auto resource = HasReHlds ? RehldsData->GetResource(i) : &Server->resourcelist[i];
+
+					if (resource->type == t_model)
+					{
+						ModelsList.insert(resource->szFileName, resource->nIndex);
+					}
+				}
+			}
 		}
 
 		GET_OFFSET("CBasePlayer", m_modelIndexPlayer);


### PR DESCRIPTION
Related to #417. 
Reported by PartialCloning here: https://forums.alliedmods.net/showthread.php?t=299821.

Moved the code in the native for convenience.