### PR TITLE
Fix a buffer issue in RegisterHam

### DIFF
--- a/modules/hamsandwich/hook.h
+++ b/modules/hamsandwich/hook.h
@@ -39,7 +39,7 @@ public:
 	char			*ent;     // ent name that's being hooked
 	int              trampSize;
 
-	Hook(void **vtable_, int entry_, void *target_, bool voidcall, bool retbuf, int paramcount, char *name) :
+	Hook(void **vtable_, int entry_, void *target_, bool voidcall, bool retbuf, int paramcount, const char *name) :
 		func(NULL), vtable(vtable_), entry(entry_), target(target_), exec(0), del(0), tramp(NULL), trampSize(0)
 		{
 			// original function is vtable[entry]


### PR DESCRIPTION
Reported by Darthan & KliPPy.

Easy & lazy fix for a classic buffer issue.

`REMOVE_ENTITY` invokes `pfnOnFreeEntPrivateData` which plugins can hook and `function` string is used after that but it is pointing to the AMXX static buffer. Basically, hooking this forward and doing stuff inside which relies on the AMXX buffer, could invalid all RegisterHam calls.

The proposed fix is to copy locally the string.