### PR TITLE
Modernize and improve scrollmsg.sma

### DIFF
--- a/plugins/scrollmsg.sma
+++ b/plugins/scrollmsg.sma
@@ -38,15 +38,21 @@ public showMsg()
 	new a = g_startPos, i = 0
 
 	while (a < g_endPos)
+	{
 		g_displayMsg[i++] = g_scrollMsg[a++]
+	}
 
 	g_displayMsg[i] = 0
 
 	if (g_endPos < g_Length)
+	{
 		g_endPos++
+	}
 
 	if (g_xPos > 0.35)
+	{
 		g_xPos -= 0.0063
+	}
 	else
 	{
 		g_startPos++
@@ -101,7 +107,9 @@ public setMessage()
 		set_task(float(g_Frequency), "msgInit", 123, "", 0, "b")
 	}
 	else
+	{
 		server_print("%L", LANG_SERVER, "MSG_DISABLED")
+	}
 	
 	return PLUGIN_HANDLED
 }

--- a/plugins/scrollmsg.sma
+++ b/plugins/scrollmsg.sma
@@ -58,6 +58,7 @@ public plugin_init()
 	bind_pcvar_float(create_cvar( "amx_scrollmsg_y_pos",           "0.9",      _, "The Y position of the message",                true, -1.0, true, 1.0),  g_amx_scrollmsg_y_pos);
 
 	g_hud_object = CreateHudSyncObj();
+	AutoExecConfig();
 }
 
 public showMsg()

--- a/plugins/scrollmsg.sma
+++ b/plugins/scrollmsg.sma
@@ -17,99 +17,99 @@
 #define SPEED 0.3
 #define SCROLLMSG_SIZE	512
 
-new g_startPos
-new g_endPos
-new g_scrollMsg[SCROLLMSG_SIZE]
-new g_displayMsg[SCROLLMSG_SIZE]
-new Float:g_xPos
-new g_Length
-new g_Frequency
+new g_startPos;
+new g_endPos;
+new g_scrollMsg[SCROLLMSG_SIZE];
+new g_displayMsg[SCROLLMSG_SIZE];
+new Float:g_xPos;
+new g_Length;
+new g_Frequency;
 
 public plugin_init()
 {
-	register_plugin("Scrolling Message", AMXX_VERSION_STR, "AMXX Dev Team")
-	register_dictionary("scrollmsg.txt")
-	register_dictionary("common.txt")
-	register_srvcmd("amx_scrollmsg", "setMessage")
+	register_plugin("Scrolling Message", AMXX_VERSION_STR, "AMXX Dev Team");
+	register_dictionary("scrollmsg.txt");
+	register_dictionary("common.txt");
+	register_srvcmd("amx_scrollmsg", "setMessage");
 }
 
 public showMsg()
 {
-	new a = g_startPos, i = 0
+	new a = g_startPos, i = 0;
 
 	while (a < g_endPos)
 	{
-		g_displayMsg[i++] = g_scrollMsg[a++]
+		g_displayMsg[i++] = g_scrollMsg[a++];
 	}
 
-	g_displayMsg[i] = 0
+	g_displayMsg[i] = 0;
 
 	if (g_endPos < g_Length)
 	{
-		g_endPos++
+		g_endPos++;
 	}
 
 	if (g_xPos > 0.35)
 	{
-		g_xPos -= 0.0063
+		g_xPos -= 0.0063;
 	}
 	else
 	{
-		g_startPos++
-		g_xPos = 0.35
+		g_startPos++;
+		g_xPos = 0.35;
 	}
 
-	set_hudmessage(200, 100, 0, g_xPos, 0.90, 0, SPEED, SPEED, 0.05, 0.05, 2)
-	show_hudmessage(0, "%s", g_displayMsg)
+	set_hudmessage(200, 100, 0, g_xPos, 0.90, 0, SPEED, SPEED, 0.05, 0.05, 2);
+	show_hudmessage(0, "%s", g_displayMsg);
 }
 
 public msgInit()
 {
-	g_endPos = 1
-	g_startPos = 0
-	g_xPos = 0.65
+	g_endPos = 1;
+	g_startPos = 0;
+	g_xPos = 0.65;
 	
-	new hostname[64]
+	new hostname[64];
 	
-	get_cvar_string("hostname", hostname, charsmax(hostname))
-	replace(g_scrollMsg, charsmax(g_scrollMsg), "%hostname%", hostname)
+	get_cvar_string("hostname", hostname, charsmax(hostname));
+	replace(g_scrollMsg, charsmax(g_scrollMsg), "%hostname%", hostname);
 	
-	g_Length = strlen(g_scrollMsg)
+	g_Length = strlen(g_scrollMsg);
 	
-	set_task(SPEED, "showMsg", 123, "", 0, "a", g_Length + 48)
-	client_print(0, print_console, "%s", g_scrollMsg)
+	set_task(SPEED, "showMsg", 123, "", 0, "a", g_Length + 48);
+	client_print(0, print_console, "%s", g_scrollMsg);
 }
 
 public setMessage()
 {
-	remove_task(123)		/* remove current messaging */
-	read_argv(1, g_scrollMsg, charsmax(g_scrollMsg))
+	remove_task(123);		/* remove current messaging */
+	read_argv(1, g_scrollMsg, charsmax(g_scrollMsg));
 	
-	g_Length = strlen(g_scrollMsg)
+	g_Length = strlen(g_scrollMsg);
 	
-	new mytime[32]
+	new mytime[32];
 	
-	read_argv(2, mytime, charsmax(mytime))
+	read_argv(2, mytime, charsmax(mytime));
 	
-	g_Frequency = str_to_num(mytime)
+	g_Frequency = str_to_num(mytime);
 	
 	if (g_Frequency > 0)
 	{
-		new minimal = floatround((g_Length + 48) * (SPEED + 0.1))
+		new minimal = floatround((g_Length + 48) * (SPEED + 0.1));
 		
 		if (g_Frequency < minimal)
 		{
-			server_print("%L", LANG_SERVER, "MIN_FREQ", minimal)
-			g_Frequency = minimal
+			server_print("%L", LANG_SERVER, "MIN_FREQ", minimal);
+			g_Frequency = minimal;
 		}
 
-		server_print("%L", LANG_SERVER, "MSG_FREQ", g_Frequency / 60, g_Frequency % 60)
-		set_task(float(g_Frequency), "msgInit", 123, "", 0, "b")
+		server_print("%L", LANG_SERVER, "MSG_FREQ", g_Frequency / 60, g_Frequency % 60);
+		set_task(float(g_Frequency), "msgInit", 123, "", 0, "b");
 	}
 	else
 	{
-		server_print("%L", LANG_SERVER, "MSG_DISABLED")
+		server_print("%L", LANG_SERVER, "MSG_DISABLED");
 	}
 	
-	return PLUGIN_HANDLED
+	return PLUGIN_HANDLED;
 }

--- a/plugins/scrollmsg.sma
+++ b/plugins/scrollmsg.sma
@@ -32,9 +32,10 @@ new g_start_pos;
 new g_end_pos;
 new g_scroll_msg[SCROLLMSG_SIZE];
 new g_display_msg[SCROLLMSG_SIZE];
-new Float:g_x_pos;
 new g_length;
 new g_frequency;
+new g_hud_object;
+new Float:g_x_pos;
 
 public plugin_init()
 {
@@ -55,6 +56,8 @@ public plugin_init()
 	bind_pcvar_float(create_cvar( "amx_scrollmsg_x_start_pos",     "0.35",     _, "Starting position on the X axis",              true, -1.0, true, 1.0),  g_amx_scrollmsg_x_start_pos);
 	bind_pcvar_float(create_cvar( "amx_scrollmsg_x_end_pos",       "0.65",     _, "Ending position on the X axis",                true, -1.0, true, 1.0),  g_amx_scrollmsg_x_end_pos);
 	bind_pcvar_float(create_cvar( "amx_scrollmsg_y_pos",           "0.9",      _, "The Y position of the message",                true, -1.0, true, 1.0),  g_amx_scrollmsg_y_pos);
+
+	g_hud_object = CreateHudSyncObj();
 }
 
 public showMsg()
@@ -92,12 +95,12 @@ public showMsg()
 
 		for(new i; i < pnum; i++)
 		{
-			show_hudmessage(players[i], g_display_msg);
+			ShowSyncHudMsg(players[i], g_hud_object, g_display_msg);
 		}
 	}
 	else
 	{
-		show_hudmessage(0, "%s", g_display_msg);
+		ShowSyncHudMsg(0, g_hud_object, g_display_msg);
 	}
 }
 

--- a/plugins/scrollmsg.sma
+++ b/plugins/scrollmsg.sma
@@ -16,6 +16,7 @@
 
 #define SCROLLMSG_SIZE 512
 
+new g_hostname[64];
 new g_amx_scrollmsg_color_red;
 new g_amx_scrollmsg_color_green;
 new g_amx_scrollmsg_color_blue;
@@ -40,7 +41,9 @@ public plugin_init()
 
 	register_dictionary("scrollmsg.txt");
 	register_dictionary("common.txt");
+
 	register_srvcmd("amx_scrollmsg", "setMessage");
+	bind_pcvar_string(get_cvar_pointer("hostname"), g_hostname, charsmax(g_hostname));
 
 	bind_pcvar_num(create_cvar(   "amx_scrollmsg_color_red",       "200",      _, "Red color amount",                             true, 0.0, true, 255.0), g_amx_scrollmsg_color_red);
 	bind_pcvar_num(create_cvar(   "amx_scrollmsg_color_green",     "100",      _, "Green color amount",                           true, 0.0, true, 255.0), g_amx_scrollmsg_color_green);
@@ -103,10 +106,7 @@ public msgInit()
 	g_startPos = 0;
 	g_xPos = g_amx_scrollmsg_x_end_pos;
 	
-	new hostname[64];
-	
-	get_cvar_string("hostname", hostname, charsmax(hostname));
-	replace(g_scrollMsg, charsmax(g_scrollMsg), "%hostname%", hostname);
+	replace(g_scrollMsg, charsmax(g_scrollMsg), "%hostname%", g_hostname);
 	
 	g_Length = strlen(g_scrollMsg);
 	

--- a/plugins/scrollmsg.sma
+++ b/plugins/scrollmsg.sma
@@ -14,7 +14,8 @@
 #include <amxmodx>
 #include <amxmisc>
 
-#define SCROLLMSG_SIZE 512
+const SCROLLMSG_SIZE = 512;
+const SCROLLMSG_TASK = 123;
 
 new g_hostname[64];
 new g_amx_scrollmsg_color_red;
@@ -110,13 +111,13 @@ public msgInit()
 	
 	g_Length = strlen(g_scrollMsg);
 	
-	set_task(g_amx_scrollmsg_speed, "showMsg", 123, "", 0, "a", g_Length + 48);
+	set_task(g_amx_scrollmsg_speed, "showMsg", SCROLLMSG_TASK, "", 0, "a", g_Length + 48);
 	client_print(0, print_console, "%s", g_scrollMsg);
 }
 
 public setMessage()
 {
-	remove_task(123);		/* remove current messaging */
+	remove_task(SCROLLMSG_TASK);		/* remove current messaging */
 	read_argv(1, g_scrollMsg, charsmax(g_scrollMsg));
 	
 	g_Length = strlen(g_scrollMsg);
@@ -138,7 +139,7 @@ public setMessage()
 		}
 
 		server_print("%L", LANG_SERVER, "MSG_FREQ", g_Frequency / 60, g_Frequency % 60);
-		set_task(float(g_Frequency), "msgInit", 123, "", 0, "b");
+		set_task(float(g_Frequency), "msgInit", SCROLLMSG_TASK, "", 0, "b");
 	}
 	else
 	{

--- a/plugins/scrollmsg.sma
+++ b/plugins/scrollmsg.sma
@@ -19,6 +19,7 @@
 new g_amx_scrollmsg_color_red;
 new g_amx_scrollmsg_color_green;
 new g_amx_scrollmsg_color_blue;
+new g_amx_scrollmsg_only_dead;
 new Float:g_amx_scrollmsg_speed;
 new Float:g_amx_scrollmsg_x_move_amount;
 new Float:g_amx_scrollmsg_x_start_pos;
@@ -44,6 +45,7 @@ public plugin_init()
 	bind_pcvar_num(create_cvar(   "amx_scrollmsg_color_red",       "200",      _, "Red color amount",                             true, 0.0, true, 255.0), g_amx_scrollmsg_color_red);
 	bind_pcvar_num(create_cvar(   "amx_scrollmsg_color_green",     "100",      _, "Green color amount",                           true, 0.0, true, 255.0), g_amx_scrollmsg_color_green);
 	bind_pcvar_num(create_cvar(   "amx_scrollmsg_color_blue",      "0",        _, "Blue color amount",                            true, 0.0, true, 255.0), g_amx_scrollmsg_color_blue);
+	bind_pcvar_num(create_cvar(   "amx_scrollmsg_only_dead",       "0",        _, "Display the message only to dead clients?",    true, 0.0, true, 1.0),   g_amx_scrollmsg_only_dead);
 	bind_pcvar_float(create_cvar( "amx_scrollmsg_speed",           "0.3",      _, "The rate at which the message will move",      true, 0.0),              g_amx_scrollmsg_speed);
 	bind_pcvar_float(create_cvar( "amx_scrollmsg_x_move_amount",   "0.0063",   _, "The amount of units to move on the X axis"),                            g_amx_scrollmsg_x_move_amount);
 	bind_pcvar_float(create_cvar( "amx_scrollmsg_x_start_pos",     "0.35",     _, "Starting position on the X axis",              true, -1.0, true, 1.0),  g_amx_scrollmsg_x_start_pos);
@@ -78,7 +80,21 @@ public showMsg()
 	}
 
 	set_hudmessage(g_amx_scrollmsg_color_red, g_amx_scrollmsg_color_green, g_amx_scrollmsg_color_blue, g_xPos, g_amx_scrollmsg_y_pos, 0, g_amx_scrollmsg_speed, g_amx_scrollmsg_speed, 0.05, 0.05, 2);
-	show_hudmessage(0, "%s", g_displayMsg);
+
+	if(g_amx_scrollmsg_only_dead)
+	{
+		new players[MAX_PLAYERS], pnum;
+		get_players_ex(players, pnum, GetPlayers_ExcludeBots|GetPlayers_ExcludeHLTV|GetPlayers_ExcludeAlive);
+
+		for(new i; i < pnum; i++)
+		{
+			show_hudmessage(players[i], g_displayMsg);
+		}
+	}
+	else
+	{
+		show_hudmessage(0, "%s", g_displayMsg);
+	}
 }
 
 public msgInit()

--- a/plugins/scrollmsg.sma
+++ b/plugins/scrollmsg.sma
@@ -110,12 +110,12 @@ public msgInit()
 	g_start_pos = 0;
 	g_x_pos = g_amx_scrollmsg_x_end_pos;
 	
-	replace(g_scroll_msg, charsmax(g_scroll_msg), "%hostname%", g_hostname);
+	replace_stringex(g_scroll_msg, charsmax(g_scroll_msg), "%hostname%", g_hostname);
 	
 	g_length = strlen(g_scroll_msg);
 	
-	set_task(g_amx_scrollmsg_speed, "showMsg", SCROLLMSG_TASK, "", 0, "a", g_length + 48);
-	client_print(0, print_console, "%s", g_scroll_msg);
+	set_task_ex(g_amx_scrollmsg_speed, "showMsg", SCROLLMSG_TASK, "", 0, SetTask_RepeatTimes, g_length + 48);
+	console_print(0, g_scroll_msg);
 }
 
 public setMessage()
@@ -124,12 +124,7 @@ public setMessage()
 	read_argv(1, g_scroll_msg, charsmax(g_scroll_msg));
 	
 	g_length = strlen(g_scroll_msg);
-	
-	new mytime[32];
-	
-	read_argv(2, mytime, charsmax(mytime));
-	
-	g_frequency = str_to_num(mytime);
+	g_frequency = read_argv_int(2);
 	
 	if (g_frequency > 0)
 	{
@@ -142,7 +137,7 @@ public setMessage()
 		}
 
 		server_print("%L", LANG_SERVER, "MSG_FREQ", g_frequency / 60, g_frequency % 60);
-		set_task(float(g_frequency), "msgInit", SCROLLMSG_TASK, "", 0, "b");
+		set_task_ex(float(g_frequency), "msgInit", SCROLLMSG_TASK, "", 0, SetTask_Repeat);
 	}
 	else
 	{

--- a/plugins/scrollmsg.sma
+++ b/plugins/scrollmsg.sma
@@ -14,8 +14,16 @@
 #include <amxmodx>
 #include <amxmisc>
 
-#define SPEED 0.3
-#define SCROLLMSG_SIZE	512
+#define SCROLLMSG_SIZE 512
+
+new g_amx_scrollmsg_color_red;
+new g_amx_scrollmsg_color_green;
+new g_amx_scrollmsg_color_blue;
+new Float:g_amx_scrollmsg_speed;
+new Float:g_amx_scrollmsg_x_move_amount;
+new Float:g_amx_scrollmsg_x_start_pos;
+new Float:g_amx_scrollmsg_x_end_pos;
+new Float:g_amx_scrollmsg_y_pos;
 
 new g_startPos;
 new g_endPos;
@@ -28,9 +36,19 @@ new g_Frequency;
 public plugin_init()
 {
 	register_plugin("Scrolling Message", AMXX_VERSION_STR, "AMXX Dev Team");
+
 	register_dictionary("scrollmsg.txt");
 	register_dictionary("common.txt");
 	register_srvcmd("amx_scrollmsg", "setMessage");
+
+	bind_pcvar_num(create_cvar(   "amx_scrollmsg_color_red",       "200",      _, "Red color amount",                             true, 0.0, true, 255.0), g_amx_scrollmsg_color_red);
+	bind_pcvar_num(create_cvar(   "amx_scrollmsg_color_green",     "100",      _, "Green color amount",                           true, 0.0, true, 255.0), g_amx_scrollmsg_color_green);
+	bind_pcvar_num(create_cvar(   "amx_scrollmsg_color_blue",      "0",        _, "Blue color amount",                            true, 0.0, true, 255.0), g_amx_scrollmsg_color_blue);
+	bind_pcvar_float(create_cvar( "amx_scrollmsg_speed",           "0.3",      _, "The rate at which the message will move",      true, 0.0),              g_amx_scrollmsg_speed);
+	bind_pcvar_float(create_cvar( "amx_scrollmsg_x_move_amount",   "0.0063",   _, "The amount of units to move on the X axis"),                            g_amx_scrollmsg_x_move_amount);
+	bind_pcvar_float(create_cvar( "amx_scrollmsg_x_start_pos",     "0.35",     _, "Starting position on the X axis",              true, -1.0, true, 1.0),  g_amx_scrollmsg_x_start_pos);
+	bind_pcvar_float(create_cvar( "amx_scrollmsg_x_end_pos",       "0.65",     _, "Ending position on the X axis",                true, -1.0, true, 1.0),  g_amx_scrollmsg_x_end_pos);
+	bind_pcvar_float(create_cvar( "amx_scrollmsg_y_pos",           "0.9",      _, "The Y position of the message",                true, -1.0, true, 1.0),  g_amx_scrollmsg_y_pos);
 }
 
 public showMsg()
@@ -49,17 +67,17 @@ public showMsg()
 		g_endPos++;
 	}
 
-	if (g_xPos > 0.35)
+	if (g_xPos > g_amx_scrollmsg_x_start_pos)
 	{
-		g_xPos -= 0.0063;
+		g_xPos -= g_amx_scrollmsg_x_move_amount;
 	}
 	else
 	{
 		g_startPos++;
-		g_xPos = 0.35;
+		g_xPos = g_amx_scrollmsg_x_start_pos;
 	}
 
-	set_hudmessage(200, 100, 0, g_xPos, 0.90, 0, SPEED, SPEED, 0.05, 0.05, 2);
+	set_hudmessage(g_amx_scrollmsg_color_red, g_amx_scrollmsg_color_green, g_amx_scrollmsg_color_blue, g_xPos, g_amx_scrollmsg_y_pos, 0, g_amx_scrollmsg_speed, g_amx_scrollmsg_speed, 0.05, 0.05, 2);
 	show_hudmessage(0, "%s", g_displayMsg);
 }
 
@@ -67,7 +85,7 @@ public msgInit()
 {
 	g_endPos = 1;
 	g_startPos = 0;
-	g_xPos = 0.65;
+	g_xPos = g_amx_scrollmsg_x_end_pos;
 	
 	new hostname[64];
 	
@@ -76,7 +94,7 @@ public msgInit()
 	
 	g_Length = strlen(g_scrollMsg);
 	
-	set_task(SPEED, "showMsg", 123, "", 0, "a", g_Length + 48);
+	set_task(g_amx_scrollmsg_speed, "showMsg", 123, "", 0, "a", g_Length + 48);
 	client_print(0, print_console, "%s", g_scrollMsg);
 }
 
@@ -95,7 +113,7 @@ public setMessage()
 	
 	if (g_Frequency > 0)
 	{
-		new minimal = floatround((g_Length + 48) * (SPEED + 0.1));
+		new minimal = floatround((g_Length + 48) * (g_amx_scrollmsg_speed + 0.1));
 		
 		if (g_Frequency < minimal)
 		{

--- a/plugins/scrollmsg.sma
+++ b/plugins/scrollmsg.sma
@@ -28,13 +28,13 @@ new Float:g_amx_scrollmsg_x_start_pos;
 new Float:g_amx_scrollmsg_x_end_pos;
 new Float:g_amx_scrollmsg_y_pos;
 
-new g_startPos;
-new g_endPos;
-new g_scrollMsg[SCROLLMSG_SIZE];
-new g_displayMsg[SCROLLMSG_SIZE];
-new Float:g_xPos;
-new g_Length;
-new g_Frequency;
+new g_start_pos;
+new g_end_pos;
+new g_scroll_msg[SCROLLMSG_SIZE];
+new g_display_msg[SCROLLMSG_SIZE];
+new Float:g_x_pos;
+new g_length;
+new g_frequency;
 
 public plugin_init()
 {
@@ -59,31 +59,31 @@ public plugin_init()
 
 public showMsg()
 {
-	new a = g_startPos, i = 0;
+	new a = g_start_pos, i = 0;
 
-	while (a < g_endPos)
+	while (a < g_end_pos)
 	{
-		g_displayMsg[i++] = g_scrollMsg[a++];
+		g_display_msg[i++] = g_scroll_msg[a++];
 	}
 
-	g_displayMsg[i] = 0;
+	g_display_msg[i] = 0;
 
-	if (g_endPos < g_Length)
+	if (g_end_pos < g_length)
 	{
-		g_endPos++;
+		g_end_pos++;
 	}
 
-	if (g_xPos > g_amx_scrollmsg_x_start_pos)
+	if (g_x_pos > g_amx_scrollmsg_x_start_pos)
 	{
-		g_xPos -= g_amx_scrollmsg_x_move_amount;
+		g_x_pos -= g_amx_scrollmsg_x_move_amount;
 	}
 	else
 	{
-		g_startPos++;
-		g_xPos = g_amx_scrollmsg_x_start_pos;
+		g_start_pos++;
+		g_x_pos = g_amx_scrollmsg_x_start_pos;
 	}
 
-	set_hudmessage(g_amx_scrollmsg_color_red, g_amx_scrollmsg_color_green, g_amx_scrollmsg_color_blue, g_xPos, g_amx_scrollmsg_y_pos, 0, g_amx_scrollmsg_speed, g_amx_scrollmsg_speed, 0.05, 0.05, 2);
+	set_hudmessage(g_amx_scrollmsg_color_red, g_amx_scrollmsg_color_green, g_amx_scrollmsg_color_blue, g_x_pos, g_amx_scrollmsg_y_pos, 0, g_amx_scrollmsg_speed, g_amx_scrollmsg_speed, 0.05, 0.05, 2);
 
 	if(g_amx_scrollmsg_only_dead)
 	{
@@ -92,54 +92,54 @@ public showMsg()
 
 		for(new i; i < pnum; i++)
 		{
-			show_hudmessage(players[i], g_displayMsg);
+			show_hudmessage(players[i], g_display_msg);
 		}
 	}
 	else
 	{
-		show_hudmessage(0, "%s", g_displayMsg);
+		show_hudmessage(0, "%s", g_display_msg);
 	}
 }
 
 public msgInit()
 {
-	g_endPos = 1;
-	g_startPos = 0;
-	g_xPos = g_amx_scrollmsg_x_end_pos;
+	g_end_pos = 1;
+	g_start_pos = 0;
+	g_x_pos = g_amx_scrollmsg_x_end_pos;
 	
-	replace(g_scrollMsg, charsmax(g_scrollMsg), "%hostname%", g_hostname);
+	replace(g_scroll_msg, charsmax(g_scroll_msg), "%hostname%", g_hostname);
 	
-	g_Length = strlen(g_scrollMsg);
+	g_length = strlen(g_scroll_msg);
 	
-	set_task(g_amx_scrollmsg_speed, "showMsg", SCROLLMSG_TASK, "", 0, "a", g_Length + 48);
-	client_print(0, print_console, "%s", g_scrollMsg);
+	set_task(g_amx_scrollmsg_speed, "showMsg", SCROLLMSG_TASK, "", 0, "a", g_length + 48);
+	client_print(0, print_console, "%s", g_scroll_msg);
 }
 
 public setMessage()
 {
 	remove_task(SCROLLMSG_TASK);		/* remove current messaging */
-	read_argv(1, g_scrollMsg, charsmax(g_scrollMsg));
+	read_argv(1, g_scroll_msg, charsmax(g_scroll_msg));
 	
-	g_Length = strlen(g_scrollMsg);
+	g_length = strlen(g_scroll_msg);
 	
 	new mytime[32];
 	
 	read_argv(2, mytime, charsmax(mytime));
 	
-	g_Frequency = str_to_num(mytime);
+	g_frequency = str_to_num(mytime);
 	
-	if (g_Frequency > 0)
+	if (g_frequency > 0)
 	{
-		new minimal = floatround((g_Length + 48) * (g_amx_scrollmsg_speed + 0.1));
+		new minimal = floatround((g_length + 48) * (g_amx_scrollmsg_speed + 0.1));
 		
-		if (g_Frequency < minimal)
+		if (g_frequency < minimal)
 		{
 			server_print("%L", LANG_SERVER, "MIN_FREQ", minimal);
-			g_Frequency = minimal;
+			g_frequency = minimal;
 		}
 
-		server_print("%L", LANG_SERVER, "MSG_FREQ", g_Frequency / 60, g_Frequency % 60);
-		set_task(float(g_Frequency), "msgInit", SCROLLMSG_TASK, "", 0, "b");
+		server_print("%L", LANG_SERVER, "MSG_FREQ", g_frequency / 60, g_frequency % 60);
+		set_task(float(g_frequency), "msgInit", SCROLLMSG_TASK, "", 0, "b");
 	}
 	else
 	{

--- a/plugins/scrollmsg.sma
+++ b/plugins/scrollmsg.sma
@@ -43,7 +43,7 @@ public plugin_init()
 	register_dictionary("scrollmsg.txt");
 	register_dictionary("common.txt");
 
-	register_srvcmd("amx_scrollmsg", "setMessage");
+	register_srvcmd("amx_scrollmsg", "setMessage", _, "<message>");
 	bind_pcvar_string(get_cvar_pointer("hostname"), g_hostname, charsmax(g_hostname));
 
 	bind_pcvar_num(create_cvar(   "amx_scrollmsg_color_red",       "200",      _, "Red color amount",                             true, 0.0, true, 255.0), g_amx_scrollmsg_color_red);

--- a/plugins/scrollmsg.sma
+++ b/plugins/scrollmsg.sma
@@ -43,7 +43,7 @@ public plugin_init()
 	register_dictionary("scrollmsg.txt");
 	register_dictionary("common.txt");
 
-	register_srvcmd("amx_scrollmsg", "setMessage", _, "<message>");
+	register_srvcmd("amx_scrollmsg", "setMessage", _, "<message> <frequency>");
 	bind_pcvar_string(get_cvar_pointer("hostname"), g_hostname, charsmax(g_hostname));
 
 	bind_pcvar_num(create_cvar(   "amx_scrollmsg_color_red",       "200",      _, "Red color amount",                             true, 0.0, true, 255.0), g_amx_scrollmsg_color_red);


### PR DESCRIPTION
The changes include:

1. Added cvar `amx_scrollmsg_color_red`.
2. Added cvar `amx_scrollmsg_color_green`.
3. Added cvar `amx_scrollmsg_color_blue`.
4. Added cvar `amx_scrollmsg_only_dead`.
5. Added cvar `amx_scrollmsg_speed`.
6. Added cvar `amx_scrollmsg_x_move_amount`.
7. Added cvar `amx_scrollmsg_x_start_pos`.
8. Added cvar `amx_scrollmsg_x_end_pos`.
9. Added cvar `amx_scrollmsg_y_pos`.
10. Usage of `create_cvar` and `bind_pcvar_*` functions instead of the old ones.
11. Change `show_hudmessage` to `ShowSyncHudMsg` to prevent overlapping messages if the repeat time is shorter.
12. Consistent variable names, semicolons and brackets.
13. Usage of `AutoConfigExec` - let me know if you want this to stay. I believe it's better this way rather than adding every cvar in `amxx.cfg`.