### PR TITLE
Bump MySQL version to 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ compiler:
 before_script:
   - CHECKOUT_DIR=$PWD && cd .. 
   - chmod a+x $CHECKOUT_DIR/support/checkout-deps.sh 
-  - $CHECKOUT_DIR/support/checkout-deps.sh --no-mysql && cd $CHECKOUT_DIR
+  - $CHECKOUT_DIR/support/checkout-deps.sh && cd $CHECKOUT_DIR
 script:
   - mkdir build && cd build
   - PATH="~/.local/bin:$PATH"
-  - CC=clang-3.7 CXX=clang-3.7 python ../configure.py --enable-optimize --no-mysql
+  - CC=clang-3.7 CXX=clang-3.7 python ../configure.py --enable-optimize
   - ambuild

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -88,7 +88,7 @@ class AMXXConfig(object):
 
     mysql_path = builder.options.mysql_path
     if not len(mysql_path):
-      mysql_path = os.getenv('MYSQL5', '')
+      mysql_path = os.getenv('MYSQL55', '')
 
     if len(mysql_path):
       self.mysql_path = os.path.join(builder.originalCwd, mysql_path)
@@ -96,7 +96,7 @@ class AMXXConfig(object):
         raise Exception('Metamod path does not exist: {0}'.format(mysql_path))
     else:
       try_paths = [
-        os.path.join(builder.sourcePath, '..', 'mysql-5.0'),
+        os.path.join(builder.sourcePath, '..', 'mysql-5.5'),
       ]
       for try_path in try_paths:
         if os.path.exists(try_path):

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,12 +7,20 @@ install:
 - git clone https://github.com/alliedmodders/ambuild
 - git clone https://github.com/alliedmodders/metamod-hl1
 - git clone https://github.com/alliedmodders/hlsdk
-- cd ambuild
+- ps: Start-FileDownload 'http://cdn.mysql.com/archives/mysql-5.5/mysql-5.5.54-win32.zip'
+- 7z x mysql-5.5.54-win32.zip -o"mysql"
+- cd mysql
+- ren mysql-5.5.54-win32 mysql-5.5
+- move /Y mysql-5.5 ..\
+- cd ..\ambuild
 - c:\python27\python setup.py install
 - cd ..\amxmodx
+cache:
+  - c:\projects\*.zip -> appveyor.yml
+  - c:\projects\mysql-5.5 -> appveyor.yml
 build_script:
 - '"%VS120COMNTOOLS%\vsvars32.bat"'
 - mkdir build
 - cd build
-- c:\python27\python ../configure.py --enable-optimize --no-mysql
+- c:\python27\python ../configure.py --enable-optimize
 - c:\python27\scripts\ambuild

--- a/modules/mysqlx/AMBuilder
+++ b/modules/mysqlx/AMBuilder
@@ -26,7 +26,7 @@ if AMXX.mysql_path:
     ]
   elif builder.target_platform is 'windows':
     binary.compiler.linkflags += [
-      os.path.join(AMXX.mysql_path, 'lib', 'opt', 'mysqlclient.lib'),
+      os.path.join(AMXX.mysql_path, 'lib', 'mysqlclient.lib'),
       'ws2_32.lib'
     ]
     if binary.compiler.vendor == 'msvc' and binary.compiler.version >= 1900:

--- a/modules/mysqlx/msvc12/mysqlx.vcxproj
+++ b/modules/mysqlx/msvc12/mysqlx.vcxproj
@@ -54,7 +54,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\;..\..\..\public;..\..\..\public\sdk;..\..\..\public\amtl;..\..\third_party;..\..\third_party\hashing;..\..\..\..\mysql-5.0\include;..\mysql;..\sdk;..\thread;$(METAMOD)\metamod;$(HLSDK)\common;$(HLSDK)\engine;$(HLSDK)\dlls;$(HLSDK)\public;$(MYSQL5)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;..\..\..\public;..\..\..\public\sdk;..\..\..\public\amtl;..\..\third_party;..\..\third_party\hashing;..\..\..\..\mysql-5.5\include;..\mysql;..\sdk;..\thread;$(METAMOD)\metamod;$(HLSDK)\common;$(HLSDK)\engine;$(HLSDK)\dlls;$(HLSDK)\public;$(MYSQL55)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_ITERATOR_DEBUG_LEVEL=0;_DEBUG;_WINDOWS;_USRDLL;MYSQL2_EXPORTS;SM_DEFAULT_THREADER;HAVE_STDINT_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -66,7 +66,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>ws2_32.lib;..\..\..\..\mysql-5.0\lib\opt\mysqlclient.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;..\..\..\..\mysql-5.5\lib\mysqlclient.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>LIBCMT;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>$(OutDir)mysql2.pdb</ProgramDatabaseFile>
@@ -78,7 +78,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\;..\..\..\public;..\..\..\public\sdk;..\..\..\public\amtl;..\..\third_party;..\..\third_party\hashing;..\..\..\..\mysql-5.0\include;..\mysql;..\sdk;..\thread;$(METAMOD)\metamod;$(HLSDK)\common;$(HLSDK)\engine;$(HLSDK)\dlls;$(HLSDK)\public;$(MYSQL5)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;..\..\..\public;..\..\..\public\sdk;..\..\..\public\amtl;..\..\third_party;..\..\third_party\hashing;..\..\..\..\mysql-5.5\include;..\mysql;..\sdk;..\thread;$(METAMOD)\metamod;$(HLSDK)\common;$(HLSDK)\engine;$(HLSDK)\dlls;$(HLSDK)\public;$(MYSQL55)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_ITERATOR_DEBUG_LEVEL=0;NDEBUG;_WINDOWS;_USRDLL;MYSQL2_EXPORTS;SM_DEFAULT_THREADER;HAVE_STDINT_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
@@ -88,7 +88,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>ws2_32.lib;..\..\..\..\mysql-5.0\lib\opt\mysqlclient.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ws2_32.lib;..\..\..\..\mysql-5.5\lib\mysqlclient.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>

--- a/support/checkout-deps.sh
+++ b/support/checkout-deps.sh
@@ -21,19 +21,19 @@ if [ "$1" != "--no-mysql" ]; then
   fi
 
   if [ $ismac -eq 1 ]; then
-    mysqlver=mysql-5.5.28-osx10.5-x86
+    mysqlver=mysql-5.5.40-osx10.6-x86
     mysqlurl=http://cdn.mysql.com/archives/mysql-5.5/$mysqlver.$archive_ext
   elif [ $iswin -eq 1 ]; then
-    mysqlver=mysql-noinstall-5.0.24a-win32
-    mysqlurl=http://cdn.mysql.com/archives/mysql-5.0/$mysqlver.$archive_ext
+    mysqlver=mysql-5.5.57-win32
+    mysqlurl=http://cdn.mysql.com/archives/mysql-5.5/$mysqlver.$archive_ext
     # The folder in the zip archive does not contain the substring "-noinstall", so strip it
     mysqlver=${mysqlver/-noinstall}
   else
-    mysqlver=mysql-5.6.15-linux-glibc2.5-i686
-    mysqlurl=http://cdn.mysql.com/archives/mysql-5.6/$mysqlver.$archive_ext
+    mysqlver=mysql-5.5.57-linux-glibc2.12-i686
+    mysqlurl=http://cdn.mysql.com/archives/mysql-5.5/$mysqlver.$archive_ext
   fi
 
-  if [ ! -d "mysql-5.0" ]; then
+  if [ ! -d "mysql-5.5" ]; then
     if [ `command -v wget` ]; then
       wget $mysqlurl -O mysql.$archive_ext
     elif [ `command -v curl` ]; then
@@ -43,7 +43,7 @@ if [ "$1" != "--no-mysql" ]; then
       exit 1
     fi
     $decomp mysql.$archive_ext
-    mv $mysqlver mysql-5.0
+    mv $mysqlver mysql-5.5
     rm mysql.$archive_ext
   fi
 fi


### PR DESCRIPTION
Bumps MySQL version to `5.5`.

OS | Old version | New version | Comment
--- | ------------- |-------------- | ---------
windows | `5.0.?` | `5.5.54`  | Latest available version before Microsoft Visual C++ 2008 Redistributable Package is required.
linux       | `5.1.?` | `5.5.58` | Latest available version.
mac        | `5.1.?` | `5.5.40` | Latest available version.


Requested by several users.

The main reason to not use `5.6+` is to keep Windows XP compatibility, avoid unnecessary prerequisite and be consistent across the platforms as much as possible.

Note: buildbot doesn't use `checkout-deps.sh`. Currently, the MySQL CDN doesn't have `.58` version so used `.57` for now.