### PR TITLE
Add a flags update forward and a override param in set_user_flags

### DIFF
--- a/amxmodx/amxmodx.cpp
+++ b/amxmodx/amxmodx.cpp
@@ -2841,7 +2841,7 @@ static cell AMX_NATIVE_CALL get_user_flags(AMX *amx, cell *params) /* 2 param */
 	return GET_PLAYER_POINTER_I(index)->flags[id];
 }
 
-static cell AMX_NATIVE_CALL set_user_flags(AMX *amx, cell *params) /* 3 param */
+static cell AMX_NATIVE_CALL set_user_flags(AMX *amx, cell *params) /* 4 param */
 {
 	int index = params[1];
 
@@ -2860,8 +2860,13 @@ static cell AMX_NATIVE_CALL set_user_flags(AMX *amx, cell *params) /* 3 param */
 
 	if (id > 31)
 		id = 31;
-
-	pPlayer->flags[id] |= flag;
+		
+	if(params[4])
+		pPlayer->flags[id] = flag;
+	else
+		pPlayer->flags[id] |= flag;
+		
+	executeForwards(FF_ClientFlagsUpdated, static_cast<cell>(pPlayer->index), pPlayer->flags[id]);
 
 	return 1;
 }
@@ -2887,7 +2892,8 @@ static cell AMX_NATIVE_CALL remove_user_flags(AMX *amx, cell *params) /* 3 param
 		id = 31;
 
 	pPlayer->flags[id] &= ~flag;
-
+	executeForwards(FF_ClientFlagsUpdated, static_cast<cell>(pPlayer->index), pPlayer->flags[id]);
+	
 	return 1;
 }
 

--- a/amxmodx/amxmodx.h
+++ b/amxmodx/amxmodx.h
@@ -333,6 +333,7 @@ extern int FF_InconsistentFile;
 extern int FF_ClientAuthorized;
 extern int FF_ChangeLevel;
 extern int FF_ClientConnectEx;
+extern int FF_ClientFlagsUpdated;
 
 extern bool g_coloredmenus;
 

--- a/amxmodx/meta_api.cpp
+++ b/amxmodx/meta_api.cpp
@@ -153,6 +153,7 @@ int FF_InconsistentFile = -1;
 int FF_ClientAuthorized = -1;
 int FF_ChangeLevel = -1;
 int FF_ClientConnectEx = -1;
+int FF_ClientFlagsUpdated = -1;
 
 IFileSystem* g_FileSystem;
 HLTypeConversion TypeConversion;
@@ -516,6 +517,7 @@ int	C_Spawn(edict_t *pent)
 	FF_ClientAuthorized = registerForward("client_authorized", ET_IGNORE, FP_CELL, FP_STRING, FP_DONE);
 	FF_ChangeLevel = registerForward("server_changelevel", ET_STOP, FP_STRING, FP_DONE);
 	FF_ClientConnectEx = registerForward("client_connectex", ET_STOP, FP_CELL, FP_STRING, FP_STRING, FP_ARRAY, FP_DONE);
+	FF_ClientFlagsUpdated = registerForward("client_flags_updated", ET_IGNORE, FP_CELL, FP_CELL, FP_DONE);
 
 	CoreCfg.OnAmxxInitialized();
 

--- a/plugins/include/amxmodx.inc
+++ b/plugins/include/amxmodx.inc
@@ -160,6 +160,16 @@ forward client_connect(id);
 forward client_connectex(id, const name[], const ip[], reason[128]);
 
 /**
+ * Called after the client's admin flags are changed.
+ *
+ * @param id        Client index
+ * @param flags     New client flags
+ *
+ * @noreturn
+ */
+forward client_flags_updated(id, flags);
+
+/**
  * Called when the client gets a valid SteamID.
  *
  * @note This may occur before or after client_putinserver has been called.
@@ -1814,7 +1824,7 @@ native task_exists(id = 0, outside = 0);
  * @error           If the index is not within the range of 0 to MaxClients, an
  *                  error will be thrown.
  */
-native set_user_flags(index, flags = -1, id = 0);
+native set_user_flags(index, flags = -1, id = 0, override = false);
 
 /**
  * Returns the client's admin flags as a bitflag sum.
@@ -1826,6 +1836,7 @@ native set_user_flags(index, flags = -1, id = 0);
  *
  * @param index     Client index, 0 to set flags of server
  * @param id        Flag set id, ranging from 0 to 31
+ * @param override  If set to true, all other flags will be removed
  *
  * @noreturn
  * @error           If the index is not within the range of 0 to MaxClients, an


### PR DESCRIPTION
Added a forward called "client_flags_updated" which will be called when the client's flags are modified using "set_user_flags" or "remove_user_flags". I also added another param in the "set_user_flags" function called "override", which if set to true will remove any other flags from the user - I found this necessary because the name of the function is "SET_user_flags", but it actually adds them to the current ones. This way coders can actually SET the flags instead of add them to the current ones.