### PR TITLE
Fix OnPluginsUnloaded not being called for reloadable modules.

### DIFF
--- a/amxmodx/meta_api.cpp
+++ b/amxmodx/meta_api.cpp
@@ -751,8 +751,6 @@ void C_ServerDeactivate_Post()
 
 	modules_callPluginsUnloading();
 
-	detachReloadModules();
-
 	CoreCfg.Clear();
 
 	g_auth.clear();
@@ -775,6 +773,8 @@ void C_ServerDeactivate_Post()
 
 	ClearPluginLibraries();
 	modules_callPluginsUnloaded();
+
+	detachReloadModules();
 
 	ClearMessages();
 


### PR DESCRIPTION
Modules are loaded before plugins, and can hook OnPluginsLoaded. Therefore, they should be unloaded AFTER plugins, and be able to hook OnPluginsUnloaded. This was not the case for reloadable modules.
This affects nvault module, whose OnPluginsUnloaded function wasn't being called.