### PR TITLE
Add 2 new cvars

### DIFF
--- a/configs/amxx.cfg
+++ b/configs/amxx.cfg
@@ -95,6 +95,16 @@ amx_time_display "ab 1200" "ab 600" "ab 300" "ab 180" "ab 60" "bcde 11"
 // Default value: 1
 amx_time_voice 1
 
+// Print the information to all players when a player types "timeleft" or "thetime" in chat, 0 to disable
+//
+// Default value: 1
+amx_time_print_to_all 1
+
+// Set to 0 to prevent the "timeleft" and "thetime" commands from showing in chat
+//
+// Default value: 1
+amx_time_show_cmd_in_chat 1
+
 // Minimum delay in seconds between two voting sessions
 //
 // Default value: 10

--- a/configs/cstrike/amxx.cfg
+++ b/configs/cstrike/amxx.cfg
@@ -95,6 +95,16 @@ amx_time_display "ab 1200" "ab 600" "ab 300" "ab 180" "ab 60" "bcde 11"
 // Default value: 1
 amx_time_voice 1
 
+// Print the information to all players when a player types "timeleft" or "thetime" in chat, 0 to disable
+//
+// Default value: 1
+amx_time_print_to_all 1
+
+// Set to 0 to prevent the "timeleft" and "thetime" commands from showing in chat
+//
+// Default value: 1
+amx_time_show_cmd_in_chat 1
+
 // Minimum delay in seconds between two voting sessions
 //
 // Default value: 10

--- a/configs/ns/amxx.cfg
+++ b/configs/ns/amxx.cfg
@@ -95,6 +95,16 @@ amx_time_display "ab 180" "ab 120" "ab 60" "bcde 11"
 // Default value: 1
 amx_time_voice 1
 
+// Print the information to all players when a player types "timeleft" or "thetime" in chat, 0 to disable
+//
+// Default value: 1
+amx_time_print_to_all 1
+
+// Set to 0 to prevent the "timeleft" and "thetime" commands from showing in chat
+//
+// Default value: 1
+amx_time_show_cmd_in_chat 1
+
 // Minimum delay in seconds between two voting sessions
 //
 // Default value: 10

--- a/plugins/ns/timeleft.sma
+++ b/plugins/ns/timeleft.sma
@@ -19,6 +19,7 @@ new g_CountDown
 new g_Switch
 new Float:g_roundStartTime = 999999.9
 new bool:is_combat
+new g_amx_time_print_to_all, g_amx_time_show_cmd_in_chat
 
 public plugin_init() {
   register_plugin("TimeLeft",AMXX_VERSION_STR,"AMXX Dev Team")
@@ -28,6 +29,9 @@ public plugin_init() {
   register_clcmd("say timeleft","sayTimeLeft",0,"- displays timeleft")
   register_clcmd("say thetime","sayTheTime",0,"- displays current time")
   set_task(0.8,"timeRemain",8648458,"",0,"b")
+
+  g_amx_time_print_to_all = register_cvar("amx_time_print_to_all", "1")
+  g_amx_time_show_cmd_in_chat = register_cvar("amx_time_show_cmd_in_chat", "1")
   
   new szMapName[4]
   get_mapname(szMapName, charsmax(szMapName))
@@ -62,8 +66,8 @@ public sayTheTime(id){
   }
   new ctime[64]  
   get_time("%m/%d/%Y - %H:%M:%S",ctime,charsmax(ctime))  
-  client_print(0,print_chat, "The time:   %s",ctime )
-  return PLUGIN_CONTINUE
+  client_print(get_pcvar_bool(g_amx_time_print_to_all) ? 0 : id,print_chat, "The time:   %s",ctime )
+  return get_pcvar_bool(g_amx_time_show_cmd_in_chat) ? PLUGIN_CONTINUE : PLUGIN_HANDLED
 }
 
 public sayTimeLeft(id){
@@ -74,11 +78,11 @@ public sayTimeLeft(id){
       setTimeVoice( svoice , charsmax(svoice) , 0 , a )
       client_cmd( id , "%s", svoice  )
     }    
-    client_print(0,print_chat, "Time Left:  %d:%02d", (a / 60) , (a % 60) )
+    client_print(get_pcvar_bool(g_amx_time_print_to_all) ? 0 : id,print_chat, "Time Left:  %d:%02d", (a / 60) , (a % 60) )
   }
   else
-    client_print(0,print_chat, "No Time Limit" )
-  return PLUGIN_CONTINUE
+    client_print(get_pcvar_bool(g_amx_time_print_to_all) ? 0 : id,print_chat, "No Time Limit" )
+  return get_pcvar_bool(g_amx_time_show_cmd_in_chat) ? PLUGIN_CONTINUE : PLUGIN_HANDLED
 }
 
 setTimeText(text[],len,tmlf){

--- a/plugins/timeleft.sma
+++ b/plugins/timeleft.sma
@@ -29,7 +29,7 @@ new g_CountDown
 new g_Switch
 
 // pcvars
-new g_amx_time_voice, g_amx_timeleft
+new g_amx_time_voice, g_amx_timeleft, g_amx_time_print_to_all, g_amx_time_show_cmd_in_chat
 new g_mp_timelimit
 
 public plugin_init()
@@ -39,6 +39,8 @@ public plugin_init()
 	g_amx_time_voice = register_cvar("amx_time_voice", "1")
 	register_srvcmd("amx_time_display", "setDisplaying")
 	g_amx_timeleft = register_cvar("amx_timeleft", "00:00", FCVAR_SERVER|FCVAR_EXTDLL|FCVAR_UNLOGGED|FCVAR_SPONLY)
+	g_amx_time_print_to_all = register_cvar("amx_time_print_to_all", "1")
+	g_amx_time_show_cmd_in_chat = register_cvar("amx_time_show_cmd_in_chat", "1")
 	register_clcmd("say timeleft", "sayTimeLeft", 0, "- displays timeleft")
 	register_clcmd("say thetime", "sayTheTime", 0, "- displays current time")
 	
@@ -83,9 +85,8 @@ public sayTheTime(id)
 	new ctime[64]
 	
 	get_time("%m/%d/%Y - %H:%M:%S", ctime, charsmax(ctime))
-	client_print(0, print_chat, "%L:   %s", LANG_PLAYER, "THE_TIME", ctime)
-	
-	return PLUGIN_CONTINUE
+	client_print(get_pcvar_bool(g_amx_time_print_to_all) ? 0 : id, print_chat, "%L:   %s", LANG_PLAYER, "THE_TIME", ctime)
+	return get_pcvar_bool(g_amx_time_show_cmd_in_chat) ? PLUGIN_CONTINUE : PLUGIN_HANDLED
 }
 
 public sayTimeLeft(id)
@@ -100,12 +101,12 @@ public sayTimeLeft(id)
 			setTimeVoice(svoice, charsmax(svoice), 0, a)
 			client_cmd(id, "%s", svoice)
 		}
-		client_print(0, print_chat, "%L:  %d:%02d", LANG_PLAYER, "TIME_LEFT", (a / 60), (a % 60))
+		client_print(get_pcvar_bool(g_amx_time_print_to_all) ? 0 : id, print_chat, "%L:  %d:%02d", LANG_PLAYER, "TIME_LEFT", (a / 60), (a % 60))
 	}
 	else
-		client_print(0, print_chat, "%L", LANG_PLAYER, "NO_T_LIMIT")
+		client_print(get_pcvar_bool(g_amx_time_print_to_all) ? 0 : id, print_chat, "%L", LANG_PLAYER, "NO_T_LIMIT")
 	
-	return PLUGIN_CONTINUE
+	return get_pcvar_bool(g_amx_time_show_cmd_in_chat) ? PLUGIN_CONTINUE : PLUGIN_HANDLED
 }
 
 setTimeText(text[], len, tmlf, id)


### PR DESCRIPTION
Requested in #557.

Added 2 new cvars in `timeleft.sma`:
- amx_time_print_to_all 0/1 -- controls whether or not the messages will be pritned to all players or just to the player who issued the command
- amx_time_show_cmd_in_chat 0/1 -- controls whether or not the commands will be shown in the chat or not