### PR TITLE
Fix typos in few localinfo identifiers for the AMXX config directory retrieval (bug 6629)

### DIFF
--- a/amxmodx/CoreConfig.cpp
+++ b/amxmodx/CoreConfig.cpp
@@ -53,7 +53,7 @@ void CoreConfig::ExecuteMainConfig()
 	char path[PLATFORM_MAX_PATH];
 	char command[PLATFORM_MAX_PATH + sizeof(CommandFormat)];
 
-	ke::SafeSprintf(path, sizeof(path), "%s/%s/%s", g_mod_name.chars(), get_localinfo("amx_configdir", "addons/amxmodx/configs"), MainConfigFile);
+	ke::SafeSprintf(path, sizeof(path), "%s/%s/%s", g_mod_name.chars(), get_localinfo("amxx_configsdir", "addons/amxmodx/configs"), MainConfigFile);
 	ke::SafeSprintf(command, sizeof(command), CommandFormat, path);
 
 	SERVER_COMMAND(command);
@@ -80,7 +80,7 @@ bool CoreConfig::ExecuteAutoConfig(CPluginMngr::CPlugin *plugin, AutoConfig *con
 {
 	bool will_create = false;
 
-	const char *configsDir = get_localinfo("amx_configdir", "addons/amxmodx/configs");
+	const char *configsDir = get_localinfo("amxx_configsdir", "addons/amxmodx/configs");
 
 	if (can_create && config->create)
 	{
@@ -254,7 +254,7 @@ bool CoreConfig::ExecuteAutoConfig(CPluginMngr::CPlugin *plugin, AutoConfig *con
 
 void CoreConfig::ExecuteMapConfig()
 {
-	const char *configsDir = get_localinfo("amx_configdir", "addons/amxmodx/configs");
+	const char *configsDir = get_localinfo("amxx_configsdir", "addons/amxmodx/configs");
 
 	char cfgPath[PLATFORM_MAX_PATH];
 	char mapName[PLATFORM_MAX_PATH];


### PR DESCRIPTION
Reported on https://bugs.alliedmods.net/show_bug.cgi?id=6629.
Related to #266.

The code was using the old `amx_configdir` identifier for AMX instead of `amxx_configsdir` for AMXX.
This means if a path was customized in `core.ini`, the change would be ignored and fallback to the default path.