### PR TITLE
allow arrayset to accept any type

### DIFF
--- a/plugins/include/amxmodx.inc
+++ b/plugins/include/amxmodx.inc
@@ -3283,7 +3283,7 @@ native DestroyForward(forward_handle);
  *
  * @noreturn
  */
-native arrayset(array[], value, size);
+native arrayset(any:array[], any:value, size);
 
 /**
  * Returns the weapon id associated with a weapon name.


### PR DESCRIPTION
example of use case : 
```
#include <amxmodx>

new Float:g_FloatArray[33]

public plugin_init( )
{
    register_plugin( "arrayset", "0.0.1", "JustGo" )

    for( new i = 1; i <= 32; i++ )
    {
        g_FloatArray[i] = random_float(1.0, 9.0)
        server_print( "g_FloatArray[%d]=%f", i, g_FloatArray[i] )
    }

    register_concmd( "amx_arrayset", "cmd_arrayset")
}

public cmd_arrayset( )
{
    arrayset( g_FloatArray, 0.0, sizeof(g_FloatArray) )

    for( new i = 1; i <= 32; i++ )
    {
        server_print( "g_FloatArray[%d]=%f", i, g_FloatArray[i] )
    }
}
```
