### PR TITLE
Don't reset m_iMenu if player is not fully joined

### DIFF
--- a/amxmodx/amxmodx.cpp
+++ b/amxmodx/amxmodx.cpp
@@ -1278,8 +1278,16 @@ static cell AMX_NATIVE_CALL show_menu(AMX *amx, cell *params) /* 3 param */
 
 		if (g_bmod_cstrike)
 		{
+			enum JoinState { Joined = 0 };
+			enum MenuState { Menu_OFF = 0, Menu_ChooseTeam = 1, Menu_ChooseAppearance = 3 };
+
+			GET_OFFSET("CBasePlayer", m_iJoiningState);
 			GET_OFFSET("CBasePlayer", m_iMenu);
-			set_pdata<int>(pPlayer->pEdict, m_iMenu, 0);
+
+			if (get_pdata<int>(pPlayer->pEdict, m_iJoiningState) == Joined || (get_pdata<int>(pPlayer->pEdict, m_iMenu) != Menu_ChooseTeam && get_pdata<int>(pPlayer->pEdict, m_iMenu) != Menu_ChooseAppearance))
+			{
+				set_pdata<int>(pPlayer->pEdict, m_iMenu, Menu_OFF);
+			}
 		}
 
 		return 0;

--- a/amxmodx/newmenus.cpp
+++ b/amxmodx/newmenus.cpp
@@ -825,8 +825,16 @@ static cell AMX_NATIVE_CALL menu_display(AMX *amx, cell *params)
 
 	if (g_bmod_cstrike)
 	{
+		enum JoinState { Joined = 0 };
+		enum MenuState { Menu_OFF = 0, Menu_ChooseTeam = 1, Menu_ChooseAppearance = 3 };
+
+		GET_OFFSET("CBasePlayer", m_iJoiningState);
 		GET_OFFSET("CBasePlayer", m_iMenu);
-		set_pdata<int>(pPlayer->pEdict, m_iMenu, 0);
+
+		if (get_pdata<int>(pPlayer->pEdict, m_iJoiningState) == Joined || (get_pdata<int>(pPlayer->pEdict, m_iMenu) != Menu_ChooseTeam && get_pdata<int>(pPlayer->pEdict, m_iMenu) != Menu_ChooseAppearance))
+		{
+			set_pdata<int>(pPlayer->pEdict, m_iMenu, Menu_OFF);
+		}
 	}
 
 	int time = -1;


### PR DESCRIPTION
Related to #471.

Similar to what does the [game ](https://github.com/s1lentq/ReGameDLL_CS/blob/master/regamedll/dlls/client.cpp#L2752-L2762), `m_iMenu` should not be reset if the player is not fully joined or is stuck in team or appearance menus.

#471 was about to fix a resursion issue due to `menuselect 10` be sent in all situations to close the game menu before displaying the plugin menu. However, when sent on a player not fully joined, the game will try to redraw the menu and if it happens a plugin overwrites this menu, the recusion is here. That's why `m_iMenu` has been used directly. 

But this should be ignored in this situation. The player has yet to join a team/choose an appearance and the plugins will sent a `jointeam`/`joinclass` command. The game will expect `m_iMenu` value to be set, you can't mess with that.


