### PR TITLE
Modernize pluginmenu.sma

### DIFF
--- a/plugins/lang/pluginmenu.txt
+++ b/plugins/lang/pluginmenu.txt
@@ -3,11 +3,11 @@ PLUGINCVARMENU_DESC = - displays the plugin cvar menu
 PLUGINCMDMENU_DESC = - displays the plugin command menu
 PLUGIN_NOT_RUNNING = Plugin %s is not running
 CVAR_NOT_CHANGED = Cvar not changed
-CVAR_PTR_ERROR = There was an error extracting the cvar pointer. (Name = "%s")
-CVAR_TYPE_NEW_VALUE = Type in the new value for %s, or !cancel to cancel
+CVAR_PTR_ERROR = There was an error extracting the cvar pointer (name = "%s")
+CVAR_TYPE_NEW_VALUE = Type in the new value for %s or !cancel to cancel
 CVARS = Cvars
 CMD_NAME_ERROR = There was an error extracting the command name
-CMD_TYPE_PARAMS = Type in the parameters for %s, or !cancel to cancel
+CMD_TYPE_PARAMS = Type in the parameters for %s or !cancel to cancel
 CMD_EXEC_NO_PARAMS = Command "%s" executed with no parameters
 EXEC_WITH_PARAMS = Execute with parameters
 EXEC_WITHOUT_PARAMS = Execute with no parameters
@@ -16,3 +16,22 @@ CMD_EXECUTED = Command "%s" executed with "%s"
 COMMANDS = Commands
 PLUGIN_CVAR_MENU = Plugin Cvar Menu
 PLUGIN_CMD_MENU = Plugin Command Menu
+
+[mk]
+PLUGINCVARMENU_DESC = - prikazhuva menu so cvarovi za pluginite
+PLUGINCMDMENU_DESC = - prikazhuva menu so komandi za pluginite
+PLUGIN_NOT_RUNNING = Pluginot %s ne raboti
+CVAR_NOT_CHANGED = Cvarot ne e promenen
+CVAR_PTR_ERROR = Se pojavi greshka pri izvlekuvanje na cvar pointerot (ime = "%s")
+CVAR_TYPE_NEW_VALUE = Vnesete ja novata vrednost za %s ili !cancel za da otkazhete
+CVARS = Cvarovi
+CMD_NAME_ERROR = Se pojavi greshka pri izvlekuvanjeto na imeto na komandata
+CMD_TYPE_PARAMS = Vnesete gi parametrite za %s ili !cancel za da otkazhete
+CMD_EXEC_NO_PARAMS = Komandata "%s" e izvrshena bez parametri
+EXEC_WITH_PARAMS = Izvrshi so parametri
+EXEC_WITHOUT_PARAMS = Izvrshi bez parametri
+CMD_NOT_EXECUTED = Komandata ne e izvrshena
+CMD_EXECUTED = Komandata "%s" e izvrshena so "%s"
+COMMANDS = Komandi
+PLUGIN_CVAR_MENU = Menu so cvarovi za pluginite
+PLUGIN_CMD_MENU = Menu so komandi za pluginite

--- a/plugins/lang/pluginmenu.txt
+++ b/plugins/lang/pluginmenu.txt
@@ -1,0 +1,18 @@
+[en]
+PLUGINCVARMENU_DESC = - displays the plugin cvar menu
+PLUGINCMDMENU_DESC = - displays the plugin command menu
+PLUGIN_NOT_RUNNING = Plugin %s is not running
+CVAR_NOT_CHANGED = Cvar not changed
+CVAR_PTR_ERROR = There was an error extracting the cvar pointer. (Name = "%s")
+CVAR_TYPE_NEW_VALUE = Type in the new value for %s, or !cancel to cancel
+CVARS = Cvars
+CMD_NAME_ERROR = There was an error extracting the command name
+CMD_TYPE_PARAMS = Type in the parameters for %s, or !cancel to cancel
+CMD_EXEC_NO_PARAMS = Command "%s" executed with no parameters
+EXEC_WITH_PARAMS = Execute with parameters
+EXEC_WITHOUT_PARAMS = Execute with no parameters
+CMD_NOT_EXECUTED = Command not executed
+CMD_EXECUTED = Command "%s" executed with "%s"
+COMMANDS = Commands
+PLUGIN_CVAR_MENU = Plugin Cvar Menu
+PLUGIN_CMD_MENU = Plugin Command Menu

--- a/plugins/lang/pluginmenu.txt
+++ b/plugins/lang/pluginmenu.txt
@@ -35,3 +35,22 @@ CMD_EXECUTED = Komandata "%s" e izvrshena so "%s"
 COMMANDS = Komandi
 PLUGIN_CVAR_MENU = Menu so cvarovi za pluginite
 PLUGIN_CMD_MENU = Menu so komandi za pluginite
+
+[bg]
+PLUGINCVARMENU_DESC = - pokazva menu s cvarove za pluginite
+PLUGINCMDMENU_DESC = - pokazva menu s komandi za pluginite
+PLUGIN_NOT_RUNNING = Pluginut %s ne raboti
+CVAR_NOT_CHANGED = Cvarut ne e promenen
+CVAR_PTR_ERROR = Poqvi se greshka pri izvlichaneto na cvar pointera (ime = "%s")
+CVAR_TYPE_NEW_VALUE = Vuvedete novata stoinost za %s ili !cancel za da otkajete
+CVARS = Cvarove
+CMD_NAME_ERROR = Poqvi se gresha pri izvlichaneto na imeto na komandata
+CMD_TYPE_PARAMS = Vuvedete parametrite za %s ili !cancel za da otkajete
+CMD_EXEC_NO_PARAMS = Komandata "%s" e izpulnena bez parametri
+EXEC_WITH_PARAMS = Izpulni s parametri
+EXEC_WITHOUT_PARAMS = Izpulni bez parametri
+CMD_NOT_EXECUTED = Komandata ne e izpulnena
+CMD_EXECUTED = Komandata "%s" e izpulnena s "%s"
+COMMANDS = Komandi
+PLUGIN_CVAR_MENU = Menu s cvarove za pluginite
+PLUGIN_CMD_MENU = Menu s komandi za pluginite

--- a/plugins/pluginmenu.sma
+++ b/plugins/pluginmenu.sma
@@ -30,7 +30,7 @@ new g_current_player_id[MAX_PLAYERS + 1];
 new g_current_page[MAX_PLAYERS + 1];
 
 // Menu function ID that the client is in
-new g_current_menu_function[MAX_PLAYERS + 1] = { -1,... };
+new g_current_menu_function[MAX_PLAYERS + 1] = { -1, ... };
 
 new g_current_command[MAX_PLAYERS + 1][32];
 new g_cvarmenu_cmdid;
@@ -40,7 +40,7 @@ new g_explicit_plugin[MAX_PLAYERS + 1];
 
 public plugin_init()
 {
-	register_plugin("Plugin Menu",AMXX_VERSION_STR,"AMXX Dev Team");
+	register_plugin("Plugin Menu", AMXX_VERSION_STR, "AMXX Dev Team");
 	
 	register_dictionary("common.txt");
 	register_dictionary("pausecfg.txt"); // Needed for PAUSE_COULDNT_FIND
@@ -48,12 +48,12 @@ public plugin_init()
 	g_cvarmenu_cmdid=register_clcmd("amx_plugincvarmenu", "CvarMenuCommand", ADMIN_CVAR, " - displays the plugin cvar menu");
 	g_cmdmenu_cmdid=register_clcmd("amx_plugincmdmenu", "CommandMenuCommand", ADMIN_MENU, " - displays the plugin command menu");
 	
-	register_clcmd("amx_changecvar","CommandChangeCvar");
-	register_clcmd("amx_executecmd","CommandExecuteCommand");
+	register_clcmd("amx_changecvar", "CommandChangeCvar");
+	register_clcmd("amx_executecmd", "CommandExecuteCommand");
 	
 	// Register global menu callbacks.
-	g_disabled_callback=menu_makecallback("AlwaysDisableCallback");
-	g_enabled_callback=menu_makecallback("AlwaysEnableCallback");
+	g_disabled_callback = menu_makecallback("AlwaysDisableCallback");
+	g_enabled_callback = menu_makecallback("AlwaysEnableCallback");
 }
 
 // Add these menus to the amxmodmenu
@@ -93,12 +93,12 @@ public addToMenuFront()
 // Reset all fields for each client as they connect.
 public client_connect(id)
 {
-	g_current_cvar[id]=0;
-	g_current_player_id[id]=0;
-	g_current_menu_function[id]=-1;
-	g_current_cvar_name[id][0]=0;
-	g_current_command[id][0]=0;
-	g_explicit_plugin[id]=-1;
+	g_current_cvar[id] = 0;
+	g_current_player_id[id] = 0;
+	g_current_menu_function[id] = -1;
+	g_current_cvar_name[id][0] = 0;
+	g_current_command[id][0] = 0;
+	g_explicit_plugin[id] = -1;
 	
 }
 
@@ -110,48 +110,48 @@ public client_connect(id)
  * @param Command		The function to pass to the handler.  It will be passed as "PLID Command".
  * @param Callback		Function to call for each plugin to be listed.  Displays a number next to it (how many cvars, etc.)
  */
-stock DisplayPluginMenu(id,const menu_text[], const Handler[], const Command[], const Callback[])
+stock DisplayPluginMenu(id, const menu_text[], const Handler[], const Command[], const Callback[])
 {
-	new menu=menu_create(menu_text,Handler);
+	new menu=menu_create(menu_text, Handler);
 	
 	
 	new plugin_state[32];
 	new plugin_name[64];
-	new func=get_func_id(Callback);
+	new func = get_func_id(Callback);
 	new tally;
 	new plugincmd[64];
 	new menu_text[64];
-	for (new i=0, max=get_pluginsnum();
+	for (new i = 0, max = get_pluginsnum();
 		 i<max;
 		 i++)
 	{
-		if (callfunc_begin_i(func,-1)==1)
+		if (callfunc_begin_i(func,-1) == 1)
 		{
 			callfunc_push_int(i); // push the plid
-			if ((tally=callfunc_end())>0)
+			if ((tally = callfunc_end()) > 0)
 			{
-				get_plugin(i,"",0,plugin_name,charsmax(plugin_name),"",0,"",0,plugin_state,charsmax(plugin_state));
+				get_plugin(i, "", 0, plugin_name, charsmax(plugin_name), "", 0, "", 0, plugin_state, charsmax(plugin_state));
 						
 				// Command syntax is: "# Function", # being plugin ID, function being public function to call.
-				formatex(plugincmd,charsmax(plugincmd),"%d %s",i,Command);
-				formatex(menu_text,charsmax(menu_text),"%s - %d",plugin_name,tally);
+				formatex(plugincmd, charsmax(plugincmd), "%d %s", i, Command);
+				formatex(menu_text, charsmax(menu_text), "%s - %d", plugin_name, tally);
 				// If the plugin is running, add this as an activated menu item.
-				if (strcmp(plugin_state,"running",true)==0 ||
-					strcmp(plugin_state,"debug",  true)==0)
+				if (strcmp(plugin_state, "running", true) == 0 ||
+					strcmp(plugin_state, "debug", true) == 0)
 				{
-					menu_additem(menu,menu_text,plugincmd,g_enabled_callback);
+					menu_additem(menu, menu_text, plugincmd, g_enabled_callback);
 				}
 				else
 				{
-					menu_additem(menu,menu_text,"",_,g_disabled_callback);
+					menu_additem(menu, menu_text, "", _, g_disabled_callback);
 				}
 			}
 		}
 	}
 
-	menu_setprop(menu,MPROP_NUMBER_COLOR,"\y");
-	menu_setprop(menu,MPROP_EXIT,MEXIT_ALL);
-	menu_display(id,menu,0);
+	menu_setprop(menu, MPROP_NUMBER_COLOR, "\y");
+	menu_setprop(menu, MPROP_EXIT, MEXIT_ALL);
+	menu_display(id, menu, 0);
 
 }
 
@@ -166,43 +166,43 @@ stock bool:GetPlidForValidPlugins(id, &plid)
 {
 	// If arguments have been passed, then we were given
 	// a specific plugin to examine.
-	if (read_argc()>1)
+	if (read_argc() > 1)
 	{ 
 		// Yes, we were provided a plugin.
 		new target_plugin[64];
-		read_argv(1,target_plugin,charsmax(target_plugin));
+		read_argv(1, target_plugin, charsmax(target_plugin));
 		
 		new buffer_name[64];
 		new buffer_file[64];
 		new buffer_state[64];
 		// Scan for the plugin ID.
-		for (new i=0, max=get_pluginsnum();
-			 i<max;
+		for (new i = 0, max = get_pluginsnum();
+			 i < max;
 			 i++)
 		{
-			get_plugin(i,buffer_file,charsmax(buffer_file),buffer_name,charsmax(buffer_name),"",0,"",0,buffer_state,charsmax(buffer_state));
+			get_plugin(i, buffer_file, charsmax(buffer_file), buffer_name, charsmax(buffer_name), "", 0, "", 0, buffer_state, charsmax(buffer_state));
 			
-			if (strcmp(buffer_file,target_plugin,true) != 0||
-				strcmp(buffer_name,target_plugin,true) != 0)
+			if (strcmp(buffer_file, target_plugin, true) != 0 ||
+				strcmp(buffer_name, target_plugin, true) != 0)
 			{
 				// We have a match.
 				
 				// Check the status of the plugin.  If it's anything other than "running" or "debug" fail.
-				if (strcmp(buffer_state,"running") != 0 &&
-					strcmp(buffer_state,"debug")   != 0)
+				if (strcmp(buffer_state, "running") != 0 &&
+					strcmp(buffer_state, "debug")   != 0)
 				{
 					// TODO: ML This
-					console_print(id,"Plugin ^"%s^" is not running.",buffer_file);
+					console_print(id, "Plugin ^"%s^" is not running.", buffer_file);
 					// Return a failed state.
 					return false;
 				}
-				plid=i;
+				plid = i;
 				break;
 			}
 		}
 		
 		// If the plugin was not found, then tell them there was an error.
-		if (plid==-1)
+		if (plid == -1)
 		{
 			console_print(id, "%L", id, "PAUSE_COULDNT_FIND", target_plugin);
 			
@@ -221,15 +221,15 @@ stock bool:GetPlidForValidPlugins(id, &plid)
  */
 public GetNumberOfCvarsForPlid(plid)
 {
-	new count=0;
+	new count = 0;
 	new cvar_plid;
-	for (new i=0, max=get_plugins_cvarsnum();
-		 i<max;
+	for (new i = 0, max = get_plugins_cvarsnum();
+		 i < max;
 		 i++)
 	{
 		get_plugins_cvar(i, "", 0,_, cvar_plid, _);
 		
-		if (cvar_plid==plid)
+		if (cvar_plid == plid)
 		{
 			count++;
 		}
@@ -244,13 +244,13 @@ public GetNumberOfCvarsForPlid(plid)
  */
 public GetNumberOfCmdsForPlid(plid)
 {
-	new count=0;
+	new count = 0;
 	
-	for (new i=0, max=get_concmdsnum(-1,-1);
-		 i<max;
+	for (new i = 0, max = get_concmdsnum(-1,-1);
+		 i < max;
 		 i++)
 	{
-		if (get_concmd_plid(i,-1,-1)==plid)
+		if (get_concmd_plid(i, -1, -1) == plid)
 		{
 			count++;
 		}
@@ -263,12 +263,12 @@ public GetNumberOfCmdsForPlid(plid)
  * Whether or not the client has access to modify this cvar.
  *
  * @param id			The admin id.
- * @param Cvar			The name of the cvar to be checked.
+ * @param cvar			The name of the cvar to be checked.
  * @return				True if the client has access, false otherwise.
  */
-stock bool:CanIModifyCvar(id, const Cvar[])
+stock bool:CanIModifyCvar(id, const cvar[])
 {
-	new user_flags=get_user_flags(id);
+	new user_flags = get_user_flags(id);
 	// If the user has rcon access don't bother checking anything.
 	if (user_flags & ADMIN_RCON)
 	{
@@ -276,13 +276,13 @@ stock bool:CanIModifyCvar(id, const Cvar[])
 	}
 	
 	// If the cvar is "sv_password" (somehow), then check access.
-	if (equali(Cvar,"sv_password") && user_flags & ADMIN_PASSWORD)
+	if (equali(cvar, "sv_password") && user_flags & ADMIN_PASSWORD)
 	{
 		return true;
 	}
 	
 	// Check to see if the cvar is flagged as protected.
-	if (get_cvar_flags(Cvar) & FCVAR_PROTECTED)
+	if (get_cvar_flags(cvar) & FCVAR_PROTECTED)
 	{
 		// non-rcon user trying to modify a protected cvar.
 		return false;
@@ -320,11 +320,11 @@ public AlwaysEnableCallback(playerid, menuid, itemid)
  */
 public PluginMenuSelection(id, menu, item)
 {
-	if (item==MENU_EXIT)
+	if (item == MENU_EXIT)
 	{
 		menu_destroy(menu);
 	}
-	if (item<0)
+	if (item < 0)
 	{
 		return PLUGIN_HANDLED;
 	}
@@ -338,31 +338,31 @@ public PluginMenuSelection(id, menu, item)
 	// Note the menu is destroyed BEFORE the command
 	// gets executed.
 	// The command retrieved is in the format: "PLID Command"
-	menu_item_getinfo(menu, item, dummy[0], command, charsmax(command),dummy,0,dummy[0]);
+	menu_item_getinfo(menu, item, dummy[0], command, charsmax(command), dummy, 0, dummy[0]);
 	
 	
-	new plid=str_to_num(command);
+	new plid = str_to_num(command);
 	new function[32];
 	
-	for (new i=0;i<charsmax(command);i++)
+	for (new i = 0; i < charsmax(command); i++)
 	{
-		if (command[i]==' ')
+		if (command[i] == ' ')
 		{
 			// we're at the break. move up one space.
 			i++;
-			copy(function,charsmax(function),command[i]);
+			copy(function, charsmax(function), command[i]);
 			break;
 		}
 	}
 	
 	menu_destroy(menu);
 	
-	new funcid=get_func_id(function);
-	if (funcid != -1 && callfunc_begin_i(funcid)==1)
+	new funcid = get_func_id(function);
+	if (funcid != -1 && callfunc_begin_i(funcid) == 1)
 	{
-		g_current_page[id]=0;
-		g_current_player_id[id]=plid;
-		g_current_menu_function[id]=funcid;
+		g_current_page[id] = 0;
+		g_current_player_id[id] = plid;
+		g_current_menu_function[id] = funcid;
 		callfunc_push_int(id);
 		callfunc_push_int(plid);
 		callfunc_push_int(0);
@@ -382,38 +382,38 @@ public CommandChangeCvar(id)
 	// All access checks are done before this command is called.
 	// So if the client has no pcvar pointer in his array slot
 	// then just ignore the command.
-	if (g_current_cvar[id]==0)
+	if (g_current_cvar[id] == 0)
 	{
 		return PLUGIN_CONTINUE;
 	}
 	
 	new args[256];
 	
-	read_args(args,charsmax(args));
+	read_args(args, charsmax(args));
 	
 	remove_quotes(args);
 	
-	if (equali(args,"!cancel",7))
+	if (equali(args, "!cancel", 7))
 	{
 		// The client didn't want to change this cvar.
-		client_print(id,print_chat,"[AMXX] Cvar not changed.");
+		client_print(id, print_chat, "[AMXX] Cvar not changed.");
 	}
 	else
 	{
 		// Changed to set_cvar_* for 1.76 tests
 		
-		new pointer=g_current_cvar[id];
-		set_pcvar_string(g_current_cvar[id],args);
+		new pointer = g_current_cvar[id];
+		set_pcvar_string(g_current_cvar[id], args);
 		
-		client_print(id,print_chat,"[AMXX] Cvar ^"%s^" changed to ^"%s^"",g_current_cvar_name[id],args);
+		client_print(id, print_chat, "[AMXX] Cvar ^"%s^" changed to ^"%s^"", g_current_cvar_name[id], args);
 		
 		// Copy of admincmd's global output.
 		
 		new name[MAX_NAME_LENGTH];
 		new authid[40];
 		
-		get_user_name(id,name,charsmax(name));
-		get_user_authid(id,authid,charsmax(authid));
+		get_user_name(id, name, charsmax(name));
+		get_user_authid(id, authid, charsmax(authid));
 		
 		log_amx("Cmd: ^"%s<%d><%s><>^" set cvar (name ^"%s^") (value ^"%s^")", name, get_user_userid(id), authid, g_current_cvar_name[id], args);
 	
@@ -439,7 +439,7 @@ public CommandChangeCvar(id)
 	}
 	
 	// Now redraw the menu for the client
-	if (g_current_menu_function[id]!=-1 && callfunc_begin_i(g_current_menu_function[id])==1)
+	if (g_current_menu_function[id] != -1 && callfunc_begin_i(g_current_menu_function[id]) == 1)
 	{
 		callfunc_push_int(id);
 		callfunc_push_int(g_current_player_id[id]);
@@ -460,24 +460,24 @@ public CommandChangeCvar(id)
 public CvarMenuSelection(id, menu, item)
 {
 	
-	if (item==MENU_EXIT)
+	if (item == MENU_EXIT)
 	{
 		menu_destroy(menu);
 		
-		if (g_explicit_plugin[id]==-1)
+		if (g_explicit_plugin[id] == -1)
 		{
 			DisplayPluginMenuDefault(id);
 		}
 	}
-	else if (item==MENU_BACK)
+	else if (item == MENU_BACK)
 	{
 		--g_current_page[id];
-		client_print(id,print_chat,"MENU_BACK");
+		client_print(id, print_chat, "MENU_BACK");
 	}
-	else if (item==MENU_MORE)
+	else if (item == MENU_MORE)
 	{
 		++g_current_page[id];
-		client_print(id,print_chat,"MENU_MORE");
+		client_print(id, print_chat, "MENU_MORE");
 	}
 	else
 	{
@@ -485,29 +485,29 @@ public CvarMenuSelection(id, menu, item)
 		new command[32];
 		new dummy[1];
 		// pcvar pointer is stored in command, extract the name of the cvar from the name field.
-		menu_item_getinfo(menu, item, dummy[0], command, charsmax(command),cvar_name,charsmax(cvar_name),dummy[0]);
+		menu_item_getinfo(menu, item, dummy[0], command, charsmax(command), cvar_name, charsmax(cvar_name), dummy[0]);
 		
-		g_current_cvar[id]=str_to_num(command);
+		g_current_cvar[id] = str_to_num(command);
 		
-		if (g_current_cvar[id]==0) // This should never happen, but just incase..
+		if (g_current_cvar[id] == 0) // This should never happen, but just incase..
 		{
-			client_print(id,print_chat,"[AMXX] There was an error extracting the cvar pointer. (Name=^"%s^")",cvar_name);
+			client_print(id, print_chat, "[AMXX] There was an error extracting the cvar pointer. (Name=^"%s^")", cvar_name);
 			return PLUGIN_HANDLED;
 		}
 		// TODO: ML this
 		
 		// Scan up "cvar_name" and stop at the first space
-		for (new i=0;i<charsmax(cvar_name);i++)
+		for (new i = 0; i < charsmax(cvar_name); i++)
 		{
-			if (cvar_name[i]==' ')
+			if (cvar_name[i] == ' ')
 			{
-				cvar_name[i]='^0';
+				cvar_name[i]= '^0';
 				break;
 			}
 		}
-		copy(g_current_cvar_name[id],charsmax(g_current_cvar_name[]),cvar_name);
-		client_print(id,print_chat,"[AMXX] Type in the new value for %s, or !cancel to cancel.",cvar_name);
-		client_cmd(id,"messagemode amx_changecvar");
+		copy(g_current_cvar_name[id], charsmax(g_current_cvar_name[]), cvar_name);
+		client_print(id, print_chat, "[AMXX] Type in the new value for %s, or !cancel to cancel.", cvar_name);
+		client_cmd(id, "messagemode amx_changecvar");
 		
 		menu_destroy(menu);
 	}
@@ -525,11 +525,11 @@ public DisplayCvarMenu(id, plid, page)
 {
 	new plugin_name[32];
 	new menu_title[64];
-	get_plugin(plid,"",0,plugin_name,charsmax(plugin_name),"",0,"",0,"",0);
+	get_plugin(plid, "", 0, plugin_name, charsmax(plugin_name), "", 0, "", 0, "", 0);
 	
-	formatex(menu_title,charsmax(menu_title),"%s Cvars:",plugin_name);
+	formatex(menu_title, charsmax(menu_title), "%s Cvars:", plugin_name);
 	
-	new menu=menu_create(menu_title,"CvarMenuSelection");
+	new menu = menu_create(menu_title, "CvarMenuSelection");
 	
 	new cvar[64];
 	new cvar_plid;
@@ -537,34 +537,34 @@ public DisplayCvarMenu(id, plid, page)
 	new cvar_data[32];
 	new cvar_pointer;
 	
-	for (new i=0, max=get_plugins_cvarsnum();
-		 i<max;
+	for (new i = 0, max = get_plugins_cvarsnum();
+		 i < max;
 		 i++)
 	{
 		get_plugins_cvar(i, cvar, charsmax(cvar),_, cvar_plid, cvar_pointer);
 		
-		if (cvar_plid==plid)
+		if (cvar_plid == plid)
 		{
-			if (CanIModifyCvar(id,cvar))
+			if (CanIModifyCvar(id, cvar))
 			{
-				get_pcvar_string(cvar_pointer,cvar_data,charsmax(cvar_data));
-				formatex(cvar_text,charsmax(cvar_text),"%s - %s",cvar,cvar_data);
+				get_pcvar_string(cvar_pointer, cvar_data, charsmax(cvar_data));
+				formatex(cvar_text, charsmax(cvar_text), "%s - %s", cvar, cvar_data);
 				
 				// Now store the pcvar data in cvar
-				num_to_str(cvar_pointer,cvar,charsmax(cvar));
-				menu_additem(menu,cvar_text,cvar,_,g_enabled_callback);
+				num_to_str(cvar_pointer, cvar, charsmax(cvar));
+				menu_additem(menu, cvar_text, cvar,_ ,g_enabled_callback);
 			}
 			else
 			{
-				menu_additem(menu,cvar,"",_,g_disabled_callback);
+				menu_additem(menu, cvar, "",_, g_disabled_callback);
 			}
 			
 		}
 	}
 	
-	menu_setprop(menu,MPROP_EXIT,MEXIT_ALL);
-	menu_setprop(menu,MPROP_NUMBER_COLOR,"\y");
-	menu_display(id,menu,page);
+	menu_setprop(menu, MPROP_EXIT, MEXIT_ALL);
+	menu_setprop(menu, MPROP_NUMBER_COLOR, "\y");
+	menu_display(id, menu, page);
 
 }
 /**
@@ -576,33 +576,33 @@ public DisplayCvarMenu(id, plid, page)
  */
 public CvarMenuCommand(id, level, cid)
 {
-	if (!cmd_access(id,level,cid,0))
+	if (!cmd_access(id, level, cid, 0))
 	{
 		return PLUGIN_HANDLED;
 	}
 	
 	// This is which plugin to display.  -1 means display all plugins in a list.
-	new plid=-1;
+	new plid = -1;
 	
-	if (GetPlidForValidPlugins(id,plid)!=true)
+	if (GetPlidForValidPlugins(id, plid) != true)
 	{
 		// If GetPlidForValidPlugins returns false then it failed to find the plugin.
 		return PLUGIN_HANDLED;
 	}
 	
 	// Check if we were passed a specific plugin to display or not.
-	if (plid==-1)
+	if (plid == -1)
 	{
-		g_explicit_plugin[id]=-1;
+		g_explicit_plugin[id] = -1;
 		// We need to display a list of the plugins, instead of a specific plugin.
-		DisplayPluginMenu(id,"Plugin Cvar Menu:", "PluginMenuSelection","DisplayCvarMenu","GetNumberOfCvarsForPlid");
+		DisplayPluginMenu(id, "Plugin Cvar Menu:", "PluginMenuSelection", "DisplayCvarMenu", "GetNumberOfCvarsForPlid");
 	}
 	else
 	{
-		g_explicit_plugin[id]=plid;
-		g_current_player_id[id]=plid;
-		g_current_page[id]=0;
-		DisplayCvarMenu(id,plid,0);
+		g_explicit_plugin[id] = plid;
+		g_current_player_id[id] = plid;
+		g_current_page[id] = 0;
+		DisplayCvarMenu(id, plid, 0);
 	}
 	return PLUGIN_HANDLED;
 }
@@ -613,12 +613,12 @@ public CvarMenuCommand(id, level, cid)
  * @param menu		Menu handle.
  * @param item		Item that was selected.
  */
-public SpecificCommandHandler(id,menu,item)
+public SpecificCommandHandler(id, menu, item)
 {
 	// Exit was called, return to the previous menu.
-	if (item<0)
+	if (item < 0)
 	{	
-		if (g_current_menu_function[id]!=-1 && callfunc_begin_i(g_current_menu_function[id])==1)
+		if (g_current_menu_function[id] != -1 && callfunc_begin_i(g_current_menu_function[id]) == 1)
 		{
 			callfunc_push_int(id);
 			callfunc_push_int(g_current_player_id[id]);
@@ -631,36 +631,36 @@ public SpecificCommandHandler(id,menu,item)
 	}
 	
 	new dummy[1];
-	if (item==0)  // "With params"
+	if (item == 0)  // "With params"
 	{
-		menu_item_getinfo(menu, item, dummy[0], g_current_command[id], charsmax(g_current_command[]),"",0,dummy[0]);
-		if (g_current_command[id][0]==0) // This should never happen, but just incase..
+		menu_item_getinfo(menu, item, dummy[0], g_current_command[id], charsmax(g_current_command[]), "", 0, dummy[0]);
+		if (g_current_command[id][0] == 0) // This should never happen, but just incase..
 		{
-			client_print(id,print_chat,"[AMXX] There was an error extracting the command name.");
+			client_print(id, print_chat, "[AMXX] There was an error extracting the command name.");
 			return PLUGIN_HANDLED;
 		}
 		// TODO: ML this
 		
-		client_print(id,print_chat,"[AMXX] Type in the parameters for %s, or !cancel to cancel.",g_current_command[id]);
-		client_cmd(id,"messagemode amx_executecmd");
+		client_print(id, print_chat, "[AMXX] Type in the parameters for %s, or !cancel to cancel.", g_current_command[id]);
+		client_cmd(id, "messagemode amx_executecmd");
 		
 		menu_destroy(menu);
 		
 		return PLUGIN_HANDLED; // Don't return to original menu immediately!
 	}
-	else if (item==1) // "No params"
+	else if (item == 1) // "No params"
 	{
-		menu_item_getinfo(menu, item, dummy[0], g_current_command[id], charsmax(g_current_command[]),"",0,dummy[0]);
-		if (g_current_command[id][0]==0) // This should never happen, but just incase..
+		menu_item_getinfo(menu, item, dummy[0], g_current_command[id], charsmax(g_current_command[]), "", 0, dummy[0]);
+		if (g_current_command[id][0] == 0) // This should never happen, but just incase..
 		{
-			client_print(id,print_chat,"[AMXX] There was an error extracting the command name.");
+			client_print(id, print_chat, "[AMXX] There was an error extracting the command name.");
 			return PLUGIN_HANDLED;
 		}
 		// TODO: ML this
 
 		// Now redraw the menu for the client BEFORE the command is executed, incase
 		// that menu brings up a menu of its own.
-		if (g_current_menu_function[id]!=-1 && callfunc_begin_i(g_current_menu_function[id])==1)
+		if (g_current_menu_function[id] != -1 && callfunc_begin_i(g_current_menu_function[id]) == 1)
 		{
 			callfunc_push_int(id);
 			callfunc_push_int(g_current_player_id[id]);
@@ -669,8 +669,8 @@ public SpecificCommandHandler(id,menu,item)
 		}
 		menu_destroy(menu);
 		
-		client_cmd(id,"%s",g_current_command[id]);
-		client_print(id,print_chat,"[AMXX] Command ^"%s^" executed with no parameters",g_current_command[id]);
+		client_cmd(id, "%s", g_current_command[id]);
+		client_print(id, print_chat, "[AMXX] Command ^"%s^" executed with no parameters", g_current_command[id]);
 		
 		return PLUGIN_HANDLED;
 	}
@@ -687,7 +687,7 @@ public SpecificCommandHandler(id,menu,item)
  * @param id		The client to display the menu to.
  * @param cid		The command id to display.
  */
-stock DisplaySpecificCommand(id,cid)
+stock DisplaySpecificCommand(id, cid)
 {
 	new command_name[64];
 	new command_desc[128];
@@ -695,22 +695,22 @@ stock DisplaySpecificCommand(id,cid)
 	new command_access;
 	new menu;
 	
-	get_concmd(cid,command_name,charsmax(command_name),command_access, command_desc, charsmax(command_desc), -1, -1);
+	get_concmd(cid, command_name, charsmax(command_name), command_access, command_desc, charsmax(command_desc), -1, -1);
 	
-	if (command_desc[0]!='^0')
+	if (command_desc[0] != '^0')
 	{
-		formatex(command_title,charsmax(command_title),"%s^n%s",command_name,command_desc);
-		menu=menu_create(command_title,"SpecificCommandHandler");
+		formatex(command_title, charsmax(command_title), "%s^n%s", command_name, command_desc);
+		menu=menu_create(command_title, "SpecificCommandHandler");
 	}
 	else
 	{
-		menu=menu_create(command_name,"SpecificCommandHandler");
+		menu=menu_create(command_name, "SpecificCommandHandler");
 	}
-	menu_additem(menu,"Execute with parameters.",command_name,_,g_enabled_callback);
-	menu_additem(menu,"Execute with no parameters.",command_name,_,g_enabled_callback);
+	menu_additem(menu, "Execute with parameters.", command_name, _, g_enabled_callback);
+	menu_additem(menu, "Execute with no parameters.", command_name, _, g_enabled_callback);
 	
-	menu_setprop(menu,MPROP_NUMBER_COLOR,"\y");
-	menu_display(id,menu,0);
+	menu_setprop(menu, MPROP_NUMBER_COLOR, "\y");
+	menu_display(id, menu, 0);
 }
 
 /**
@@ -721,24 +721,24 @@ stock DisplaySpecificCommand(id,cid)
 public CommandExecuteCommand(id)
 {
 	// If they had no command stored, then just ignore it entirely.
-	if (g_current_command[id][0]=='^0')
+	if (g_current_command[id][0] == '^0')
 	{
 		return PLUGIN_CONTINUE;
 	}
 	
 	new args[256];
 	
-	read_args(args,charsmax(args));
+	read_args(args, charsmax(args));
 	
 	remove_quotes(args);
 	
-	if (equali(args,"!cancel",7))
+	if (equali(args, "!cancel", 7))
 	{
 		// The client didn't want to execute this command.
-		client_print(id,print_chat,"[AMXX] Command not executed.");
+		client_print(id, print_chat, "[AMXX] Command not executed.");
 		
 		// Now redraw the menu for the client
-		if (g_current_menu_function[id]!=-1 && callfunc_begin_i(g_current_menu_function[id])==1)
+		if (g_current_menu_function[id] != -1 && callfunc_begin_i(g_current_menu_function[id]) == 1)
 		{
 			callfunc_push_int(id);
 			callfunc_push_int(g_current_player_id[id]);
@@ -750,10 +750,10 @@ public CommandExecuteCommand(id)
 	else
 	{
 		// TODO: ML
-		client_print(id,print_chat,"[AMXX] Command ^"%s^" executed with ^"%s^"",g_current_command[id],args);
+		client_print(id, print_chat, "[AMXX] Command ^"%s^" executed with ^"%s^"", g_current_command[id], args);
 
 		// Now redraw the menu for the client
-		if (g_current_menu_function[id]!=-1 && callfunc_begin_i(g_current_menu_function[id])==1)
+		if (g_current_menu_function[id] != -1 && callfunc_begin_i(g_current_menu_function[id]) == 1)
 		{
 			callfunc_push_int(id);
 			callfunc_push_int(g_current_player_id[id]);
@@ -762,7 +762,7 @@ public CommandExecuteCommand(id)
 		}
 		
 		// Execute the command on the client.
-		client_cmd(id,"%s %s",g_current_command[id],args);
+		client_cmd(id, "%s %s", g_current_command[id], args);
 	}
 	
 	
@@ -779,38 +779,38 @@ public CommandExecuteCommand(id)
  */
 public CommandMenuSelection(id, menu, item)
 {
-	if (item==MENU_EXIT)
+	if (item == MENU_EXIT)
 	{
 		menu_destroy(menu);
 
 		// If the player did not explicitly specify a plugin, return them to the 
 		// plugin selection menu.
 		
-		if (g_explicit_plugin[id]==-1)
+		if (g_explicit_plugin[id] == -1)
 		{
-			client_cmd(id,"amx_plugincmdmenu");
+			client_cmd(id, "amx_plugincmdmenu");
 		}
 	}
-	else if (item==MENU_BACK)
+	else if (item == MENU_BACK)
 	{
 		--g_current_page[id];
-		client_print(id,print_chat,"MENU_BACK");
+		client_print(id, print_chat, "MENU_BACK");
 	}
-	else if (item==MENU_MORE)
+	else if (item == MENU_MORE)
 	{
 		++g_current_page[id];
-		client_print(id,print_chat,"MENU_MORE");
+		client_print(id, print_chat, "MENU_MORE");
 	}
 	else
 	{
 		new command[32];
 		new dummy[1];
 		// pcvar pointer is stored in command, extract the name of the cvar from the name field.
-		menu_item_getinfo(menu, item, dummy[0], command, charsmax(command),"",0,dummy[0]);
+		menu_item_getinfo(menu, item, dummy[0], command, charsmax(command), "", 0, dummy[0]);
 		
 		menu_destroy(menu);
 		
-		DisplaySpecificCommand(id,str_to_num(command));
+		DisplaySpecificCommand(id, str_to_num(command));
 	}
 	
 	return PLUGIN_HANDLED;
@@ -824,7 +824,7 @@ public CommandMenuSelection(id, menu, item)
 stock bool:IsDisplayableCmd(const command[])
 {
 	// Block "say" and "say_team"
-	if (equal(command,"say",3))
+	if (equal(command, "say", 3))
 	{
 		return false;
 	}
@@ -842,46 +842,46 @@ public DisplayCmdMenu(id, plid, page)
 {
 	new plugin_name[32];
 	new menu_title[64];
-	get_plugin(plid,"",0,plugin_name,charsmax(plugin_name),"",0,"",0,"",0);
+	get_plugin(plid, "", 0, plugin_name, charsmax(plugin_name), "", 0, "", 0, "", 0);
 	
-	formatex(menu_title,charsmax(menu_title),"%s Commands:",plugin_name);
+	formatex(menu_title, charsmax(menu_title), "%s Commands:", plugin_name);
 	
-	new menu=menu_create(menu_title,"CommandMenuSelection");
+	new menu = menu_create(menu_title, "CommandMenuSelection");
 	
 	new command[64];
 	new cid_string[32];
 	new command_access;
-	new userflags=get_user_flags(id);
-	new bool:isadmin=bool:is_user_admin(id);
+	new userflags = get_user_flags(id);
+	new bool:isadmin = bool:is_user_admin(id);
 	
 	
-	for (new i=0, max=get_concmdsnum(-1,-1);
-		 i<max;
+	for (new i = 0, max = get_concmdsnum(-1, -1);
+		 i < max;
 		 i++)
 	{
-		if (get_concmd_plid(i,-1,-1)==plid)
+		if (get_concmd_plid(i, -1, -1) == plid)
 		{
-			get_concmd(i,command,charsmax(command),command_access, "",0, -1, -1);
+			get_concmd(i, command, charsmax(command), command_access, "", 0, -1, -1);
 			
 			if (IsDisplayableCmd(command))
 			{
-				if ( userflags & command_access || 
-					(command_access==ADMIN_ADMIN && isadmin) ||
-					 command_access==ADMIN_USER ||
-					 command_access==ADMIN_ALL)
+				if (userflags & command_access || 
+					(command_access == ADMIN_ADMIN && isadmin) ||
+					 command_access == ADMIN_USER ||
+					 command_access == ADMIN_ALL)
 				{
-					num_to_str(i,cid_string,charsmax(cid_string));
-					menu_additem(menu,command,cid_string,0,g_enabled_callback);
+					num_to_str(i, cid_string, charsmax(cid_string));
+					menu_additem(menu, command, cid_string, 0, g_enabled_callback);
 				}
 				else
 				{
-					menu_additem(menu,command,"",0,g_disabled_callback);
+					menu_additem(menu, command, "", 0, g_disabled_callback);
 				}
 			}
 		}
 	}
-	menu_setprop(menu,MPROP_NUMBER_COLOR,"\y");
-	menu_display(id,menu,page);
+	menu_setprop(menu, MPROP_NUMBER_COLOR, "\y");
+	menu_display(id, menu, page);
 
 }
 /**
@@ -893,38 +893,38 @@ public DisplayCmdMenu(id, plid, page)
  */
 public CommandMenuCommand(id, level, cid)
 {
-	if (!cmd_access(id,level,cid,0))
+	if (!cmd_access(id, level, cid, 0))
 	{
 		return PLUGIN_HANDLED;
 	}
 	
 	// This is which plugin to display.  -1 means display all plugins in a list.
-	new plid=-1;
+	new plid = -1;
 	
-	if (GetPlidForValidPlugins(id,plid)!=true)
+	if (GetPlidForValidPlugins(id, plid) != true)
 	{
 		// If GetPlidForValidPlugins returns false then it failed to find the plugin.
 		return PLUGIN_HANDLED;
 	}
 	
 	// Check if we were passed a specific plugin to display or not.
-	if (plid==-1)
+	if (plid == -1)
 	{
 		// We need to display a list of the plugins, instead of a specific plugin.
-		g_explicit_plugin[id]=-1;
+		g_explicit_plugin[id] = -1;
 		DisplayPluginMenuDefault(id);
 	}
 	else
 	{
-		g_explicit_plugin[id]=plid;
-		g_current_player_id[id]=plid;
-		g_current_page[id]=0;
-		DisplayCmdMenu(id,plid,0);
+		g_explicit_plugin[id] = plid;
+		g_current_player_id[id] = plid;
+		g_current_page[id] = 0;
+		DisplayCmdMenu(id, plid, 0);
 	}
 	return PLUGIN_HANDLED;
 }
 
 DisplayPluginMenuDefault(id)
 {
-	DisplayPluginMenu(id,"Plugin Command Menu:", "PluginMenuSelection","DisplayCmdMenu","GetNumberOfCmdsForPlid");
+	DisplayPluginMenu(id, "Plugin Command Menu:", "PluginMenuSelection", "DisplayCmdMenu", "GetNumberOfCmdsForPlid");
 }

--- a/plugins/pluginmenu.sma
+++ b/plugins/pluginmenu.sma
@@ -45,8 +45,8 @@ public plugin_init()
 	register_dictionary("common.txt");
 	register_dictionary("pausecfg.txt"); // Needed for PAUSE_COULDNT_FIND
 	
-	g_cvarmenu_cmdid=register_clcmd("amx_plugincvarmenu", "CvarMenuCommand", ADMIN_CVAR, " - displays the plugin cvar menu");
-	g_cmdmenu_cmdid=register_clcmd("amx_plugincmdmenu", "CommandMenuCommand", ADMIN_MENU, " - displays the plugin command menu");
+	g_cvarmenu_cmdid = register_clcmd("amx_plugincvarmenu", "CvarMenuCommand", ADMIN_CVAR, " - displays the plugin cvar menu");
+	g_cmdmenu_cmdid = register_clcmd("amx_plugincmdmenu", "CommandMenuCommand", ADMIN_MENU, " - displays the plugin command menu");
 	
 	register_clcmd("amx_changecvar", "CommandChangeCvar");
 	register_clcmd("amx_executecmd", "CommandExecuteCommand");
@@ -122,10 +122,10 @@ stock DisplayPluginMenu(id, const menu_text[], const Handler[], const Command[],
 	new plugincmd[64];
 	new menu_text[64];
 	for (new i = 0, max = get_pluginsnum();
-		 i<max;
+		 i < max;
 		 i++)
 	{
-		if (callfunc_begin_i(func,-1) == 1)
+		if (callfunc_begin_i(func, -1) == 1)
 		{
 			callfunc_push_int(i); // push the plid
 			if ((tally = callfunc_end()) > 0)
@@ -227,7 +227,7 @@ public GetNumberOfCvarsForPlid(plid)
 		 i < max;
 		 i++)
 	{
-		get_plugins_cvar(i, "", 0,_, cvar_plid, _);
+		get_plugins_cvar(i, "", 0, _, cvar_plid, _);
 		
 		if (cvar_plid == plid)
 		{
@@ -541,7 +541,7 @@ public DisplayCvarMenu(id, plid, page)
 		 i < max;
 		 i++)
 	{
-		get_plugins_cvar(i, cvar, charsmax(cvar),_, cvar_plid, cvar_pointer);
+		get_plugins_cvar(i, cvar, charsmax(cvar), _, cvar_plid, cvar_pointer);
 		
 		if (cvar_plid == plid)
 		{
@@ -552,11 +552,11 @@ public DisplayCvarMenu(id, plid, page)
 				
 				// Now store the pcvar data in cvar
 				num_to_str(cvar_pointer, cvar, charsmax(cvar));
-				menu_additem(menu, cvar_text, cvar,_ ,g_enabled_callback);
+				menu_additem(menu, cvar_text, cvar, _ , g_enabled_callback);
 			}
 			else
 			{
-				menu_additem(menu, cvar, "",_, g_disabled_callback);
+				menu_additem(menu, cvar, "", _, g_disabled_callback);
 			}
 			
 		}

--- a/plugins/pluginmenu.sma
+++ b/plugins/pluginmenu.sma
@@ -130,7 +130,7 @@ stock DisplayPluginMenu(id, const menu_text[], const Handler[], const Command[],
 
 			if ((tally = callfunc_end()) > 0)
 			{
-				get_plugin(i, "", 0, plugin_name, charsmax(plugin_name), "", 0, "", 0, plugin_state, charsmax(plugin_state));
+				get_plugin(i, _, _, plugin_name, charsmax(plugin_name), _, _, _, _, plugin_state, charsmax(plugin_state));
 						
 				// Command syntax is: "# Function", # being plugin ID, function being public function to call.
 				formatex(plugincmd, charsmax(plugincmd), "%d %s", i, Command);
@@ -177,7 +177,7 @@ stock bool:GetPlidForValidPlugins(id, &plid)
 		// Scan for the plugin ID.
 		for (new i = 0, max = get_pluginsnum(); i < max; i++)
 		{
-			get_plugin(i, buffer_file, charsmax(buffer_file), buffer_name, charsmax(buffer_name), "", 0, "", 0, buffer_state, charsmax(buffer_state));
+			get_plugin(i, buffer_file, charsmax(buffer_file), buffer_name, charsmax(buffer_name), _, _, _, _, buffer_state, charsmax(buffer_state));
 			
 			if (strcmp(buffer_file, target_plugin, true) != 0 || strcmp(buffer_name, target_plugin, true) != 0)
 			{
@@ -328,7 +328,6 @@ public PluginMenuSelection(id, menu, item)
 	}
 	
 	new command[64];
-	new dummy[1];
 	
 	// All of the commands set for each item is the public
 	// function that we want to call after the item is selected.
@@ -336,7 +335,7 @@ public PluginMenuSelection(id, menu, item)
 	// Note the menu is destroyed BEFORE the command
 	// gets executed.
 	// The command retrieved is in the format: "PLID Command"
-	menu_item_getinfo(menu, item, dummy[0], command, charsmax(command), dummy, 0, dummy[0]);
+	menu_item_getinfo(menu, item, _, command, charsmax(command));
 	
 	new plid = str_to_num(command);
 	new function[32];
@@ -478,9 +477,9 @@ public CvarMenuSelection(id, menu, item)
 	{
 		new cvar_name[64];
 		new command[32];
-		new dummy[1];
+
 		// pcvar pointer is stored in command, extract the name of the cvar from the name field.
-		menu_item_getinfo(menu, item, dummy[0], command, charsmax(command), cvar_name, charsmax(cvar_name), dummy[0]);
+		menu_item_getinfo(menu, item, _, command, charsmax(command), cvar_name, charsmax(cvar_name));
 		
 		g_current_cvar[id] = str_to_num(command);
 		
@@ -521,7 +520,7 @@ public DisplayCvarMenu(id, plid, page)
 {
 	new plugin_name[32];
 	new menu_title[64];
-	get_plugin(plid, "", 0, plugin_name, charsmax(plugin_name), "", 0, "", 0, "", 0);
+	get_plugin(plid, _, _, plugin_name, charsmax(plugin_name));
 	
 	formatex(menu_title, charsmax(menu_title), "%s Cvars:", plugin_name);
 	
@@ -627,11 +626,9 @@ public SpecificCommandHandler(id, menu, item)
 		return PLUGIN_HANDLED;
 	}
 	
-	new dummy[1];
-
 	if (item == 0)  // "With params"
 	{
-		menu_item_getinfo(menu, item, dummy[0], g_current_command[id], charsmax(g_current_command[]), "", 0, dummy[0]);
+		menu_item_getinfo(menu, item, _, g_current_command[id], charsmax(g_current_command[]));
 
 		if (g_current_command[id][0] == 0) // This should never happen, but just incase..
 		{
@@ -649,7 +646,7 @@ public SpecificCommandHandler(id, menu, item)
 	}
 	else if (item == 1) // "No params"
 	{
-		menu_item_getinfo(menu, item, dummy[0], g_current_command[id], charsmax(g_current_command[]), "", 0, dummy[0]);
+		menu_item_getinfo(menu, item, _, g_current_command[id], charsmax(g_current_command[]));
 
 		if (g_current_command[id][0] == 0) // This should never happen, but just incase..
 		{
@@ -800,10 +797,9 @@ public CommandMenuSelection(id, menu, item)
 	else
 	{
 		new command[32];
-		new dummy[1];
 
 		// pcvar pointer is stored in command, extract the name of the cvar from the name field.
-		menu_item_getinfo(menu, item, dummy[0], command, charsmax(command), "", 0, dummy[0]);
+		menu_item_getinfo(menu, item, _, command, charsmax(command));
 		menu_destroy(menu);
 		DisplaySpecificCommand(id, str_to_num(command));
 	}
@@ -839,7 +835,7 @@ public DisplayCmdMenu(id, plid, page)
 {
 	new plugin_name[32];
 	new menu_title[64];
-	get_plugin(plid, "", 0, plugin_name, charsmax(plugin_name), "", 0, "", 0, "", 0);
+	get_plugin(plid, _, _, plugin_name, charsmax(plugin_name));
 	
 	formatex(menu_title, charsmax(menu_title), "%s Commands:", plugin_name);
 	
@@ -913,7 +909,7 @@ public CommandMenuCommand(id, level, cid)
 		g_current_page[id] = 0;
 		DisplayCmdMenu(id, plid, 0);
 	}
-	
+
 	return PLUGIN_HANDLED;
 }
 

--- a/plugins/pluginmenu.sma
+++ b/plugins/pluginmenu.sma
@@ -321,7 +321,7 @@ public PluginMenuSelection(id, menu, item)
 	// Note the menu is destroyed BEFORE the command
 	// gets executed.
 	// The command retrieved is in the format: "PLID Command"
-	new command[64]
+	new command[64];
 	menu_item_getinfo(menu, item, _, command, charsmax(command));
 	
 	new function[32], plid = str_to_num(command);

--- a/plugins/pluginmenu.sma
+++ b/plugins/pluginmenu.sma
@@ -396,23 +396,23 @@ public CommandChangeCvar(id)
 		
 		log_amx("Cmd: ^"%s<%d><%s><>^" set cvar (name ^"%s^") (value ^"%s^")", name, get_user_userid(id), authid, g_current_cvar_name[id], args);
 	
-		new cvar_val[64];
+		new cvar_val[64], players[MAX_PLAYERS], pnum;
+		get_players_ex(players, pnum, GetPlayers_ExcludeBots);
 
-		for (new i = 1; i <= MaxClients; i++)
+		for (new player, i; i < pnum; i++)
 		{
-			if (is_user_connected(i) && !is_user_bot(i))
-			{
-				if (get_pcvar_flags(pointer) & FCVAR_PROTECTED || equali(args, "rcon_password"))
-				{
-					formatex(cvar_val, charsmax(cvar_val), "*** %L ***", i, "PROTECTED");
-				}
-				else
-				{
-					copy(cvar_val, charsmax(cvar_val), args);
-				}
+			player = players[i];
 
-				show_activity_id(i, id, name, "%L", i, "SET_CVAR_TO", "", g_current_cvar_name[id], cvar_val);
+			if (get_pcvar_flags(pointer) & FCVAR_PROTECTED || equali(args, "rcon_password"))
+			{
+				formatex(cvar_val, charsmax(cvar_val), "*** %L ***", player, "PROTECTED");
 			}
+			else
+			{
+				copy(cvar_val, charsmax(cvar_val), args);
+			}
+
+			show_activity_id(player, id, name, "%L", player, "SET_CVAR_TO", "", g_current_cvar_name[id], cvar_val);
 		}
 
 		console_print(id, "[AMXX] %l", "CVAR_CHANGED", g_current_cvar_name[id], args);

--- a/plugins/pluginmenu.sma
+++ b/plugins/pluginmenu.sma
@@ -385,16 +385,7 @@ public CommandChangeCvar(id)
 		set_pcvar_string(g_current_cvar[id], args);
 		
 		client_print(id, print_chat, "%l", "CVAR_CHANGED", g_current_cvar_name[id], args);
-		
-		// Copy of admincmd's global output.
-		
-		new name[MAX_NAME_LENGTH];
-		new authid[40];
-		
-		get_user_name(id, name, charsmax(name));
-		get_user_authid(id, authid, charsmax(authid));
-		
-		log_amx("Cmd: ^"%s<%d><%s><>^" set cvar (name ^"%s^") (value ^"%s^")", name, get_user_userid(id), authid, g_current_cvar_name[id], args);
+		log_amx("Cmd: ^"%N^" set cvar (name ^"%s^") (value ^"%s^")", id, g_current_cvar_name[id], args);
 	
 		new cvar_val[64], players[MAX_PLAYERS], pnum;
 		get_players_ex(players, pnum, GetPlayers_ExcludeBots);
@@ -412,7 +403,7 @@ public CommandChangeCvar(id)
 				copy(cvar_val, charsmax(cvar_val), args);
 			}
 
-			show_activity_id(player, id, name, "%L", player, "SET_CVAR_TO", "", g_current_cvar_name[id], cvar_val);
+			show_activity_id(player, id, fmt("%n", id), "%L", player, "SET_CVAR_TO", "", g_current_cvar_name[id], cvar_val);
 		}
 
 		console_print(id, "[AMXX] %l", "CVAR_CHANGED", g_current_cvar_name[id], args);

--- a/plugins/pluginmenu.sma
+++ b/plugins/pluginmenu.sma
@@ -190,7 +190,7 @@ stock bool:GetPlidForValidPlugins(id, &plid)
 		// If the plugin was not found, then tell them there was an error.
 		if (plid == -1)
 		{
-			console_print(id, "%L", id, "PAUSE_COULDNT_FIND", target_plugin);
+			console_print(id, "%l", "PAUSE_COULDNT_FIND", target_plugin);
 			
 			// return a failure state
 			return false;
@@ -415,7 +415,7 @@ public CommandChangeCvar(id)
 			}
 		}
 
-		console_print(id, "[AMXX] %L", id, "CVAR_CHANGED", g_current_cvar_name[id], args);
+		console_print(id, "[AMXX] %l", "CVAR_CHANGED", g_current_cvar_name[id], args);
 	}
 	
 	// Now redraw the menu for the client

--- a/plugins/pluginmenu.sma
+++ b/plugins/pluginmenu.sma
@@ -61,6 +61,7 @@ public plugin_cfg()
 {
 	set_task(0.1, "addToMenuFront");
 }
+
 public addToMenuFront()
 {
 	new plugin_filename[64];
@@ -78,6 +79,7 @@ public addToMenuFront()
 		// this should never happen, but just incase!
 		cmdflags = ADMIN_MENU;
 	}
+
 	get_concmd(g_cvarmenu_cmdid, cmd, charsmax(cmd), cvarflags, garbage, charsmax(garbage), -1);
 
 	if (strcmp(cmd, "amx_plugincvarmenu") != 0)
@@ -99,7 +101,6 @@ public client_connect(id)
 	g_current_cvar_name[id][0] = 0;
 	g_current_command[id][0] = 0;
 	g_explicit_plugin[id] = -1;
-	
 }
 
 /**
@@ -114,20 +115,19 @@ stock DisplayPluginMenu(id, const menu_text[], const Handler[], const Command[],
 {
 	new menu=menu_create(menu_text, Handler);
 	
-	
 	new plugin_state[32];
 	new plugin_name[64];
 	new func = get_func_id(Callback);
 	new tally;
 	new plugincmd[64];
 	new menu_text[64];
-	for (new i = 0, max = get_pluginsnum();
-		 i < max;
-		 i++)
+
+	for (new i = 0, max = get_pluginsnum(); i < max; i++)
 	{
 		if (callfunc_begin_i(func, -1) == 1)
 		{
 			callfunc_push_int(i); // push the plid
+
 			if ((tally = callfunc_end()) > 0)
 			{
 				get_plugin(i, "", 0, plugin_name, charsmax(plugin_name), "", 0, "", 0, plugin_state, charsmax(plugin_state));
@@ -135,9 +135,9 @@ stock DisplayPluginMenu(id, const menu_text[], const Handler[], const Command[],
 				// Command syntax is: "# Function", # being plugin ID, function being public function to call.
 				formatex(plugincmd, charsmax(plugincmd), "%d %s", i, Command);
 				formatex(menu_text, charsmax(menu_text), "%s - %d", plugin_name, tally);
+
 				// If the plugin is running, add this as an activated menu item.
-				if (strcmp(plugin_state, "running", true) == 0 ||
-					strcmp(plugin_state, "debug", true) == 0)
+				if (strcmp(plugin_state, "running", true) == 0 || strcmp(plugin_state, "debug", true) == 0)
 				{
 					menu_additem(menu, menu_text, plugincmd, g_enabled_callback);
 				}
@@ -152,7 +152,6 @@ stock DisplayPluginMenu(id, const menu_text[], const Handler[], const Command[],
 	menu_setprop(menu, MPROP_NUMBER_COLOR, "\y");
 	menu_setprop(menu, MPROP_EXIT, MEXIT_ALL);
 	menu_display(id, menu, 0);
-
 }
 
 /**
@@ -176,26 +175,24 @@ stock bool:GetPlidForValidPlugins(id, &plid)
 		new buffer_file[64];
 		new buffer_state[64];
 		// Scan for the plugin ID.
-		for (new i = 0, max = get_pluginsnum();
-			 i < max;
-			 i++)
+		for (new i = 0, max = get_pluginsnum(); i < max; i++)
 		{
 			get_plugin(i, buffer_file, charsmax(buffer_file), buffer_name, charsmax(buffer_name), "", 0, "", 0, buffer_state, charsmax(buffer_state));
 			
-			if (strcmp(buffer_file, target_plugin, true) != 0 ||
-				strcmp(buffer_name, target_plugin, true) != 0)
+			if (strcmp(buffer_file, target_plugin, true) != 0 || strcmp(buffer_name, target_plugin, true) != 0)
 			{
 				// We have a match.
 				
 				// Check the status of the plugin.  If it's anything other than "running" or "debug" fail.
-				if (strcmp(buffer_state, "running") != 0 &&
-					strcmp(buffer_state, "debug")   != 0)
+				if (strcmp(buffer_state, "running") != 0 &&	strcmp(buffer_state, "debug") != 0)
 				{
 					// TODO: ML This
 					console_print(id, "Plugin ^"%s^" is not running.", buffer_file);
+
 					// Return a failed state.
 					return false;
 				}
+
 				plid = i;
 				break;
 			}
@@ -223,9 +220,8 @@ public GetNumberOfCvarsForPlid(plid)
 {
 	new count = 0;
 	new cvar_plid;
-	for (new i = 0, max = get_plugins_cvarsnum();
-		 i < max;
-		 i++)
+
+	for (new i = 0, max = get_plugins_cvarsnum(); i < max; i++)
 	{
 		get_plugins_cvar(i, "", 0, _, cvar_plid, _);
 		
@@ -246,9 +242,7 @@ public GetNumberOfCmdsForPlid(plid)
 {
 	new count = 0;
 	
-	for (new i = 0, max = get_concmdsnum(-1,-1);
-		 i < max;
-		 i++)
+	for (new i = 0, max = get_concmdsnum(-1,-1); i < max; i++)
 	{
 		if (get_concmd_plid(i, -1, -1) == plid)
 		{
@@ -269,6 +263,7 @@ public GetNumberOfCmdsForPlid(plid)
 stock bool:CanIModifyCvar(id, const cvar[])
 {
 	new user_flags = get_user_flags(id);
+
 	// If the user has rcon access don't bother checking anything.
 	if (user_flags & ADMIN_RCON)
 	{
@@ -302,6 +297,7 @@ public AlwaysDisableCallback(playerid, menuid, itemid)
 {
 	return ITEM_DISABLED;
 }
+
 /**
  * Simple function to ensure that a menu item is always enabled.
  *
@@ -311,6 +307,7 @@ public AlwaysEnableCallback(playerid, menuid, itemid)
 {
 	return ITEM_ENABLED;
 }
+
 /**
  * Handler for the plugin menu.
  *
@@ -324,6 +321,7 @@ public PluginMenuSelection(id, menu, item)
 	{
 		menu_destroy(menu);
 	}
+
 	if (item < 0)
 	{
 		return PLUGIN_HANDLED;
@@ -340,7 +338,6 @@ public PluginMenuSelection(id, menu, item)
 	// The command retrieved is in the format: "PLID Command"
 	menu_item_getinfo(menu, item, dummy[0], command, charsmax(command), dummy, 0, dummy[0]);
 	
-	
 	new plid = str_to_num(command);
 	new function[32];
 	
@@ -356,8 +353,8 @@ public PluginMenuSelection(id, menu, item)
 	}
 	
 	menu_destroy(menu);
-	
 	new funcid = get_func_id(function);
+
 	if (funcid != -1 && callfunc_begin_i(funcid) == 1)
 	{
 		g_current_page[id] = 0;
@@ -369,6 +366,7 @@ public PluginMenuSelection(id, menu, item)
 		callfunc_end();
 		
 	}
+
 	return PLUGIN_HANDLED;
 }
 
@@ -388,9 +386,7 @@ public CommandChangeCvar(id)
 	}
 	
 	new args[256];
-	
 	read_args(args, charsmax(args));
-	
 	remove_quotes(args);
 	
 	if (equali(args, "!cancel", 7))
@@ -417,8 +413,8 @@ public CommandChangeCvar(id)
 		
 		log_amx("Cmd: ^"%s<%d><%s><>^" set cvar (name ^"%s^") (value ^"%s^")", name, get_user_userid(id), authid, g_current_cvar_name[id], args);
 	
-	
 		new cvar_val[64];
+
 		for (new i = 1; i <= MaxClients; i++)
 		{
 			if (is_user_connected(i) && !is_user_bot(i))
@@ -434,8 +430,8 @@ public CommandChangeCvar(id)
 				show_activity_id(i, id, name, "%L", i, "SET_CVAR_TO", "", g_current_cvar_name[id], cvar_val);
 			}
 		}
+
 		console_print(id, "[AMXX] %L", id, "CVAR_CHANGED", g_current_cvar_name[id], args);
-		
 	}
 	
 	// Now redraw the menu for the client
@@ -459,7 +455,6 @@ public CommandChangeCvar(id)
  */
 public CvarMenuSelection(id, menu, item)
 {
-	
 	if (item == MENU_EXIT)
 	{
 		menu_destroy(menu);
@@ -505,6 +500,7 @@ public CvarMenuSelection(id, menu, item)
 				break;
 			}
 		}
+
 		copy(g_current_cvar_name[id], charsmax(g_current_cvar_name[]), cvar_name);
 		client_print(id, print_chat, "[AMXX] Type in the new value for %s, or !cancel to cancel.", cvar_name);
 		client_cmd(id, "messagemode amx_changecvar");
@@ -537,9 +533,7 @@ public DisplayCvarMenu(id, plid, page)
 	new cvar_data[32];
 	new cvar_pointer;
 	
-	for (new i = 0, max = get_plugins_cvarsnum();
-		 i < max;
-		 i++)
+	for (new i = 0, max = get_plugins_cvarsnum(); i < max; i++)
 	{
 		get_plugins_cvar(i, cvar, charsmax(cvar), _, cvar_plid, cvar_pointer);
 		
@@ -565,8 +559,8 @@ public DisplayCvarMenu(id, plid, page)
 	menu_setprop(menu, MPROP_EXIT, MEXIT_ALL);
 	menu_setprop(menu, MPROP_NUMBER_COLOR, "\y");
 	menu_display(id, menu, page);
-
 }
+
 /**
  * Process the "amx_plugincvarmenu" command.
  *
@@ -594,6 +588,7 @@ public CvarMenuCommand(id, level, cid)
 	if (plid == -1)
 	{
 		g_explicit_plugin[id] = -1;
+
 		// We need to display a list of the plugins, instead of a specific plugin.
 		DisplayPluginMenu(id, "Plugin Cvar Menu:", "PluginMenuSelection", "DisplayCvarMenu", "GetNumberOfCvarsForPlid");
 	}
@@ -604,8 +599,10 @@ public CvarMenuCommand(id, level, cid)
 		g_current_page[id] = 0;
 		DisplayCvarMenu(id, plid, 0);
 	}
+
 	return PLUGIN_HANDLED;
 }
+
 /**
  * Handler for the menu that displays a single command ("Execute with no params", etc).
  *
@@ -625,22 +622,24 @@ public SpecificCommandHandler(id, menu, item)
 			callfunc_push_int(g_current_page[id]);
 			callfunc_end();
 		}
+
 		menu_destroy(menu);
-		
 		return PLUGIN_HANDLED;
 	}
 	
 	new dummy[1];
+
 	if (item == 0)  // "With params"
 	{
 		menu_item_getinfo(menu, item, dummy[0], g_current_command[id], charsmax(g_current_command[]), "", 0, dummy[0]);
+
 		if (g_current_command[id][0] == 0) // This should never happen, but just incase..
 		{
 			client_print(id, print_chat, "[AMXX] There was an error extracting the command name.");
 			return PLUGIN_HANDLED;
 		}
-		// TODO: ML this
-		
+
+		// TODO: ML this		
 		client_print(id, print_chat, "[AMXX] Type in the parameters for %s, or !cancel to cancel.", g_current_command[id]);
 		client_cmd(id, "messagemode amx_executecmd");
 		
@@ -651,13 +650,14 @@ public SpecificCommandHandler(id, menu, item)
 	else if (item == 1) // "No params"
 	{
 		menu_item_getinfo(menu, item, dummy[0], g_current_command[id], charsmax(g_current_command[]), "", 0, dummy[0]);
+
 		if (g_current_command[id][0] == 0) // This should never happen, but just incase..
 		{
 			client_print(id, print_chat, "[AMXX] There was an error extracting the command name.");
 			return PLUGIN_HANDLED;
 		}
-		// TODO: ML this
 
+		// TODO: ML this
 		// Now redraw the menu for the client BEFORE the command is executed, incase
 		// that menu brings up a menu of its own.
 		if (g_current_menu_function[id] != -1 && callfunc_begin_i(g_current_menu_function[id]) == 1)
@@ -667,6 +667,7 @@ public SpecificCommandHandler(id, menu, item)
 			callfunc_push_int(g_current_page[id]);
 			callfunc_end();
 		}
+
 		menu_destroy(menu);
 		
 		client_cmd(id, "%s", g_current_command[id]);
@@ -676,8 +677,7 @@ public SpecificCommandHandler(id, menu, item)
 	}
 	
 	// We should never get here, but just incase..
-	menu_destroy(menu);
-	
+	menu_destroy(menu);	
 	return PLUGIN_HANDLED;
 }
 
@@ -706,6 +706,7 @@ stock DisplaySpecificCommand(id, cid)
 	{
 		menu=menu_create(command_name, "SpecificCommandHandler");
 	}
+
 	menu_additem(menu, "Execute with parameters.", command_name, _, g_enabled_callback);
 	menu_additem(menu, "Execute with no parameters.", command_name, _, g_enabled_callback);
 	
@@ -727,9 +728,7 @@ public CommandExecuteCommand(id)
 	}
 	
 	new args[256];
-	
 	read_args(args, charsmax(args));
-	
 	remove_quotes(args);
 	
 	if (equali(args, "!cancel", 7))
@@ -745,7 +744,6 @@ public CommandExecuteCommand(id)
 			callfunc_push_int(g_current_page[id]);
 			callfunc_end();
 		}
-
 	}
 	else
 	{
@@ -765,9 +763,7 @@ public CommandExecuteCommand(id)
 		client_cmd(id, "%s %s", g_current_command[id], args);
 	}
 	
-	
 	return PLUGIN_HANDLED;
-	
 }
 
 /**
@@ -805,16 +801,16 @@ public CommandMenuSelection(id, menu, item)
 	{
 		new command[32];
 		new dummy[1];
+
 		// pcvar pointer is stored in command, extract the name of the cvar from the name field.
 		menu_item_getinfo(menu, item, dummy[0], command, charsmax(command), "", 0, dummy[0]);
-		
 		menu_destroy(menu);
-		
 		DisplaySpecificCommand(id, str_to_num(command));
 	}
 	
 	return PLUGIN_HANDLED;
 }
+
 /**
  * This blocks "say" and "say_team" commands. 
  * Other commands that shouldn't be displayed (eg: amxauth<stuff>) should be filtered out already.
@@ -831,6 +827,7 @@ stock bool:IsDisplayableCmd(const command[])
 	
 	return true;
 }
+
 /**
  * Displays a command list for the specified plugin.
  *
@@ -854,10 +851,7 @@ public DisplayCmdMenu(id, plid, page)
 	new userflags = get_user_flags(id);
 	new bool:isadmin = bool:is_user_admin(id);
 	
-	
-	for (new i = 0, max = get_concmdsnum(-1, -1);
-		 i < max;
-		 i++)
+	for (new i = 0, max = get_concmdsnum(-1, -1); i < max; i++)
 	{
 		if (get_concmd_plid(i, -1, -1) == plid)
 		{
@@ -865,10 +859,7 @@ public DisplayCmdMenu(id, plid, page)
 			
 			if (IsDisplayableCmd(command))
 			{
-				if (userflags & command_access || 
-					(command_access == ADMIN_ADMIN && isadmin) ||
-					 command_access == ADMIN_USER ||
-					 command_access == ADMIN_ALL)
+				if (userflags & command_access || (command_access == ADMIN_ADMIN && isadmin) || command_access == ADMIN_USER || command_access == ADMIN_ALL)
 				{
 					num_to_str(i, cid_string, charsmax(cid_string));
 					menu_additem(menu, command, cid_string, 0, g_enabled_callback);
@@ -880,10 +871,11 @@ public DisplayCmdMenu(id, plid, page)
 			}
 		}
 	}
+
 	menu_setprop(menu, MPROP_NUMBER_COLOR, "\y");
 	menu_display(id, menu, page);
-
 }
+
 /**
  * Handles the "amx_plugincmdmenu" command.
  *
@@ -921,6 +913,7 @@ public CommandMenuCommand(id, level, cid)
 		g_current_page[id] = 0;
 		DisplayCmdMenu(id, plid, 0);
 	}
+	
 	return PLUGIN_HANDLED;
 }
 

--- a/plugins/pluginmenu.sma
+++ b/plugins/pluginmenu.sma
@@ -64,14 +64,8 @@ public plugin_cfg()
 
 public addToMenuFront()
 {
-	new plugin_filename[64];
-	
+	new plugin_filename[64], cmd[32], garbage[1], cvarflags, cmdflags;
 	get_plugin(-1, plugin_filename, charsmax(plugin_filename));
-	new cvarflags;
-	new cmdflags;
-	new garbage[1];
-	new cmd[32];
-
 	get_concmd(g_cmdmenu_cmdid, cmd, charsmax(cmd), cmdflags, garbage, charsmax(garbage), -1);
 
 	if (strcmp(cmd, "amx_plugincmdmenu") != 0)
@@ -113,14 +107,10 @@ public client_connect(id)
  */
 stock DisplayPluginMenu(id, const menu_text[], const Handler[], const Command[], const Callback[])
 {
-	new menu=menu_create(menu_text, Handler);
-	
-	new plugin_state[32];
-	new plugin_name[64];
-	new func = get_func_id(Callback);
-	new tally;
-	new plugincmd[64];
-	new menu_text[64];
+	new plugin_name[64], plugincmd[64], menu_text[64], plugin_state[32], tally;
+
+	new menu = menu_create(menu_text, Handler);
+	new func = get_func_id(Callback);	
 
 	for (new i = 0, max = get_pluginsnum(); i < max; i++)
 	{
@@ -168,12 +158,9 @@ stock bool:GetPlidForValidPlugins(id, &plid)
 	if (read_argc() > 1)
 	{ 
 		// Yes, we were provided a plugin.
-		new target_plugin[64];
+		new buffer_name[64], buffer_file[64] ,buffer_state[64], target_plugin[64];
 		read_argv(1, target_plugin, charsmax(target_plugin));
 		
-		new buffer_name[64];
-		new buffer_file[64];
-		new buffer_state[64];
 		// Scan for the plugin ID.
 		for (new i = 0, max = get_pluginsnum(); i < max; i++)
 		{
@@ -218,8 +205,7 @@ stock bool:GetPlidForValidPlugins(id, &plid)
  */
 public GetNumberOfCvarsForPlid(plid)
 {
-	new count = 0;
-	new cvar_plid;
+	new cvar_plid, count;
 
 	for (new i = 0, max = get_plugins_cvarsnum(); i < max; i++)
 	{
@@ -240,7 +226,7 @@ public GetNumberOfCvarsForPlid(plid)
  */
 public GetNumberOfCmdsForPlid(plid)
 {
-	new count = 0;
+	new count;
 	
 	for (new i = 0, max = get_concmdsnum(-1,-1); i < max; i++)
 	{
@@ -327,18 +313,16 @@ public PluginMenuSelection(id, menu, item)
 		return PLUGIN_HANDLED;
 	}
 	
-	new command[64];
-	
 	// All of the commands set for each item is the public
 	// function that we want to call after the item is selected.
 	// The parameters are: function(idPlayer,itemnumber)
 	// Note the menu is destroyed BEFORE the command
 	// gets executed.
 	// The command retrieved is in the format: "PLID Command"
+	new command[64]
 	menu_item_getinfo(menu, item, _, command, charsmax(command));
 	
-	new plid = str_to_num(command);
-	new function[32];
+	new function[32], plid = str_to_num(command);
 	
 	for (new i = 0; i < charsmax(command); i++)
 	{
@@ -363,7 +347,6 @@ public PluginMenuSelection(id, menu, item)
 		callfunc_push_int(plid);
 		callfunc_push_int(0);
 		callfunc_end();
-		
 	}
 
 	return PLUGIN_HANDLED;
@@ -379,7 +362,7 @@ public CommandChangeCvar(id)
 	// All access checks are done before this command is called.
 	// So if the client has no pcvar pointer in his array slot
 	// then just ignore the command.
-	if (g_current_cvar[id] == 0)
+	if (!g_current_cvar[id])
 	{
 		return PLUGIN_CONTINUE;
 	}
@@ -396,7 +379,6 @@ public CommandChangeCvar(id)
 	else
 	{
 		// Changed to set_cvar_* for 1.76 tests
-		
 		new pointer = g_current_cvar[id];
 		set_pcvar_string(g_current_cvar[id], args);
 		
@@ -475,12 +457,10 @@ public CvarMenuSelection(id, menu, item)
 	}
 	else
 	{
-		new cvar_name[64];
-		new command[32];
+		new cvar_name[64], command[32];
 
 		// pcvar pointer is stored in command, extract the name of the cvar from the name field.
 		menu_item_getinfo(menu, item, _, command, charsmax(command), cvar_name, charsmax(cvar_name));
-		
 		g_current_cvar[id] = str_to_num(command);
 		
 		if (g_current_cvar[id] == 0) // This should never happen, but just incase..
@@ -518,19 +498,13 @@ public CvarMenuSelection(id, menu, item)
  */
 public DisplayCvarMenu(id, plid, page)
 {
-	new plugin_name[32];
-	new menu_title[64];
+	new menu_title[64], plugin_name[32];
 	get_plugin(plid, _, _, plugin_name, charsmax(plugin_name));
-	
 	formatex(menu_title, charsmax(menu_title), "%s Cvars:", plugin_name);
 	
 	new menu = menu_create(menu_title, "CvarMenuSelection");
 	
-	new cvar[64];
-	new cvar_plid;
-	new cvar_text[64];
-	new cvar_data[32];
-	new cvar_pointer;
+	new cvar[64], cvar_text[64], cvar_data[32], cvar_plid, cvar_pointer;
 	
 	for (new i = 0, max = get_plugins_cvarsnum(); i < max; i++)
 	{
@@ -686,22 +660,17 @@ public SpecificCommandHandler(id, menu, item)
  */
 stock DisplaySpecificCommand(id, cid)
 {
-	new command_name[64];
-	new command_desc[128];
-	new command_title[256];
-	new command_access;
-	new menu;
-	
+	new command_title[256], command_desc[128], command_name[64], command_access, menu;
 	get_concmd(cid, command_name, charsmax(command_name), command_access, command_desc, charsmax(command_desc), -1, -1);
 	
 	if (command_desc[0] != '^0')
 	{
 		formatex(command_title, charsmax(command_title), "%s^n%s", command_name, command_desc);
-		menu=menu_create(command_title, "SpecificCommandHandler");
+		menu = menu_create(command_title, "SpecificCommandHandler");
 	}
 	else
 	{
-		menu=menu_create(command_name, "SpecificCommandHandler");
+		menu = menu_create(command_name, "SpecificCommandHandler");
 	}
 
 	menu_additem(menu, "Execute with parameters.", command_name, _, g_enabled_callback);
@@ -833,17 +802,11 @@ stock bool:IsDisplayableCmd(const command[])
  */
 public DisplayCmdMenu(id, plid, page)
 {
-	new plugin_name[32];
-	new menu_title[64];
+	new menu_title[64], command[64], plugin_name[32], cid_string[32], command_access;
 	get_plugin(plid, _, _, plugin_name, charsmax(plugin_name));
-	
 	formatex(menu_title, charsmax(menu_title), "%s Commands:", plugin_name);
 	
 	new menu = menu_create(menu_title, "CommandMenuSelection");
-	
-	new command[64];
-	new cid_string[32];
-	new command_access;
 	new userflags = get_user_flags(id);
 	new bool:isadmin = bool:is_user_admin(id);
 	

--- a/support/PackageScript
+++ b/support/PackageScript
@@ -388,6 +388,7 @@ datafiles = [
   'nextmap.txt',
   'pausecfg.txt',
   'plmenu.txt',
+  'pluginmenu.txt',
   'restmenu.txt',
   'scrollmsg.txt',
   'stats_dod.txt',


### PR DESCRIPTION
The changes include:

1. Consistent variable names.
2. Added missing translations.
4. Usage of `%N` instead of `%s<%d><%s><>` in log messages.
6. Usage of `%l` instead of `%L` where possible.
7. Consistent brackets, indentation, spaces and semicolons.