### PR TITLE
Revert "Fun: Make TraceLine a post forward"

### DIFF
--- a/modules/fun/fun.cpp
+++ b/modules/fun/fun.cpp
@@ -315,8 +315,6 @@ static cell AMX_NATIVE_CALL set_user_hitzones(AMX *amx, cell *params)
 		Players.SetBodyHits(attacker, target, hitzones);
 	}
 
-	g_pengfuncsTable_Post->pfnTraceLine = Players.HaveBodyHits() ? TraceLine_Post : nullptr;
-
 	return 1;
 }
 
@@ -484,8 +482,10 @@ int ClientConnect(edict_t *pPlayer, const char *pszName, const char *pszAddress,
 	RETURN_META_VALUE(MRES_IGNORED, 0);
 }
 
-void TraceLine_Post(const float *v1, const float *v2, int fNoMonsters, edict_t *shooter, TraceResult *ptr)
+void TraceLine(const float *v1, const float *v2, int fNoMonsters, edict_t *shooter, TraceResult *ptr)
 {
+	TRACE_LINE(v1, v2, fNoMonsters, shooter, ptr);
+
 	if (ptr->pHit && (ptr->pHit->v.flags & (FL_CLIENT | FL_FAKECLIENT))
 	    && shooter &&  (shooter->v.flags & (FL_CLIENT | FL_FAKECLIENT)) )
 	{
@@ -499,7 +499,7 @@ void TraceLine_Post(const float *v1, const float *v2, int fNoMonsters, edict_t *
 		}
 	}
 
-	RETURN_META(MRES_IGNORED);
+	RETURN_META(MRES_SUPERCEDE);
 }
 
 

--- a/modules/fun/moduleconfig.h
+++ b/modules/fun/moduleconfig.h
@@ -232,7 +232,7 @@
 // #define FN_SetOrigin							SetOrigin
 // #define FN_EmitSound							EmitSound
 // #define FN_EmitAmbientSound					EmitAmbientSound
-// #define FN_TraceLine							TraceLine
+#define FN_TraceLine							TraceLine
 // #define FN_TraceToss							TraceToss
 // #define FN_TraceMonsterHull					TraceMonsterHull
 // #define FN_TraceHull							TraceHull


### PR DESCRIPTION
This revers the change in #421 which would make the Traceline forward as post.

As a reminder, `pfnTraceLine` is a function which traces a line, gathers data and populates the `TraceResult* ptr` argument. This means if you hook `FM_TraceLine` as pre, and you try to access right away let's say `ptr->pHit`, you will get a crash due `ptr->pHit` holding invalid data. Usually, you should call `EngFunc_TraceLine` before to fill the structure and supersede at the end.

**Note**: this crash can be produced on 1.8.2, plugins are responsible to call `EngFunc_TraceLine` when you should. (crash could be avoided by initializing the structure before in fakemeta module though)

**Note**: crash doesn't happen if fun module is loaded _before_ fakemeta because the original  `pfnTraceLine` being called all the time in the hook.

Two reasons to revert:
1. The original motivation for this change is incorrect. Even if superseded, the callbacks will be executed. This doesn't change the fact it makes sense to have a post forward here.
2.  This breaks certain plugins which abuse this internal context by hooking `pfnTraceLine` as pre and accessing `TraceResult` data or superseding without calling `EngFunc_TraceLine` before. 

Unfortunately, I could not find a sane fix to avoid a behavior change. Really silly.
For now, reverting in hoping we can find another way.