### PR TITLE
Enhance cs_get_user_weapon_entity

### DIFF
--- a/modules/cstrike/cstrike/CstrikeNatives.cpp
+++ b/modules/cstrike/cstrike/CstrikeNatives.cpp
@@ -1944,17 +1944,58 @@ static cell AMX_NATIVE_CALL cs_get_weapon_info(AMX* amx, cell* params)
 	return 0;
 }
 
-// native cs_get_user_weapon_entity(playerIndex);
+// native cs_get_user_weapon_entity(playerIndex, weaponIndex = CSW_NONE);
 static cell AMX_NATIVE_CALL cs_get_user_weapon_entity(AMX *amx, cell *params)
 {
-	GET_OFFSET("CBasePlayer", m_pActiveItem);
+	GET_OFFSET("CBasePlayer"    , m_pActiveItem);
+	GET_OFFSET("CBasePlayer"    , m_rgpPlayerItems);
+	GET_OFFSET("CBasePlayerItem", m_iId);
+	GET_OFFSET("CBasePlayerItem", m_pNext);
 
 	int playerIndex = params[1];
+	int weaponIndex = params[2];
 
 	CHECK_PLAYER(playerIndex);
 	edict_t *pPlayer = MF_GetPlayerEdict(playerIndex);
 
-	int weaponEntIndex = TypeConversion.cbase_to_id(get_pdata<void *>(pPlayer, m_pActiveItem));
+	int weaponEntIndex = -1;
+	if (weaponIndex == CSW_NONE)
+	{
+		weaponEntIndex = TypeConversion.cbase_to_id(get_pdata<void *>(pPlayer, m_pActiveItem));
+	}
+	else
+	{
+		if (weaponIndex >= MAX_WEAPONS)
+		{
+			MF_LogError(amx, AMX_ERR_NATIVE, "Invalid weapon id %d", weaponIndex);
+			return 0;
+		}
+
+		edict_t *pWeapon;
+		bool foundWeapon = false;
+
+		for (int i = 1; i < MAX_ITEM_TYPES; i++)
+		{
+			pWeapon = TypeConversion.cbase_to_edict(get_pdata<void *>(pPlayer, m_rgpPlayerItems, i));
+			while(!FNullEnt(pWeapon))
+			{
+				if (get_pdata<int>(pWeapon, m_iId) == weaponIndex)
+				{
+					weaponEntIndex = TypeConversion.edict_to_id(pWeapon);
+					foundWeapon = true;
+					break;
+				}
+		
+				pWeapon = TypeConversion.cbase_to_edict(get_pdata<void *>(pWeapon, m_pNext));
+				
+			}
+
+			if (foundWeapon)
+			{
+				break;
+			}
+		}
+	}
 
 	return (weaponEntIndex != -1) ? weaponEntIndex : 0;
 }

--- a/plugins/include/cstrike.inc
+++ b/plugins/include/cstrike.inc
@@ -1113,16 +1113,18 @@ native bool:cs_get_translated_item_alias(const alias[], itemname[], maxlength);
 native any:cs_get_weapon_info(weapon_id, CsWeaponInfo:type);
 
 /**
- * Returns active weapon entity.
+ * Returns a weapon entity index.
  *
  * @param playerIndex   Player index
+ * @param weaponIndex   A CSW_* id or 0. If 0(CSW_NONE) is passed the active item entity index will be retrieved
+					 If non-zero it will retrieve the entity index of the weapon with the given CSW_* id				
  *
- * @return              Weapon entity index on success or 0 if there is no active weapon
+ * @return              Weapon entity index on success or 0 if weapon could not be found
  * @error               If the client index is not within the range of 1 to
- *                      maxClients, or the client is not connected, an error will be
+ *                      maxClients, or the client is not connected or an invalid CSW_* value is passed an error will be
  *                      thrown.
  */
-native cs_get_user_weapon_entity(playerIndex);
+native cs_get_user_weapon_entity(playerIndex, weaponIndex = CSW_NONE);
 
 /**
  * Returns weapon index of the active weapon.


### PR DESCRIPTION
The purpose is to extend the functionality of cs_get_user_weapon_entity and allow it to retrieve the weapon entity index not only from the active item, but from any weapon.

Another param (weaponIndex) was added which controls the behavior of the native. 
1. If weaponIndex is 0 it will attempt to retrieve the weapon entity index of the active item. 
2. If a valid CSW_* constant is passed it will retrieve the entity index from this specific weapon, if it is found.

This is useful with natives like cs_set_weapon_ammo/cs_get_weapon_ammo or whenever you want to retrieve such information. There are many other use cases for this.