### PR TITLE
Compiler: Add __FILE__ and remove __BINARY_PATH__ constants

### DIFF
--- a/compiler/libpc300/sc.h
+++ b/compiler/libpc300/sc.h
@@ -521,6 +521,10 @@ SC_FUNC symbol *add_constant(char *name,cell val,int vclass,int tag);
 SC_FUNC void exporttag(int tag);
 SC_FUNC void sc_attachdocumentation(symbol *sym);
 SC_FUNC int get_actual_compound(symbol *sym);
+#if !defined NO_DEFINE
+SC_FUNC void inst_file_name(char* filename, int strip_path);
+#endif
+
 
 /* function prototypes in SC2.C */
 #define PUSHSTK_P(v)  { stkitem s_; s_.pv=(v); pushstk(s_); }

--- a/compiler/libpc300/sc1.c
+++ b/compiler/libpc300/sc1.c
@@ -408,11 +408,47 @@ void inst_datetime_defines()
   insert_subst("__TIME__", ltime, 8);
 }
 
+void inst_file_name(char *file, int strip_path)
+{
+  char newname[_MAX_PATH];
+  char *fileptr;
+
+  fileptr = NULL;
+
+  if (strip_path) {
+    size_t i, len;
+    int slashchar;
+
+    len = strlen(file);
+    for (i = len - 1; i < len; i--)
+    {
+      slashchar = file[i] == '/';
+    #if defined WIN32 || defined _WIN32
+      slashchar = slashchar || file[i] == '\\';
+    #endif
+      if (slashchar)
+      {
+        fileptr = &file[i + 1];
+        break;
+      }
+    }
+  }
+
+  if (fileptr == NULL) {
+    fileptr = file;
+  }
+
+  snprintf(newname, sizeof(newname), "\"%s\"", fileptr);
+
+  insert_subst("__FILE__", newname, 8);
+}
+
+
 static void inst_binary_name(char *binfname)
 {
   size_t i, len;
   char *binptr;
-  char newpath[512], newname[512];
+  char newname[_MAX_PATH];
   int slashchar;
 
   binptr = NULL;
@@ -435,10 +471,8 @@ static void inst_binary_name(char *binfname)
     binptr = binfname;
   }
 
-  snprintf(newpath, sizeof(newpath), "\"%s\"", binfname);
   snprintf(newname, sizeof(newname), "\"%s\"", binptr);
 
-  insert_subst("__BINARY_PATH__", newpath, 15);
   insert_subst("__BINARY_NAME__", newname, 15);
 }
 
@@ -598,6 +632,7 @@ int pc_compile(int argc, char *argv[])
       delete_substtable();
       inst_datetime_defines();
       inst_binary_name(binfname);
+      inst_file_name(inpfname, TRUE);
     #endif
     resetglobals();
     sc_ctrlchar=sc_ctrlchar_org;
@@ -663,6 +698,7 @@ int pc_compile(int argc, char *argv[])
     delete_substtable();
     inst_datetime_defines();
     inst_binary_name(binfname);
+    inst_file_name(inpfname, TRUE);
   #endif
   resetglobals();
   sc_ctrlchar=sc_ctrlchar_org;

--- a/compiler/libpc300/sc1.c
+++ b/compiler/libpc300/sc1.c
@@ -473,7 +473,7 @@ static void inst_binary_name(char *binfname)
 
   snprintf(newname, sizeof(newname), "\"%s\"", binptr);
 
-  insert_subst("__BINARY_NAME__", newname, 15);
+  insert_subst("__BINARY__", newname, 10);
 }
 
 /*  "main" of the compiler

--- a/compiler/libpc300/sc2.c
+++ b/compiler/libpc300/sc2.c
@@ -270,6 +270,11 @@ static void doinclude(int silent)
   result=plungefile(name,(c!='>'),TRUE);
   if (!result && !silent)
     error(100,name);            /* cannot read from ... (fatal error) */
+#if !defined NO_DEFINE
+  if (result) {
+    inst_file_name(name, FALSE);
+  }
+#endif
 }
 
 /*  readline
@@ -324,6 +329,9 @@ static void readline(unsigned char *line)
       inpf=(FILE *)POPSTK_P();
       insert_dbgfile(inpfname);
       setfiledirect(inpfname);
+#if !defined NO_DEFINE
+      inst_file_name(inpfname, TRUE);
+#endif
       assert(sc_status==statFIRST || strcmp(get_inputfile(fcurrent),inpfname)==0);
       listline=-1;              /* force a #line directive when changing the file */
     } /* if */
@@ -972,8 +980,14 @@ static int command(void)
       if (strlen(pathname)>0) {
         free(inpfname);
         inpfname=duplicatestring(pathname);
-        if (inpfname==NULL)
+        if (inpfname==NULL) {
           error(103);           /* insufficient memory */
+        }
+#if !defined NO_DEFINE
+        else {
+          inst_file_name(inpfname, TRUE);
+        }
+#endif
       } /* if */
     } /* if */
     check_empty(lptr);


### PR DESCRIPTION
Basically, done #497 in a different way using the existing code rather than introducing redundant code.

`__FILE__` can be either the main plugin (e.g. `main.sma`) or any file that the main plugin includes with the relative path (what you define after `#include` , e.g. `myinclude.inc`, or `mydir/myinclude.inc`.

`__BINARY_PATH__` is removed because the absolute path is not useful as it can vary, and some people will not like having their personal directories being displayed.

Should I rename `__BINARY_NAME__` to `__BINARY__` ?