### PR TITLE
Comment MODULE_RELOAD_ON_MAP_CHANGE on modules that use USE_METAMOD

### DIFF
--- a/modules/cstrike/cstrike/moduleconfig.h
+++ b/modules/cstrike/cstrike/moduleconfig.h
@@ -25,7 +25,7 @@
 #define MODULE_LIBRARY "cstrike"
 #define MODULE_LIBCLASS ""
 // If you want the module not to be reloaded on mapchange, remove / comment out the next line
-#define MODULE_RELOAD_ON_MAPCHANGE
+// #define MODULE_RELOAD_ON_MAPCHANGE
 
 #ifdef __DATE__
 #define MODULE_DATE __DATE__

--- a/modules/cstrike/csx/moduleconfig.h
+++ b/modules/cstrike/csx/moduleconfig.h
@@ -25,7 +25,7 @@
 #define MODULE_LIBRARY "csx"
 #define MODULE_LIBCLASS "xstats"
 // If you want the module not to be reloaded on mapchange, remove / comment out the next line
-#define MODULE_RELOAD_ON_MAPCHANGE
+// #define MODULE_RELOAD_ON_MAPCHANGE
 
 #ifdef __DATE__
 #define MODULE_DATE __DATE__

--- a/modules/dod/dodfun/moduleconfig.h
+++ b/modules/dod/dodfun/moduleconfig.h
@@ -25,7 +25,7 @@
 #define MODULE_LIBRARY "dodfun"
 #define MODULE_LIBCLASS ""
 // If you want the module not to be reloaded on mapchange, remove / comment out the next line
-#define MODULE_RELOAD_ON_MAPCHANGE
+// #define MODULE_RELOAD_ON_MAPCHANGE
 
 #ifdef __DATE__
 #define MODULE_DATE __DATE__

--- a/modules/dod/dodx/moduleconfig.h
+++ b/modules/dod/dodx/moduleconfig.h
@@ -25,7 +25,7 @@
 #define MODULE_LIBRARY "dodx"
 #define MODULE_LIBCLASS "xstats"
 // If you want the module not to be reloaded on mapchange, remove / comment out the next line
-#define MODULE_RELOAD_ON_MAPCHANGE
+// #define MODULE_RELOAD_ON_MAPCHANGE
 
 #ifdef __DATE__
 #define MODULE_DATE __DATE__

--- a/modules/engine/moduleconfig.h
+++ b/modules/engine/moduleconfig.h
@@ -25,7 +25,7 @@
 #define MODULE_LIBRARY "engine"
 #define MODULE_LIBCLASS ""
 // If you want the module not to be reloaded on mapchange, remove / comment out the next line
-#define MODULE_RELOAD_ON_MAPCHANGE
+// #define MODULE_RELOAD_ON_MAPCHANGE
 
 #ifdef __DATE__
 #define MODULE_DATE __DATE__

--- a/modules/fakemeta/moduleconfig.h
+++ b/modules/fakemeta/moduleconfig.h
@@ -25,7 +25,7 @@
 #define MODULE_LIBRARY "fakemeta"
 #define MODULE_LIBCLASS ""
 // If you want the module not to be reloaded on mapchange, remove / comment out the next line
-#define MODULE_RELOAD_ON_MAPCHANGE
+// #define MODULE_RELOAD_ON_MAPCHANGE
 
 #ifdef __DATE__
 #define MODULE_DATE __DATE__

--- a/modules/fun/moduleconfig.h
+++ b/modules/fun/moduleconfig.h
@@ -26,7 +26,7 @@
 #define MODULE_LIBRARY "fun"
 #define MODULE_LIBCLASS ""
 // If you want the module not to be reloaded on mapchange, remove / comment out the next line
-#define MODULE_RELOAD_ON_MAPCHANGE
+// #define MODULE_RELOAD_ON_MAPCHANGE
 
 #ifdef __DATE__
 #define MODULE_DATE __DATE__

--- a/modules/geoip/moduleconfig.h
+++ b/modules/geoip/moduleconfig.h
@@ -25,7 +25,7 @@
 #define MODULE_LIBRARY "geoip"
 #define MODULE_LIBCLASS ""
 // If you want the module not to be reloaded on mapchange, remove / comment out the next line
-#define MODULE_RELOAD_ON_MAPCHANGE
+// #define MODULE_RELOAD_ON_MAPCHANGE
 
 #ifdef __DATE__
 #define MODULE_DATE __DATE__

--- a/modules/mysqlx/moduleconfig.h
+++ b/modules/mysqlx/moduleconfig.h
@@ -35,7 +35,7 @@
 #define MODULE_LIBRARY "mysql"
 #define MODULE_LIBCLASS "sqlx"
 // If you want the module not to be reloaded on mapchange, remove / comment out the next line
-#define MODULE_RELOAD_ON_MAPCHANGE
+// #define MODULE_RELOAD_ON_MAPCHANGE
 
 #ifdef __DATE__
 #define MODULE_DATE __DATE__

--- a/modules/sqlite/moduleconfig.h
+++ b/modules/sqlite/moduleconfig.h
@@ -25,7 +25,7 @@
 #define MODULE_LIBRARY "sqlite"
 #define MODULE_LIBCLASS "sqlx"
 // If you want the module not to be reloaded on mapchange, remove / comment out the next line
-#define MODULE_RELOAD_ON_MAPCHANGE
+// #define MODULE_RELOAD_ON_MAPCHANGE
 
 #ifdef __DATE__
 #define MODULE_DATE __DATE__

--- a/modules/tfcx/moduleconfig.h
+++ b/modules/tfcx/moduleconfig.h
@@ -26,7 +26,7 @@
 #define MODULE_LIBRARY "tfcx"
 #define MODULE_LIBCLASS "xstats"
 // If you want the module not to be reloaded on mapchange, remove / comment out the next line
-#define MODULE_RELOAD_ON_MAPCHANGE
+// #define MODULE_RELOAD_ON_MAPCHANGE
 
 #ifdef __DATE__
 #define MODULE_DATE __DATE__

--- a/modules/ts/tsx/moduleconfig.h
+++ b/modules/ts/tsx/moduleconfig.h
@@ -26,7 +26,7 @@
 #define MODULE_LIBRARY "tsx"
 #define MODULE_LIBCLASS "xstats"
 // If you want the module not to be reloaded on mapchange, remove / comment out the next line
-#define MODULE_RELOAD_ON_MAPCHANGE
+// #define MODULE_RELOAD_ON_MAPCHANGE
 
 #ifdef __DATE__
 #define MODULE_DATE __DATE__


### PR DESCRIPTION
Currently amxmodx doesn't reload modules that use metamod, so MODULE_RELOAD_ON_MAP_CHANGE being defined or not doesn't make any difference.
Even though this commit currently doesn't change any behavior, amxmodx might in the future support reloading modules that use metamod, and all these modules in their current state either fail completely because of erroneous cleanup, or are untested (and most likely leak stuff).
Furthermore, these changes make it clear that these modules are in fact not being reloaded.