### PR TITLE
Fix a crash with overlapping newmenu

### DIFF
--- a/amxmodx/newmenus.cpp
+++ b/amxmodx/newmenus.cpp
@@ -809,15 +809,22 @@ static cell AMX_NATIVE_CALL menu_items(AMX *amx, cell *params)
 //page indices start at 0!
 static cell AMX_NATIVE_CALL menu_display(AMX *amx, cell *params)
 {
-	GETMENU(params[2]);
-	
+	auto handle = params[2];
+	GETMENU(handle);
+
 	int player = params[1];
 	int page = params[3];
 	CPlayer* pPlayer = GET_PLAYER_POINTER_I(player);
-	
+
 	if (!CloseNewMenus(pPlayer))
 	{
 		LogError(amx, AMX_ERR_NATIVE, "Plugin called menu_display when item=MENU_EXIT");
+		return 0;
+	}
+
+	if (!g_NewMenus[handle])
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Invalid menu id %d (was previously destroyed).", handle);
 		return 0;
 	}
 


### PR DESCRIPTION
Reported by @aron9forever on the forum: https://forums.alliedmods.net/showthread.php?t=301737.

Typically the situation where a global menu is destroyed and re-displayed.
Before displaying a menu, `menu_display` will try to close/destroy any previous menu. 
If it happens two same menu overlap, `menu_display` will destroy and display the same menu, resulting in a crash because the menu being deleted right before.

The proposed solution is to check the menu validity and erroring if the menu has been previously destroyed.