### PR TITLE
Fix client_print_color where the color is ignored if string starts with an unicode character

### DIFF
--- a/amxmodx/amxmodx.cpp
+++ b/amxmodx/amxmodx.cpp
@@ -338,7 +338,7 @@ static cell AMX_NATIVE_CALL client_print_color(AMX *amx, cell *params) /* 3 para
 				g_langMngr.SetDefLang(i);
 				msg = format_amxstring(amx, params, 3, len);
 
-				if (*msg > 4) // Insert default color code at the start if not present, otherwise message will not be colored.
+				if (static_cast<byte>(*msg) > 4) // Insert default color code at the start if not present, otherwise message will not be colored.
 				{
 					memmove(msg + 1, msg, ke::Min(len++, 191));
 					*msg = 1;
@@ -376,7 +376,7 @@ static cell AMX_NATIVE_CALL client_print_color(AMX *amx, cell *params) /* 3 para
 
 			msg = format_amxstring(amx, params, 3, len);
 
-			if (*msg > 4) // Insert default color code at the start if not present, otherwise message will not be colored.
+			if (static_cast<byte>(*msg) > 4) // Insert default color code at the start if not present, otherwise message will not be colored.
 			{
 				memmove(msg + 1, msg, ke::Min(len++, 191));
 				*msg = 1;


### PR DESCRIPTION
Related to #338.
Reported on the forum: https://forums.alliedmods.net/showthread.php?t=309314

Because of the conversion `cell` -> `char` in `format_amxstring`, utf-8 unsiged bytes will be interpreted as negative value, ie `0xc3` -> `0xffffc3`, resulting in the check failure.

Proposed fix is to cast the char as unsigned.