### PR TITLE
Implement menu_create "ml" param to allow menu title/item to be looked up as multilingual key

### DIFF
--- a/amxmodx/msvc12/amxmodx_mm.vcxproj
+++ b/amxmodx/msvc12/amxmodx_mm.vcxproj
@@ -457,6 +457,7 @@ md -p JIT 2&gt;NUL
     <None Include="..\..\plugins\include\cvars.inc" />
     <None Include="..\..\plugins\include\datapack.inc" />
     <None Include="..\..\plugins\include\gameconfig.inc" />
+    <None Include="..\..\plugins\include\newmenus.inc" />
     <None Include="..\..\plugins\include\string_const.inc" />
     <None Include="..\..\plugins\include\string_stocks.inc" />
     <None Include="..\..\plugins\include\textparse_ini.inc" />

--- a/amxmodx/msvc12/amxmodx_mm.vcxproj.filters
+++ b/amxmodx/msvc12/amxmodx_mm.vcxproj.filters
@@ -54,7 +54,7 @@
     </Filter>
     <Filter Include="ReSDK\engine">
       <UniqueIdentifier>{04fab577-6f56-40d0-8f69-7ce1b8bf3bb9}</UniqueIdentifier>
-	</Filter>
+    </Filter>
     <Filter Include="Third Party\UTF8Rewind">
       <UniqueIdentifier>{270f3524-564f-4154-bb35-242a6faac09e}</UniqueIdentifier>
     </Filter>
@@ -691,6 +691,9 @@
       <Filter>Pawn Includes</Filter>
     </None>
     <None Include="..\..\plugins\include\string_stocks.inc">
+      <Filter>Pawn Includes</Filter>
+    </None>
+    <None Include="..\..\plugins\include\newmenus.inc">
       <Filter>Pawn Includes</Filter>
     </None>
   </ItemGroup>

--- a/amxmodx/newmenus.cpp
+++ b/amxmodx/newmenus.cpp
@@ -660,7 +660,7 @@ static cell AMX_NATIVE_CALL menu_create(AMX *amx, cell *params)
 
 	if (callback == -1)
 	{
-		LogError(amx, AMX_ERR_NOTFOUND, R"(Invalid function %s)", handler);
+		LogError(amx, AMX_ERR_NOTFOUND, R"(Invalid function "%s")", handler);
 		return 0;
 	}
 

--- a/amxmodx/newmenus.h
+++ b/amxmodx/newmenus.h
@@ -95,7 +95,7 @@ typedef unsigned int page_t;
 class Menu
 {
 public:
-	Menu(const char *title, AMX *amx, int fid);
+	Menu(const char *title, AMX *amx, int fid, bool use_ml);
 	~Menu();
 	
 	menuitem *GetMenuItem(item_t item);
@@ -127,6 +127,8 @@ public:
 	bool isDestroying;
 	int pageCallback;
 	bool showPageNumber;
+	bool useMultilingual;
+	AMX *amx;
 public:
 	unsigned int items_per_page;
 };

--- a/plugins/include/newmenus.inc
+++ b/plugins/include/newmenus.inc
@@ -117,13 +117,14 @@
  * @param title 		Title the menu should use.
  * @param handler		Name of the handler function.  The function will be invoked 
  *						once and only once to every menu_display() call.
- * @param ml			Unused (should be 0).
+ * @param ml			If true, the menu title and items will be looked up as multilingual keys
+ *                      when the menu displays.
  * @return				Menu resource identifier which must be destroyed via 
  *						menu_destroy().  All menus are destroyed when the plugin 
  *						unloads.
  * @error				Function name not found.
  */
-native menu_create(const title[], const handler[], ml=0);
+native menu_create(const title[], const handler[], bool:ml = false);
 
 /**
  * Creates a menu item callback handler.  


### PR DESCRIPTION
Fixes #590.

When the menu displays, the menu title and items will be looked up as multilingual keys.
If the key doesn't exist, the menu item remains unchanged.

The `ml` param is around since the beginning I believe. It should not be needed to check whether the param exists or not.

Random test plugin:

```SourcePawn
#include <amxmodx>

new StaticMenuHandle;

public plugin_init()
{
    buildStaticMenu();

    register_dictionary("menutest.txt");
    register_clcmd("menu", "@OnCommandDisplayMenu");
}

public plugin_end()
{
    StaticMenuHandle && menu_destroy(StaticMenuHandle);
}

@OnCommandDisplayMenu(const player)
{
    menu_display(player, StaticMenuHandle);

    return PLUGIN_HANDLED;
}

buildStaticMenu()
{
    new const menu = menu_create("MENU_NAME", "@OnStaticMenu", .ml = true);

    menu_additem(menu, "ITEM_1");
    menu_additem(menu, "ITEM_2");
    menu_additem(menu, "ITEM_3");
    menu_additem(menu, "ITEM_4");

    StaticMenuHandle = menu;
}

@OnStaticMenu(const player, const menu, const item)
{

}
```
```
[en]
MENU_NAME = My Awesome Menu
ITEM_1    = My Item 1
ITEM_2    = My Item 2
ITEM_3    = My Item 3
ITEM_4    = My Item 4
```

Result:
![image](https://user-images.githubusercontent.com/360640/45881421-69fc4d80-bdab-11e8-8350-1bdb74ef32d9.png)

If it happens keys don't exist:
![image](https://user-images.githubusercontent.com/360640/45881509-aa5bcb80-bdab-11e8-9e33-9c5197167fba.png)

