### PR TITLE
Fix admin chat displaying the wrong language

### DIFF
--- a/plugins/adminchat.sma
+++ b/plugins/adminchat.sma
@@ -218,7 +218,7 @@ public cmdSayAdmin(id)
 	
 	get_players(players, inum, "ch")
 	
-	for (new bool:is_sender_admin = !!is_user_admin(id), i = 0; i < inum; ++i)
+	for (new bool:is_sender_admin = is_user_admin(id) != 0, i = 0; i < inum; ++i)
 	{
 		pl = players[i]
 

--- a/plugins/adminchat.sma
+++ b/plugins/adminchat.sma
@@ -217,9 +217,9 @@ public cmdSayAdmin(id)
 	log_message("^"%s<%d><%s><>^" triggered ^"amx_chat^" (text ^"%s^")", name, userid, authid, message[1])
 	
 	if (is_user_admin(id)) // no diff here if admins have g_AdminChatFlag access or not, but we don't want to print "PLAYER"
-		format(message, charsmax(message), "(%L) %s :  %s", LANG_PLAYER, "ADMIN", name, message[1])
+		format(message, charsmax(message), "(%l) %s :  %s", "ADMIN", name, message[1])
 	else
-		format(message, charsmax(message), "(%L) %s :  %s", LANG_PLAYER, "PLAYER", name, message[1])
+		format(message, charsmax(message), "(%l) %s :  %s", "PLAYER", name, message[1])
 
 	get_players(players, inum, "ch")
 	
@@ -227,7 +227,10 @@ public cmdSayAdmin(id)
 	{
 		pl = players[i]
 		if (pl == id || get_user_flags(pl) & g_AdminChatFlag)
+		{
+			SetGlobalTransTarget(pl)
 			client_print(pl, print_chat, "%s", message)
+		}
 	}
 	
 	return PLUGIN_HANDLED

--- a/plugins/adminchat.sma
+++ b/plugins/adminchat.sma
@@ -217,9 +217,9 @@ public cmdSayAdmin(id)
 	log_message("^"%s<%d><%s><>^" triggered ^"amx_chat^" (text ^"%s^")", name, userid, authid, message[1])
 	
 	if (is_user_admin(id)) // no diff here if admins have g_AdminChatFlag access or not, but we don't want to print "PLAYER"
-		format(message, charsmax(message), "(%L) %s :  %s", id, "ADMIN", name, message[1])
+		format(message, charsmax(message), "(%L) %s :  %s", LANG_PLAYER, "ADMIN", name, message[1])
 	else
-		format(message, charsmax(message), "(%L) %s :  %s", id, "PLAYER", name, message[1])
+		format(message, charsmax(message), "(%L) %s :  %s", LANG_PLAYER, "PLAYER", name, message[1])
 
 	get_players(players, inum, "ch")
 	

--- a/plugins/adminchat.sma
+++ b/plugins/adminchat.sma
@@ -216,23 +216,18 @@ public cmdSayAdmin(id)
 	log_amx("Chat: ^"%s<%d><%s><>^" chat ^"%s^"", name, userid, authid, message[1])
 	log_message("^"%s<%d><%s><>^" triggered ^"amx_chat^" (text ^"%s^")", name, userid, authid, message[1])
 	
-	if (is_user_admin(id)) // no diff here if admins have g_AdminChatFlag access or not, but we don't want to print "PLAYER"
-		format(message, charsmax(message), "(%l) %s :  %s", "ADMIN", name, message[1])
-	else
-		format(message, charsmax(message), "(%l) %s :  %s", "PLAYER", name, message[1])
-
 	get_players(players, inum, "ch")
 	
-	for (new i = 0; i < inum; ++i)
+	for (new bool:is_sender_admin = !!is_user_admin(id), i = 0; i < inum; ++i)
 	{
 		pl = players[i]
+
 		if (pl == id || get_user_flags(pl) & g_AdminChatFlag)
 		{
-			SetGlobalTransTarget(pl)
-			client_print(pl, print_chat, "%s", message)
+			client_print(pl, print_chat, "(%L) %s :  %s", pl, is_sender_admin ? "ADMIN" : "PLAYER", name, message[1])
 		}
 	}
-	
+
 	return PLUGIN_HANDLED
 }
 

--- a/plugins/adminchat.sma
+++ b/plugins/adminchat.sma
@@ -224,7 +224,7 @@ public cmdSayAdmin(id)
 
 		if (pl == id || get_user_flags(pl) & g_AdminChatFlag)
 		{
-			client_print(pl, print_chat, "(%L) %s :  %s", pl, is_sender_admin ? "ADMIN" : "PLAYER", name, message[1])
+			client_print(pl, print_chat, "(%l) %s :  %s", is_sender_admin ? "ADMIN" : "PLAYER", name, message[1])
 		}
 	}
 


### PR DESCRIPTION
This is an ancient bug with a very simple fix. The problem is that when you write in the admin chat (`say_team @`), your prefix is translated in your language for all players instead of translating it in the language of the player who reads the message.