### PR TITLE
Fix a crash with set_tr/2 when -1 is passed in TR_pHit

### DIFF
--- a/modules/fakemeta/fm_tr.cpp
+++ b/modules/fakemeta/fm_tr.cpp
@@ -86,7 +86,7 @@ static cell AMX_NATIVE_CALL set_tr(AMX *amx, cell *params)
 	case TR_pHit:
 		{
 			e = TypeConversion.id_to_edict(*ptr);
-			if (*ptr != -1 && FNullEnt(e))
+			if (FNullEnt(e))
 				return 0; //TODO: return error
 			gfm_tr->pHit = e;
 			return 1;

--- a/modules/fakemeta/fm_tr.cpp
+++ b/modules/fakemeta/fm_tr.cpp
@@ -27,7 +27,6 @@ static cell AMX_NATIVE_CALL set_tr(AMX *amx, cell *params)
 	}
 
 	cell *ptr = MF_GetAmxAddr(amx, params[2]);
-	edict_t *e;
 
 	switch (type)
 	{
@@ -85,12 +84,13 @@ static cell AMX_NATIVE_CALL set_tr(AMX *amx, cell *params)
 		}
 	case TR_pHit:
 		{
-			e = TypeConversion.id_to_edict(*ptr);
-			if (FNullEnt(e))
-				return 0; //TODO: return error
-			gfm_tr->pHit = e;
+			const auto pEdict = TypeConversion.id_to_edict(*ptr);
+			if (pEdict == nullptr)
+			{
+				return 0;
+			}
+			gfm_tr->pHit = pEdict;
 			return 1;
-			break;
 		}
 	case TR_iHitgroup:
 		{

--- a/modules/fakemeta/fm_tr2.cpp
+++ b/modules/fakemeta/fm_tr2.cpp
@@ -99,7 +99,7 @@ static cell AMX_NATIVE_CALL set_tr2(AMX *amx, cell *params)
 	case TR_pHit:
 		{
 			edict_t *e = TypeConversion.id_to_edict(*ptr);
-			if (*ptr != -1 && FNullEnt(e))
+			if (FNullEnt(e))
 				return 0; //TODO: return error
 			tr->pHit = e;
 			return 1;

--- a/modules/fakemeta/fm_tr2.cpp
+++ b/modules/fakemeta/fm_tr2.cpp
@@ -98,12 +98,13 @@ static cell AMX_NATIVE_CALL set_tr2(AMX *amx, cell *params)
 		}
 	case TR_pHit:
 		{
-			edict_t *e = TypeConversion.id_to_edict(*ptr);
-			if (FNullEnt(e))
-				return 0; //TODO: return error
-			tr->pHit = e;
+			const auto pEdict = TypeConversion.id_to_edict(*ptr);
+			if (pEdict == nullptr)
+			{
+				return 0;
+			}
+			tr->pHit = pEdict;
 			return 1;
-			break;
 		}
 	case TR_iHitgroup:
 		{


### PR DESCRIPTION
This reverts the changes in #433.

I think it has been imported from ReAMXX. Actually, I'm not sure why this check, but originally the intent could be to allow wordspawn, maybe?

The crash happens due to `id_to_edict` returning `nullptr` if index < 0 and because of the check `pHit` would be set with a `nullptr`.

Also, we should have likely `TR_pHit2` because as it is `TR_pHit` can't return or set wordspawn (0). It relies `FNullEnt` which includes wordspawn. If I'm not wrong, even `entity_get_edict2` is wrong then.

@WPMGPRoSToTeMa