### PR TITLE
Fix a menu recursion issue

### DIFF
--- a/amxmodx/CGameConfigs.h
+++ b/amxmodx/CGameConfigs.h
@@ -166,6 +166,19 @@ class CGameConfigManager : public IGameConfigManager
 		StringHashMap<ITextListener_SMC*> m_customHandlers;
 };
 
+#define GET_OFFSET(classname, member)												\
+	static int member = -1;															\
+	if (member == -1)																\
+	{                                                                               \
+		TypeDescription type;                                                       \
+		if (!CommonConfig->GetOffsetByClass(classname, #member, &type) || type.fieldOffset < 0)\
+		{																			\
+			LogError(amx, AMX_ERR_NATIVE, "Invalid %s offset. Native %s is disabled", #member, __FUNCTION__);\
+			return 0;																\
+		}																			\
+		member = type.fieldOffset;                                                  \
+	}
+
 extern CGameConfigManager ConfigManager;
 extern IGameConfig *CommonConfig;
 

--- a/amxmodx/amxmodx.cpp
+++ b/amxmodx/amxmodx.cpp
@@ -1245,31 +1245,44 @@ static cell AMX_NATIVE_CALL get_user_team(AMX *amx, cell *params) /* 3 param */
 
 static cell AMX_NATIVE_CALL show_menu(AMX *amx, cell *params) /* 3 param */
 {
+	auto closeMenu = [amx](int index) -> int
+	{
+		auto pPlayer = GET_PLAYER_POINTER_I(index);
+
+		if (!pPlayer->ingame)
+		{
+			return 1;
+		}
+
+		pPlayer->keys = 0;
+		pPlayer->menu = 0;
+
+		// Fire newmenu callback so closing it can be handled by the plugin
+		if (!CloseNewMenus(pPlayer))
+		{
+			LogError(amx, AMX_ERR_NATIVE, "Plugin called menu_display when item=MENU_EXIT");
+			return 2;
+		}
+
+		UTIL_FakeClientCommand(pPlayer->pEdict, "menuselect", "10");
+
+		return 0;
+	};
+
+	int index = params[1];
+
 	// If show_menu is called from within a newmenu callback upon receiving MENU_EXIT
 	// it is possible for this native to recurse. We need to close newmenus right away
 	// because the recursive call would otherwise modify/corrupt the static get_amxstring
 	// buffer mid execution. This will either display incorrect text or result in UTIL_ShowMenu
 	// running into an infinite loop.
-	int index = params[1];
 	if (index == 0)
 	{
 		for (int i = 1; i <= gpGlobals->maxClients; ++i)
 		{
-			CPlayer* pPlayer = GET_PLAYER_POINTER_I(i);
-
-			if (pPlayer->ingame)
+			if (closeMenu(i) == 2)
 			{
-				pPlayer->keys = 0;
-				pPlayer->menu = 0;
-
-				// Fire newmenu callback so closing it can be handled by the plugin
-				if (!CloseNewMenus(pPlayer))
-				{
-					LogError(amx, AMX_ERR_NATIVE, "Plugin called menu_display when item=MENU_EXIT");
-					return 0;
-				}
-
-				UTIL_FakeClientCommand(pPlayer->pEdict, "menuselect", "10", 0);
+				return 0;
 			}
 		}
 	}
@@ -1281,23 +1294,7 @@ static cell AMX_NATIVE_CALL show_menu(AMX *amx, cell *params) /* 3 param */
 			return 0;
 		}
 
-		CPlayer* pPlayer = GET_PLAYER_POINTER_I(index);
-
-		if (pPlayer->ingame)
-		{
-			pPlayer->keys = 0;
-			pPlayer->menu = 0;
-
-			// Fire newmenu callback so closing it can be handled by the plugin
-			if (!CloseNewMenus(pPlayer))
-			{
-				LogError(amx, AMX_ERR_NATIVE, "Plugin called menu_display when item=MENU_EXIT");
-				return 0;
-			}
-
-			UTIL_FakeClientCommand(pPlayer->pEdict, "menuselect", "10", 0);
-		}
-		else
+		if (closeMenu(index))
 		{
 			return 0;
 		}

--- a/amxmodx/amxmodx.cpp
+++ b/amxmodx/amxmodx.cpp
@@ -1264,7 +1264,11 @@ static cell AMX_NATIVE_CALL show_menu(AMX *amx, cell *params) /* 3 param */
 			return 2;
 		}
 
-		UTIL_FakeClientCommand(pPlayer->pEdict, "menuselect", "10");
+		if (g_bmod_cstrike)
+		{
+			GET_OFFSET("CBasePlayer", m_iMenu);
+			set_pdata<int>(pPlayer->pEdict, m_iMenu, 0);
+		}
 
 		return 0;
 	};

--- a/amxmodx/newmenus.cpp
+++ b/amxmodx/newmenus.cpp
@@ -316,11 +316,6 @@ bool Menu::Display(int player, page_t page)
 
 	CPlayer *pPlayer = GET_PLAYER_POINTER_I(player);
 
-	pPlayer->keys = 0;
-	pPlayer->menu = 0;
-
-	UTIL_FakeClientCommand(pPlayer->pEdict, "menuselect", "10", 0);
-
 	pPlayer->keys = keys;
 	pPlayer->menu = menuId;
 	pPlayer->newmenu = thisId;
@@ -826,6 +821,12 @@ static cell AMX_NATIVE_CALL menu_display(AMX *amx, cell *params)
 	{
 		LogError(amx, AMX_ERR_NATIVE, "Invalid menu id %d (was previously destroyed).", handle);
 		return 0;
+	}
+
+	if (g_bmod_cstrike)
+	{
+		GET_OFFSET("CBasePlayer", m_iMenu);
+		set_pdata<int>(pPlayer->pEdict, m_iMenu, 0);
 	}
 
 	int time = -1;


### PR DESCRIPTION
Reported by JusTGo: https://forums.alliedmods.net/showthread.php?t=275819.

This partially reverts https://bugs.alliedmods.net/show_bug.cgi?id=3199 (https://github.com/alliedmodders/amxmodx/commit/5cb07b900ae566f41f2a6ce00a7605bee48c22e5), a fix is to prevent a context where you would overwrite a default menu (such as buy menu), and once you move out of the zone where such default menu would appear, this essentially fucks up your custom menu in some ways.

By sending `menuselect 10`, this would normally set the player's `m_iMenu` member to 0, therefore avoiding a previous default menu to act. It's actually a fix specific to CS and which doesn't work on a player who is not yet fully joined (team + appearance applied) because `m_iMenu` is only set if you are either fully joined or not stuck in team/appearance menu.

Thre regression happens when you overwrite an initial menu when the player is not yet fully joined, once `menuselect 10` is sent, the game will send again the default menu, and therefore an infinite loop happens. Typically, this should happen only with team and appearance menu.

The proposed fix is simply to use `m_iMenu` directly for CS only intead.

Here a small test plugin to reproduce the error:
```Pawn
#include <amxmodx>

public plugin_init()
{
    register_message(get_user_msgid("ShowMenu"), "OnShowMenu");
}

public OnShowMenu(msgid, dest, id)
{
    static menu_text[64];
    get_msg_arg_string(4, menu_text, charsmax(menu_text));

    if (contain(menu_text, "#Team_Select") >= 0)
    {
        MainMenu(id);
        return PLUGIN_HANDLED;
    }

    return PLUGIN_CONTINUE;
}

public MainMenu(id)
{
    new const menu = menu_create("Menu", "@HandlerMainMenu");
    menu_additem(menu, "Item");
    menu_display(id, menu);
}

@HandlerMainMenu(id, menu, item)
{
    if (++item == 1)
    {
        MainMenu(id);
    }

    menu_destroy(menu);

    return PLUGIN_HANDLED;
}
```
