### PR TITLE
Add new preprocessor constant "__FILE__"

### DIFF
--- a/compiler/libpc300/sc.h
+++ b/compiler/libpc300/sc.h
@@ -518,6 +518,7 @@ SC_FUNC constvalue *append_constval(constvalue *table,const char *name,cell val,
 SC_FUNC constvalue *find_constval(constvalue *table,char *name,short index);
 SC_FUNC void delete_consttable(constvalue *table);
 SC_FUNC symbol *add_constant(char *name,cell val,int vclass,int tag);
+SC_FUNC symbol *add_string_constant(char *name,const char *val,int vclass);
 SC_FUNC void exporttag(int tag);
 SC_FUNC void sc_attachdocumentation(symbol *sym);
 SC_FUNC int get_actual_compound(symbol *sym);
@@ -572,6 +573,7 @@ SC_FUNC void begcseg(void);
 SC_FUNC void begdseg(void);
 SC_FUNC void setline(int chkbounds);
 SC_FUNC void setfiledirect(char *name);
+SC_FUNC void setfileconst(char *name);
 SC_FUNC void setlinedirect(int line);
 SC_FUNC void setlabel(int index);
 SC_FUNC void markexpr(optmark type,const char *name,cell offset);

--- a/compiler/libpc300/sc1.c
+++ b/compiler/libpc300/sc1.c
@@ -612,7 +612,7 @@ int pc_compile(int argc, char *argv[])
     fline=skipinput;            /* reset line number */
     sc_reparse=FALSE;           /* assume no extra passes */
     sc_status=statFIRST;        /* resetglobals() resets it to IDLE */
-	setfileconst(inpfname);
+    setfileconst(inpfname);
     if (strlen(incfname)>0) {
       if (strcmp(incfname,sDEF_PREFIX)==0) {
         plungefile(incfname,FALSE,TRUE);    /* parse "default.inc" */

--- a/compiler/libpc300/sc1.c
+++ b/compiler/libpc300/sc1.c
@@ -4587,40 +4587,40 @@ SC_FUNC symbol *add_constant(char *name,cell val,int vclass,int tag)
  *
  *  Adds a string constant to the symbol table.
  */
-SC_FUNC symbol * add_string_constant(char * name,
-  const char * val, int vclass) {
-  symbol * sym;
+SC_FUNC symbol *add_string_constant(char *name,const char *val,int vclass)
+{
+  symbol *sym;
 
   /* Test whether a global or local symbol with the same name exists. Since
    * constants are stored in the symbols table, this also finds previously
    * defind constants. */
-  sym = findglb(name);
+  sym=findglb(name);
   if (sym == NULL)
-    sym = findloc(name);
+    sym=findloc(name);
   if (sym != NULL) {
     int redef = 0;
-    if (sym -> ident != iARRAY) {
-      error(21, name); /* symbol already defined */
+    if (sym->ident!=iARRAY) {
+      error(21,name); /* symbol already defined */
       return NULL;
     } /* if */
   } else {
-    sym = addsym(name, 0, iARRAY, vclass, 0, uDEFINE);
-    sym -> fnumber = fcurrent;
-    sym -> usage |= uSTOCK;
+    sym=addsym(name, 0, iARRAY, vclass, 0, uDEFINE);
+    sym->fnumber = fcurrent;
+    sym->usage |= uSTOCK;
   } /* if */
-  sym -> addr = (litidx + glb_declared) * sizeof(cell);
-  sym -> usage |= (uDEFINE | uPREDEF);
+  sym->addr = (litidx + glb_declared) * sizeof(cell);
+  sym->usage |= (uDEFINE|uPREDEF);
   /* Store this constant only if it's used somewhere. This can be detected
    * in the second stage. */
-  if (sc_status == statWRITE && (sym -> usage & uREAD) != 0) {
+  if (sc_status == statWRITE && (sym->usage & uREAD) != 0) {
     assert(litidx == 0);
     begdseg();
-    while ( * val != '\0')
-      litadd( * val++);
+    while (*val!='\0')
+      litadd(*val++);
     litadd(0);
-    glb_declared += litidx;
+    glb_declared+=litidx;
     dumplits();
-    litidx = 0;
+    litidx=0;
   }
   return sym;
 }

--- a/compiler/libpc300/sc2.c
+++ b/compiler/libpc300/sc2.c
@@ -169,6 +169,7 @@ static char *extensions[] = { ".inc", ".p", ".pawn" };
   assert(sc_status == statFIRST || strcmp(get_inputfile(fcurrent), inpfname) == 0);
   setfiledirect(inpfname);      /* (optionally) set in the list file */
   listline=-1;                  /* force a #line directive when changing the file */
+  setfileconst(inpfname);
   sc_is_utf8=(short)scan_utf8(inpf,name);
   return TRUE;
 }

--- a/compiler/libpc300/sc4.c
+++ b/compiler/libpc300/sc4.c
@@ -255,6 +255,11 @@ SC_FUNC void setfiledirect(char *name)
   } /* if */
 }
 
+SC_FUNC void setfileconst(char *name)
+{
+  add_string_constant("__FILE__",name,sGLOBAL);
+}
+
 SC_FUNC void setlinedirect(int line)
 {
   if (sc_status==statFIRST && sc_listing) {


### PR DESCRIPTION
[The code for the implementation I looked at the guys from SA:MP.](https://github.com/pawn-lang/compiler/commit/d15fc2224be20eac391062d1c1898b027a168713)

Example of work and implementation:
![image](https://user-images.githubusercontent.com/18553678/42704958-77420b04-86da-11e8-8a39-1343400ce114.png)

Example easy code:
```
    #include <amxmodx>
    
    public plugin_init()
    {
       server_print("^n^t^tConstants:");
       server_print("__DATE__: %s", __DATE__);
       server_print("__TIME__: %s", __TIME__);
       server_print("cellbits: %d", cellbits);
       server_print("cellmax: %d", cellmax);
       server_print("cellmin: %d", cellmin);
       server_print("__Pawn: %d", __Pawn);
       server_print("debug: %d", debug);
       server_print("__LINE__: %d", __LINE__);
       server_print("__BINARY_PATH__: %s", __BINARY_PATH__);
       server_print("__BINARY_NAME__: %s", __BINARY_NAME__);

       server_print("__FILE__: %s", __FILE__);
    }
```
