### PR TITLE
Add -lrt flag to mysql in order to lower glibc requirement

### DIFF
--- a/modules/mysqlx/AMBuilder
+++ b/modules/mysqlx/AMBuilder
@@ -22,7 +22,8 @@ if AMXX.mysql_path:
     binary.compiler.linkflags += [
       os.path.join(AMXX.mysql_path, 'lib', 'libmysqlclient_r.a'),
       '-lpthread',
-      '-lm'
+      '-lm',
+      '-lrt',
     ]
   elif builder.target_platform is 'windows':
     binary.compiler.linkflags += [


### PR DESCRIPTION
When we bumped MySQL version to 5.5 (#466), the glibc version bumped actually to 2.17 because of a `clock_gettime` reference. From this function [documentation](https://linux.die.net/man/2/clock_gettime), we should link with `-lrt` for glibc versions before 2.17. This way we keep AMXX glibc requirement to 2.3.