### PR TITLE
Add default values for menu_item_getinfo's arguments

### DIFF
--- a/plugins/include/newmenus.inc
+++ b/plugins/include/newmenus.inc
@@ -221,7 +221,7 @@ native menu_find_id(menu, page, key);
  * @return				1 on success, 0 on failure.
  * @error				Invalid menu resource.
  */
-native menu_item_getinfo(menu, item, &access, info[], infolen, name[]="", namelen=0, &callback);
+native menu_item_getinfo(menu, item, &access = 0, info[] = "", infolen = 0, name[]="", namelen=0, &callback = 0);
 
 /**
  * Sets an item's display text.


### PR DESCRIPTION
This function has many arguments and 99% of the time people don't use all of them at once. Here's how I personally almost always use this function:

> new szKey[5], szUnused[2], iUnused
> menu_item_getinfo(iMenu, iItem, iUnused, szKey, charsmax(szKey), szUnused, charsmax(szUnused), iUnused)

This is just ridiculous. I need to create variables named "unused" just to store the values that I don't need from the function. Adding default values to those arguments would make this function much easier to use:

> new szKey[5]
> menu_item_getinfo(iMenu, iItem, _, szKey, charsmax(szKey))