### PR TITLE
Fix #395 backward compatibility issue by adding SetParamEntity2 native

### DIFF
--- a/modules/hamsandwich/DataHandler.cpp
+++ b/modules/hamsandwich/DataHandler.cpp
@@ -238,20 +238,32 @@ static cell AMX_NATIVE_CALL SetHamParamVector(AMX *amx, cell *params)
 	int ret=dat->SetVector(MF_GetAmxAddr(amx, params[2]));
 	PARSE_RETURN();
 }
-static cell AMX_NATIVE_CALL SetHamParamEntity(AMX *amx, cell *params)
+
+cell SetParamEntity(AMX *amx, cell *params, bool updateIndex)
 {
 	CHECK_STACK(ParamStack);
 	ke::Vector<Data *> *vec = ParamStack.front();
-	if (vec->length() < (unsigned)params[1]) 
-	{ 
-		MF_LogError(amx, AMX_ERR_NATIVE, "Invalid parameter number, got %d, expected %d", params[1], vec->length()); 
-		return 0; 
-	} 
-	Data *dat=vec->at(params[1] - 1);
+	if (vec->length() < (unsigned)params[1])
+	{
+		MF_LogError(amx, AMX_ERR_NATIVE, "Invalid parameter number, got %d, expected %d", params[1], vec->length());
+		return 0;
+	}
+	Data *dat = vec->at(params[1] - 1);
 
-	int ret=dat->SetEntity(&params[2]);
+	int ret = dat->SetEntity(&params[2], updateIndex);
 	PARSE_RETURN();
 }
+
+static cell AMX_NATIVE_CALL SetHamParamEntity(AMX *amx, cell *params)
+{
+	return SetParamEntity(amx, params, false);
+}
+
+static cell AMX_NATIVE_CALL SetHamParamEntity2(AMX *amx, cell *params)
+{
+	return SetParamEntity(amx, params, true);
+}
+
 static cell AMX_NATIVE_CALL SetHamParamString(AMX *amx, cell *params)
 {
 	CHECK_STACK(ParamStack);
@@ -483,6 +495,7 @@ AMX_NATIVE_INFO ReturnNatives[] =
 	{ "SetHamParamFloat",			SetHamParamFloat },
 	{ "SetHamParamVector",			SetHamParamVector },
 	{ "SetHamParamEntity",			SetHamParamEntity },
+	{ "SetHamParamEntity2",			SetHamParamEntity2 },
 	{ "SetHamParamString",			SetHamParamString },
 	{ "SetHamParamTraceResult",		SetHamParamTraceResult },
 	{ "SetHamParamItemInfo",		SetHamParamItemInfo },

--- a/modules/hamsandwich/DataHandler.h
+++ b/modules/hamsandwich/DataHandler.h
@@ -210,7 +210,7 @@ public:
 		return 0;
 	};
 
-	int SetEntity(cell *data)
+	int SetEntity(cell *data, bool updateIndex = false)
 	{
 		if (!IsSet())
 		{
@@ -219,7 +219,7 @@ public:
 		if (IsType(RET_CBASE))
 		{
 			*(reinterpret_cast<void **>(m_data))= TypeConversion.id_to_cbase(*data);
-			if (m_index != 0)
+			if (updateIndex && m_index)
 			{
 				*m_index=*data;
 			}
@@ -229,7 +229,7 @@ public:
 		else if (IsType(RET_ENTVAR))
 		{
 			*(reinterpret_cast<entvars_t **>(m_data))= TypeConversion.id_to_entvars(*data);
-			if (m_index != 0)
+			if (updateIndex && m_index)
 			{
 				*m_index=*data;
 			}
@@ -239,7 +239,7 @@ public:
 		else if (IsType(RET_EDICT))
 		{
 			*(reinterpret_cast<edict_t **>(m_data)) = TypeConversion.id_to_edict(*data);
-			if (m_index != 0)
+			if (updateIndex && m_index)
 			{
 				*m_index = *data;
 			}

--- a/plugins/include/hamsandwich.inc
+++ b/plugins/include/hamsandwich.inc
@@ -265,10 +265,24 @@ native SetHamParamVector(which, const Float:value[3]);
  * Sets a parameter on the fly of the current hook.  This has no effect in post hooks.
  * Use this on parameters that are entities.
  *
+ * @note Due to a historical bug, the changes made by this native are not reflected in the corresponding post forward
+ *       for backward compatibility reasons. Use SetHamParamEntity2 if this is required.
+ *
  * @param which				Which parameter to change.  Starts at 1, and works up from the left to right.  1 is always "this".
  * @param value				The value to change it to.
  */
 native SetHamParamEntity(which, value);
+
+/**
+ * Sets a parameter on the fly of the current hook.  This has no effect in post hooks.
+ * Use this on parameters that are entities.
+ *
+ * @note Same as SetHamParamEntity except the changes made by this native are reflected in the corresponding post forward.
+ *
+ * @param which				Which parameter to change.  Starts at 1, and works up from the left to right.  1 is always "this".
+ * @param value				The value to change it to.
+ */
+native SetHamParamEntity2(which, value);
 
 /**
  * Sets a parameter on the fly of the current hook.  This has no effect in post hooks.


### PR DESCRIPTION
Unfortunately a bit late, but this fixes a backward compatibility issue introduced in #395.
Reported by Th3822 on the forum: https://forums.alliedmods.net/showthread.php?p=2512733#post2512733.

Proposed solution is to keep the old behavior and adding a new `SetParamEntity2` native which will reflect any change in the corresponding post forward.