### PR TITLE
Strip whitespace when reading product.version

### DIFF
--- a/support/generate_headers.py
+++ b/support/generate_headers.py
@@ -50,7 +50,7 @@ def output_version_headers():
     count, shorthash, longhash = get_git_version()
 
   with open(os.path.join(SourceFolder, 'product.version')) as fp:
-    contents = fp.read()
+    contents = fp.read().rstrip()
   m = re.match('(\d+)\.(\d+)\.(\d+)-?(.*)', contents)
   if m == None:
     raise Exception('Could not detremine product version')


### PR DESCRIPTION
For whatever reason the `tag` variable contained `dev\r\n` on my installation of Ubuntu 14.04 (it's Windows Subsystem for Linux) and caused the build to fail because of wrongly generated `amxmodx_version_auto.h`. I don't know the reason behind this but I guess it doesn't hurt to right-strip whitespace just in case.