### PR TITLE
Fix a compilation regression in LookupLangKey (introduced with #222)

### DIFF
--- a/plugins/include/lang.inc
+++ b/plugins/include/lang.inc
@@ -103,7 +103,7 @@ native AddTranslation(const lang[3], TransKey:key, const phrase[]);
  *
  * @return 				1 on success, 0 otherwise
  */
-native LookupLangKey(Output[], OutputSize, const Key[], &id);
+native LookupLangKey(Output[], OutputSize, const Key[], const &id);
 
 /**
  * Sets the global language target.


### PR DESCRIPTION
Reported by WPMGPRoSToTeMa here: https://github.com/alliedmodders/amxmodx/pull/498.

The constantness of `id` parameter has been removed in #222 for some reasons.
This induces a compilation error in the following situation:
```Pawn
public func(const player) {
	new output[64];
	LookupLangKey(output, sizeof(output), "SOME_LANG_KEY", player);
	// error 035: argument type mismatch with #222         ^^^^^^
}
```

This PR brings back the missing `const`. 