### PR TITLE
Added ADMIN_SUPER flag

### DIFF
--- a/plugins/include/amxconst.inc
+++ b/plugins/include/amxconst.inc
@@ -94,6 +94,7 @@ public stock const Float:NULL_VECTOR[3];
 #define ADMIN_LEVEL_H       (1<<19) /* flag "t" */
 #define ADMIN_MENU          (1<<20) /* flag "u" */
 #define ADMIN_BAN_TEMP      (1<<21) /* flag "v" */
+#define ADMIN_SUPER         (1<<23) /* flag "x" */
 #define ADMIN_ADMIN         (1<<24) /* flag "y" */
 #define ADMIN_USER          (1<<25) /* flag "z" */
 

--- a/plugins/include/amxmisc.inc
+++ b/plugins/include/amxmisc.inc
@@ -167,7 +167,7 @@ stock cmd_target(id, const arg[], flags = CMDTARGET_OBEY_IMMUNITY)
 	}
 	if (flags & CMDTARGET_OBEY_IMMUNITY)
 	{
-		if ((get_user_flags(player) & ADMIN_IMMUNITY) && ((flags & CMDTARGET_ALLOW_SELF) ? (id != player) : true))
+		if ((get_user_flags(player) & ADMIN_IMMUNITY) && !(get_user_flags(id) & ADMIN_SUPER) && ((flags & CMDTARGET_ALLOW_SELF) ? (id != player) : true))
 		{
 			new imname[MAX_NAME_LENGTH];
 			get_user_name(player, imname, charsmax(imname));


### PR DESCRIPTION
Users with flag "x" (ADMIN_SUPER) are able to bypass the ADMIN_IMMUNITY flag on commands that are properly made with `cmd_target`.