### PR TITLE
Using negative values for generating random RGB values in (D)HUD messages

### DIFF
--- a/amxmodx/amxmodx.cpp
+++ b/amxmodx/amxmodx.cpp
@@ -480,9 +480,9 @@ static cell AMX_NATIVE_CALL set_hudmessage(AMX *amx, cell *params) /* 11 param *
 	g_hudset.r2 = 255;
 	g_hudset.g2 = 255;
 	g_hudset.b2 = 250;
-	g_hudset.r1 = static_cast<byte>(params[1]);
-	g_hudset.g1 = static_cast<byte>(params[2]);
-	g_hudset.b1 = static_cast<byte>(params[3]);
+	g_hudset.r1 = params[1] < 0 ? RANDOM_LONG(abs(params[1]), 255) : static_cast<byte>(params[1]);
+	g_hudset.g1 = params[2] < 0 ? RANDOM_LONG(abs(params[2]), 255) : static_cast<byte>(params[2]);
+	g_hudset.b1 = params[3] < 0 ? RANDOM_LONG(abs(params[3]), 255) : static_cast<byte>(params[3]);
 	g_hudset.x = amx_ctof(params[4]);
 	g_hudset.y = amx_ctof(params[5]);
 	g_hudset.effect = params[6];
@@ -574,9 +574,9 @@ static cell AMX_NATIVE_CALL set_dhudmessage(AMX *amx, cell *params) /* 10 param 
 	g_hudset.r2 = 255;
 	g_hudset.g2 = 255;
 	g_hudset.b2 = 250;
-	g_hudset.r1 = static_cast<byte>(params[1]);
-	g_hudset.g1 = static_cast<byte>(params[2]);
-	g_hudset.b1 = static_cast<byte>(params[3]);
+	g_hudset.r1 = params[1] < 0 ? RANDOM_LONG(abs(params[1]), 255) : static_cast<byte>(params[1]);
+	g_hudset.g1 = params[2] < 0 ? RANDOM_LONG(abs(params[2]), 255) : static_cast<byte>(params[2]);
+	g_hudset.b1 = params[3] < 0 ? RANDOM_LONG(abs(params[3]), 255) : static_cast<byte>(params[3]);
 	g_hudset.x = amx_ctof(params[4]);
 	g_hudset.y = amx_ctof(params[5]);
 	g_hudset.effect = params[6];

--- a/plugins/include/amxmodx.inc
+++ b/plugins/include/amxmodx.inc
@@ -663,6 +663,9 @@ native disable_logevent(handle);
  *       specific channel to avoid possible flickering due to auto-channeling.
  * @note For the hudmessage coordinates x and y, -1.0 will center the message
  *       on the respective axis.
+ * @note Using a negative value for any of the color components will generate a
+ *       random value for that component ranging from the absolute value of the
+ *       specified number to the maximum RGB value of 255.
  * @note These parameters stay until the next call to set_hudmessage overwrites
  *       them. Multiple calls to show_hudmessage will therefore re-use the same
  *       parameters. The parameters are not stored per-plugin, so other plugins
@@ -710,6 +713,9 @@ native show_hudmessage(index, const message[], any:...);
  *
  * @note For the hudmessage coordinates x and y, -1.0 will center the message
  *       on the respective axis.
+ * @note Using a negative value for any of the color components will generate a
+ *       random value for that component ranging from the absolute value of the
+ *       specified number to the maximum RGB value of 255.
  * @note These parameters stay until the next call to set_dhudmessage overwrites
  *       them. Multiple calls to show_dhudmessage will therefore re-use the same
  *       parameters. The parameters are not stored per-plugin, so other plugins


### PR DESCRIPTION
A very simple change that allows users to generate random colors for their HUD and DHUD messages by using a negative number for any of the RGB components. For example, using `set_hudmessage(-1, -1, -1)` will generate a fully random colored message. Another example is using `set_hudmessage(255, 0, -150)` which will generate a random amount for the blue component ranging from 150 to 255.