### PR TITLE
Fix build clang 3.9+

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -208,6 +208,8 @@ class AMXXConfig(object):
       cxx.cflags += ['-Wno-sometimes-uninitialized']
       if builder.target_platform == 'linux' and cxx.version >= '3.6':
         cxx.cxxflags += ['-Wno-inconsistent-missing-override']
+      if builder.target_platform == 'linux' and cxx.version >= '4.0':
+        cxx.cxxflags += ['-Wno-address-of-packed-member']
 
     if have_gcc:
       cxx.cflags += ['-Wno-parentheses']

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -208,6 +208,8 @@ class AMXXConfig(object):
       cxx.cflags += ['-Wno-sometimes-uninitialized']
       if builder.target_platform == 'linux' and cxx.version >= '3.6':
         cxx.cxxflags += ['-Wno-inconsistent-missing-override']
+      if builder.target_platform == 'linux' and cxx.version >= '3.9':
+        cxx.cxxflags += ['-Wno-varargs']
       if builder.target_platform == 'linux' and cxx.version >= '4.0':
         cxx.cxxflags += ['-Wno-address-of-packed-member']
 

--- a/modules/cstrike/cstrike/CstrikeNatives.cpp
+++ b/modules/cstrike/cstrike/CstrikeNatives.cpp
@@ -1681,7 +1681,7 @@ static cell AMX_NATIVE_CALL cs_set_c4_defusing(AMX* amx, cell* params)
 // cs_create_entity(const classname[])
 static cell AMX_NATIVE_CALL cs_create_entity(AMX* amx, cell* params)
 {
-	if (CS_CreateNamedEntity <= 0)
+	if (!CS_CreateNamedEntity)
 	{
 		MF_LogError(amx, AMX_ERR_NATIVE, "Native cs_create_entity() is disabled. Check your amxx logs.");
 		return 0;
@@ -1703,7 +1703,7 @@ static cell AMX_NATIVE_CALL cs_create_entity(AMX* amx, cell* params)
 // cs_find_ent_by_class(start_index, const classname[])
 static cell AMX_NATIVE_CALL cs_find_ent_by_class(AMX* amx, cell* params)
 {
-	if (CS_UTIL_FindEntityByString <= 0)
+	if (!CS_UTIL_FindEntityByString)
 	{
 		MF_LogError(amx, AMX_ERR_NATIVE, "Native cs_find_ent_by_class() is disabled. Check your amxx logs.");
 		return 0;
@@ -1726,7 +1726,7 @@ static cell AMX_NATIVE_CALL cs_find_ent_by_class(AMX* amx, cell* params)
 // cs_find_ent_by_owner(start_index, const classname[], owner)
 static cell AMX_NATIVE_CALL cs_find_ent_by_owner(AMX* amx, cell* params)
 {
-	if (CS_UTIL_FindEntityByString <= 0)
+	if (!CS_UTIL_FindEntityByString)
 	{
 		MF_LogError(amx, AMX_ERR_NATIVE, "Native cs_find_ent_by_owner() is disabled. Check your amxx logs.");
 		return 0;
@@ -1762,7 +1762,7 @@ static cell AMX_NATIVE_CALL cs_find_ent_by_owner(AMX* amx, cell* params)
 // cs_set_ent_class(index, const classname[])
 static cell AMX_NATIVE_CALL cs_set_ent_class(AMX* amx, cell* params)
 {
-	if (AddEntityHashValue <= 0 || RemoveEntityHashValue <= 0)
+	if (!AddEntityHashValue || !RemoveEntityHashValue)
 	{
 		MF_LogError(amx, AMX_ERR_NATIVE, "Native cs_set_ent_class() is disabled. Check your amxx logs.");
 		return 0;
@@ -1894,7 +1894,7 @@ static cell AMX_NATIVE_CALL cs_get_translated_item_alias(AMX* amx, cell* params)
 // native cs_get_weapon_info(weapon_id, CsWeaponInfo:type);
 static cell AMX_NATIVE_CALL cs_get_weapon_info(AMX* amx, cell* params)
 {
-	if (!HasReGameDll && GetWeaponInfo <= 0)
+	if (!HasReGameDll && !GetWeaponInfo)
 	{
 		MF_LogError(amx, AMX_ERR_NATIVE, "Native cs_get_weapon_info() is disabled. Check your amxx logs.");
 		return 0;

--- a/modules/hamsandwich/DataHandler.cpp
+++ b/modules/hamsandwich/DataHandler.cpp
@@ -318,19 +318,19 @@ static cell AMX_NATIVE_CALL GetHamItemInfo(AMX *amx, cell *params)
 			return pItem->iPosition;
 
 		case ItemInfo_pszAmmo1:
-			return MF_SetAmxString( amx, params[3], pItem->pszAmmo1 > 0 ? pItem->pszAmmo1 : "", params[4] );
+			return MF_SetAmxString( amx, params[3], pItem->pszAmmo1 ? pItem->pszAmmo1 : "", params[4] );
 
 		case ItemInfo_iMaxAmmo1:
 			return pItem->iMaxAmmo1;
 
 		case ItemInfo_pszAmmo2:
-			return MF_SetAmxString( amx, params[3], pItem->pszAmmo2 > 0 ? pItem->pszAmmo2 : "", params[4] );
+			return MF_SetAmxString( amx, params[3], pItem->pszAmmo2 ? pItem->pszAmmo2 : "", params[4] );
 
 		case ItemInfo_iMaxAmmo2:
 			return pItem->iMaxAmmo2;
 
 		case ItemInfo_pszName:
-			return MF_SetAmxString( amx, params[3], pItem->pszName > 0 ? pItem->pszName : "", params[4] );
+			return MF_SetAmxString( amx, params[3], pItem->pszName ? pItem->pszName : "", params[4] );
 
 		case ItemInfo_iMaxClip:
 			return pItem->iMaxClip;


### PR DESCRIPTION
This PR will allow to compile current codebase using newer versions of clang.

**Note:** Also compiles successfully using clang 5.0