### PR TITLE
Add cs_get_weaponbox_item native

### DIFF
--- a/modules/cstrike/cstrike/CstrikeNatives.cpp
+++ b/modules/cstrike/cstrike/CstrikeNatives.cpp
@@ -1998,6 +1998,34 @@ static cell AMX_NATIVE_CALL cs_get_user_weapon(AMX *amx, cell *params)
 	return 0;
 }
 
+// native cs_get_wpnbox_weapon(weaponboxIndex);
+static cell AMX_NATIVE_CALL cs_get_wpnbox_weapon(AMX *amx, cell *params)
+{
+	GET_OFFSET("CWeaponBox", m_rgpPlayerItems);
+
+	int weaponboxIndex = params[1];
+	CHECK_NONPLAYER(weaponboxIndex);
+	edict_t *pWeaponBox = TypeConversion.id_to_edict(weaponboxIndex);
+
+	if (strcmp(STRING(pWeaponBox->v.classname), "weaponbox"))
+	{
+		MF_LogError(amx, AMX_ERR_NATIVE, "Not a weaponbox entity! (%d)", weaponboxIndex);
+		return 0;
+	}
+
+	edict_t *pWeapon;
+	for (int i = 1; i < MAX_ITEM_TYPES; i++)
+	{
+		pWeapon = TypeConversion.cbase_to_edict(get_pdata<void *>(pWeaponBox, m_rgpPlayerItems, i));
+		if (!FNullEnt(pWeapon))
+		{
+			return TypeConversion.edict_to_id(pWeapon);
+		}
+	}
+
+	return 0;
+}
+
 AMX_NATIVE_INFO CstrikeNatives[] =
 {
 	{"cs_set_user_money",			cs_set_user_money},
@@ -2070,5 +2098,6 @@ AMX_NATIVE_INFO CstrikeNatives[] =
 	{"cs_get_weapon_info",          cs_get_weapon_info},
 	{"cs_get_user_weapon_entity",   cs_get_user_weapon_entity},
 	{"cs_get_user_weapon",          cs_get_user_weapon},
+	{"cs_get_wpnbox_weapon",		cs_get_wpnbox_weapon},
 	{nullptr,						nullptr}
 };

--- a/modules/cstrike/cstrike/CstrikeNatives.cpp
+++ b/modules/cstrike/cstrike/CstrikeNatives.cpp
@@ -1998,8 +1998,8 @@ static cell AMX_NATIVE_CALL cs_get_user_weapon(AMX *amx, cell *params)
 	return 0;
 }
 
-// native cs_get_wpnbox_weapon(weaponboxIndex);
-static cell AMX_NATIVE_CALL cs_get_wpnbox_weapon(AMX *amx, cell *params)
+// native cs_get_weaponbox_item(weaponboxIndex);
+static cell AMX_NATIVE_CALL cs_get_weaponbox_item(AMX *amx, cell *params)
 {
 	GET_OFFSET("CWeaponBox", m_rgpPlayerItems);
 
@@ -2007,7 +2007,7 @@ static cell AMX_NATIVE_CALL cs_get_wpnbox_weapon(AMX *amx, cell *params)
 	CHECK_NONPLAYER(weaponboxIndex);
 	edict_t *pWeaponBox = TypeConversion.id_to_edict(weaponboxIndex);
 
-	if (strcmp(STRING(pWeaponBox->v.classname), "weaponbox"))
+	if (strcmp(STRING(pWeaponBox->v.classname), "weaponbox") != 0)
 	{
 		MF_LogError(amx, AMX_ERR_NATIVE, "Not a weaponbox entity! (%d)", weaponboxIndex);
 		return 0;
@@ -2098,6 +2098,6 @@ AMX_NATIVE_INFO CstrikeNatives[] =
 	{"cs_get_weapon_info",          cs_get_weapon_info},
 	{"cs_get_user_weapon_entity",   cs_get_user_weapon_entity},
 	{"cs_get_user_weapon",          cs_get_user_weapon},
-	{"cs_get_wpnbox_weapon",		cs_get_wpnbox_weapon},
+	{"cs_get_weaponbox_item",		cs_get_weaponbox_item},
 	{nullptr,						nullptr}
 };

--- a/plugins/include/cstrike.inc
+++ b/plugins/include/cstrike.inc
@@ -740,6 +740,17 @@ native cs_get_armoury_type(index, &count = 1);
 native cs_set_armoury_type(index, type, count = -1);
 
 /**
+ * Returns the weapon entity index that was packed into a weaponbox.
+ *
+ * @param weaponboxIndex  Weaponbox entity index
+ *
+ * @return                Weapon entity index on success or 0 if no weapon can be found
+ * @error                 If a non-weaponbox entity is provided or the entity is invalid, an error will be
+ *                        thrown.
+ */
+native cs_get_wpnbox_weapon(weaponboxIndex);
+
+/**
  * Returns the map zones the client is inside of as a bitflag value.
  *
  * @note If the user does not have the ability to plant (cs_get_user_plant()

--- a/plugins/include/cstrike.inc
+++ b/plugins/include/cstrike.inc
@@ -748,7 +748,7 @@ native cs_set_armoury_type(index, type, count = -1);
  * @error                 If a non-weaponbox entity is provided or the entity is invalid, an error will be
  *                        thrown.
  */
-native cs_get_wpnbox_weapon(weaponboxIndex);
+native cs_get_weaponbox_item(weaponboxIndex);
 
 /**
  * Returns the map zones the client is inside of as a bitflag value.


### PR DESCRIPTION
The purpose is to add a native to retrieve the weapon entity that was packed into a weaponbox. This is quite a common thing to do in plugins(for example when creating custom weapons or blocking touch for specific weapons).
Moreover, we already have a native to retrieve the type of an armoury_entity so it makes sense to have one for weaponbox too.

This is the first time when I make a PR, I hope everything is fine. If I messed something let me know.