### PR TITLE
Compiler: Increase the maximum number of array dimension

### DIFF
--- a/compiler/libpc300/sc.h
+++ b/compiler/libpc300/sc.h
@@ -54,7 +54,7 @@
 #define CTRL_CHAR   '^'    /* default control character */
 #define sCHARBITS   8       /* size of a packed character */
 
-#define sDIMEN_MAX     3    /* maximum number of array dimensions */
+#define sDIMEN_MAX     4    /* maximum number of array dimensions */
 #define sLINEMAX     4095    /* input line length (in characters) */
 #define sCOMP_STACK   32    /* maximum nesting of #if .. #endif sections */
 #define sDEF_LITMAX  500    /* initial size of the literal pool, in "cells" */

--- a/compiler/libpc300/sc1.c
+++ b/compiler/libpc300/sc1.c
@@ -2170,53 +2170,48 @@ static cell calc_arraysize(int dim[],int numdim,int cur)
   return dim[cur]+(dim[cur]*calc_arraysize(dim,numdim,cur+1));
 }
 
-static cell adjust_indirectiontables(int dim[],int numdim,int cur,cell increment,
-                                     int startlit,constvalue *lastdim,int *skipdim)
+static void adjust_indirectiontables(int dim[],int numdim,int startlit,
+                                     constvalue *lastdim,int *skipdim)
 {
 static int base;
-  int d;
+  int cur;
+  int i,d;
   cell accum;
+  cell size;
 
-  assert(cur>=0 && cur<numdim);
-  assert(increment>=0);
-  assert(cur>0 && startlit==-1 || startlit>=0 && startlit<=litidx);
-  if (cur==0)
-    base=startlit;
-  if (cur==numdim-1)
-    return 0;
-  /* 2 or more dimensions left, fill in an indirection vector */
-  assert(dim[cur]>0);
-  if (dim[cur+1]>0) {
-    for (d=0; d<dim[cur]; d++)
-      litq[base++]=(dim[cur]+d*(dim[cur+1]-1)+increment) * sizeof(cell);
-    accum=dim[cur]*(dim[cur+1]-1);
-  } else {
-    /* final dimension is variable length */
-    constvalue *ld;
-    assert(dim[cur+1]==0);
-    assert(lastdim!=NULL);
-    assert(skipdim!=NULL);
-    accum=0;
-    /* skip the final dimension sizes for all earlier major dimensions */
-    for (d=0,ld=lastdim->next; d<*skipdim; d++,ld=ld->next) {
-      assert(ld!=NULL);
-    } /* for */
-    for (d=0; d<dim[cur]; d++) {
-      assert(ld!=NULL);
-      assert(strtol(ld->name,NULL,16)==d);
-      litq[base++]=(dim[cur]+accum+increment) * sizeof(cell);
-      accum+=ld->value-1;
-      *skipdim+=1;
-      ld=ld->next;
-    } /* for */
-  } /* if */
-  /* create the indirection tables for the lower level */
-  if (cur+2<numdim) {   /* are there at least 2 dimensions below this one? */
-    increment+=(dim[cur]-1)*dim[cur+1]; /* this many indirection tables follow */
-    for (d=0; d<dim[cur]; d++)
-      increment+=adjust_indirectiontables(dim,numdim,cur+1,increment,-1,lastdim,skipdim);
-  } /* if */
-  return accum;
+  assert(startlit==-1 || startlit>=0 && startlit<=litidx);
+  base=startlit;
+  size=1;
+  for (cur=0; cur<numdim-1; cur++) {
+    /* 2 or more dimensions left, fill in an indirection vector */
+    if (dim[cur+1]>0) {
+      for (i=0; i<size; i++)
+        for (d=0; d<dim[cur]; d++)
+          litq[base++]=(size*dim[cur]+(dim[cur+1]-1)*(dim[cur]*i+d)) * sizeof(cell);
+    } else {
+      /* final dimension is variable length */
+      constvalue *ld;
+      assert(dim[cur+1]==0);
+      assert(lastdim!=NULL);
+      assert(skipdim!=NULL);
+      accum=0;
+      for (i=0; i<size; i++) {
+        /* skip the final dimension sizes for all earlier major dimensions */
+        for (d=0,ld=lastdim->next; d<*skipdim; d++,ld=ld->next) {
+          assert(ld!=NULL);
+        } /* for */
+        for (d=0; d<dim[cur]; d++) {
+          assert(ld!=NULL);
+          assert(strtol(ld->name,NULL,16)==d);
+          litq[base++]=(size*dim[cur]+accum) * sizeof(cell);
+          accum+=ld->value-1;
+          *skipdim+=1;
+          ld=ld->next;
+        } /* for */
+      } /* for */
+    } /* if */
+    size*=dim[cur];
+  } /* for */
 }
 
 /*  initials
@@ -2274,7 +2269,7 @@ static void initials2(int ident,int tag,cell *size,int dim[],int numdim,
       for (tablesize=calc_arraysize(dim,numdim-1,0); tablesize>0; tablesize--)
         litadd(0);
       if (dim[numdim-1]!=0)     /* error 9 has already been given */
-        adjust_indirectiontables(dim,numdim,0,0,curlit,NULL,NULL);
+        adjust_indirectiontables(dim,numdim,curlit,NULL,NULL);
     } /* if */
     return;
   } /* if */
@@ -2340,7 +2335,7 @@ static void initials2(int ident,int tag,cell *size,int dim[],int numdim,
        * of the array and we can properly adjust the indirection vectors
        */
       if (err==0)
-        adjust_indirectiontables(dim,numdim,0,0,curlit,&lastdim,&skipdim);
+        adjust_indirectiontables(dim,numdim,curlit,&lastdim,&skipdim);
       delete_consttable(&lastdim);  /* clear list of minor dimension sizes */
     } /* if */
   } /* if */


### PR DESCRIPTION
Per request. SM uses 4D as well. To be discussed.

Increasing dimension is easy but a fix is necessarry and is stolen from SAMP guys: https://github.com/pawn-lang/compiler/commit/d14f4870a8069ca446c0528a39b75e7d081ba3d5 and https://github.com/pawn-lang/compiler/commit/1cca8af0d2c6d290c095f27f39bd941e4374054e

Small test plugin:
```SourcePawn
#include <amxmodx>

public plugin_init()
{
    new a[2][2][2][2] =
    {
        {
            {
                {1, 2}, {3, 4}
            },
            {
                {5, 6}, {7, 8}
            }
        },
        {
            {
                {11, 12}, {13, 14}
            },
            {
                {15, 16}, {17, 18}
            }
        }
    }

    for (new i = 0; i < sizeof a; i++)
    {
        for (new j = 0; j < sizeof a[]; j++)
         {
            for (new k = 0; k < sizeof a[][]; k++)
            {
                for (new l = 0; l < sizeof a[][][]; l++)
                {
                    server_print("a[%d][%d][%d][%d] = %d", i, j, k, l, a[i][j][k][l]);
                }
            }
        }
    }
}

Output:

a[0][0][0][0] = 1
a[0][0][0][1] = 2
a[0][0][1][0] = 3
a[0][0][1][1] = 4
a[0][1][0][0] = 5
a[0][1][0][1] = 6
a[0][1][1][0] = 7
a[0][1][1][1] = 8
a[1][0][0][0] = 11
a[1][0][0][1] = 12
a[1][0][1][0] = 13
a[1][0][1][1] = 14
a[1][1][0][0] = 15
a[1][1][0][1] = 16
a[1][1][1][0] = 17
a[1][1][1][1] = 18
```

Better visual diff for the fix:
![image](https://user-images.githubusercontent.com/360640/45558865-34061900-b841-11e8-97bb-3072da2942db.png)

Please give some test - here a temporay link for the lib (windows only): http://users.alliedmods.net/~arkshine/amxxpc32.dll