### PR TITLE
Execute amxx.cfg before plugin_init to keep compatibility after #266

### DIFF
--- a/amxmodx/meta_api.cpp
+++ b/amxmodx/meta_api.cpp
@@ -657,10 +657,11 @@ void C_ServerActivate_Post(edict_t *pEdictList, int edictCount, int clientMax)
 		pPlayer->Init(pEdictList + i, i);
 	}
 
+	CoreCfg.ExecuteMainConfig();    // Execute amxx.cfg
+
 	executeForwards(FF_PluginInit);
 	executeForwards(FF_PluginCfg);
 
-	CoreCfg.ExecuteMainConfig();    // Execute amxx.cfg
 	CoreCfg.ExecuteAutoConfigs();   // Execute configs created with AutoExecConfig native.
 	CoreCfg.SetMapConfigTimer(6.1); // Prepare per-map configs to be executed 6.1 seconds later.
 	                                // Original value which was used in admin.sma.


### PR DESCRIPTION
Reported on the forum.
Related to #266.

Originally, the `amxx.cfg` file was executed in `admin.sma` and specifically inside `plugin_init`.
This means any plugins declared after could use their cvars in `plugin_init` with values updated from `amxx.cfg`.

After #266, the file was executed after all `plugin_init` calls resulting in a behavior change. Not a dramatic issue, more an inconvenience.

Proposed fix is to execute `amxx.cfg` before `plugin_init`. I don't see any downside to this, or is there one?