### PR TITLE
Add constants for various game events

### DIFF
--- a/plugins/include/amxmodx.inc
+++ b/plugins/include/amxmodx.inc
@@ -808,7 +808,7 @@ native show_menu(index, keys, const menu[], time = -1, const title[] = "");
  *                         (truncated) to an integer
  *                     2 - Returns the number of cells written to the buffer
  */
-native read_data(value, any:...);
+native read_data(any:value, any:...);
 
 /**
  * Returns the number of values in the client message.

--- a/plugins/include/message_const.inc
+++ b/plugins/include/message_const.inc
@@ -1129,3 +1129,877 @@ enum
 
 #define MAX_DIRECTOR_CMD_PARAMETERS		4
 #define MAX_DIRECTOR_CMD_STRING			128
+
+/**
+ * @section Constants for various event arguments
+ */
+
+/**
+ * Constants for the "AllowSpec" event's arguments
+ */
+enum AllowSpecArgs
+{
+	AllowSpec_IsAllowed
+};
+
+/**
+ * Constants for the "AmmoPickup" event's arguments
+ */
+enum AmmoPickupArgs
+{
+	AmmoPickup_AmmoId,
+	AmmoPickup_Amount
+};
+
+/**
+ * Constants for the "AmmoX" event's arguments
+ */
+enum AmmoXArgs
+{
+	AmmoX_AmmoId,
+	AmmoX_Amount
+};
+
+/**
+ * Constants for the "ArmorType" event's arguments
+ */
+enum ArmorTypeArgs
+{
+	ArmorType_Flag
+};
+
+/**
+ * Constants for the "BarTime" event's arguments
+ */
+enum BarTimeArgs
+{
+	BarTime_Duration
+};
+
+/**
+ * Constants for the "BarTime2" event's arguments
+ */
+enum BarTime2Args
+{
+	BarTime2_Duration,
+	BarTime2_StartPercent
+};
+
+/**
+ * Constants for the "Battery" event's arguments
+ */
+enum BatteryArgs
+{
+	Battery_Armor
+};
+
+/**
+ * Constants for the "BlinkAcct" event's arguments
+ */
+enum BlinkAcctArgs
+{
+	BlinkAcct_BlinkAmount
+};
+
+/**
+ * Constants for the "BloodPuff" event's arguments
+ */
+enum BloodPuffArgs
+{
+	BloodPuff_CoordX,
+	BloodPuff_CoordY,
+	BloodPuff_CoordZ
+};
+
+/**
+ * Constants for the "BombDrop" event's arguments
+ */
+enum BombDropArgs
+{
+	BombDrop_CoordX,
+	BombDrop_CoordY,
+	BombDrop_CoordZ,
+	BombDrop_Flag
+};
+
+/**
+ * Constants for the "BotProgress" event's arguments
+ */
+enum BotProgressArgs
+{
+	BotProgress_Flag,
+	BotProgress_Progress,
+	BotProgress_Header
+};
+
+/**
+ * Constants for the "BotVoice" event's arguments
+ */
+enum BotVoiceArgs
+{
+	BotVoice_Status,
+	BotVoice_PlayerId
+};
+
+/**
+ * Constants for the "Brass" event's arguments
+ */
+enum BrassArgs
+{
+	Brass_MessageId,
+	Brass_StartX,
+	Brass_StartY,
+	Brass_StartZ,
+	Brass_VelocityX,
+	Brass_VelocityY,
+	Brass_VelocityZ,
+	Brass_UnknownX,
+	Brass_UnknownY,
+	Brass_UnknownZ,
+	Brass_Rotation,
+	Brass_ModelId,
+	Brass_BounceSoundType,
+	Brass_Life,
+	Brass_PlayerId
+};
+
+/**
+ * Constants for the "CapMsg" event's arguments
+ */
+enum CapMsgArgs
+{
+	CapMsg_PlayerId,
+	CapMsg_PointName,
+	CapMsg_TeamId,
+};
+
+/**
+ * Constants for the "ClCorpse" event's arguments
+ */
+enum ClCorpseArgs
+{
+	ClCorpse_ModelName,
+	ClCorpse_CoordX,
+	ClCorpse_CoordY,
+	ClCorpse_CoordZ,
+	ClCorpse_Angle0,
+	ClCorpse_Angle1,
+	ClCorpse_Angle2,
+	ClCorpse_Delay,
+	ClCorpse_Sequence,
+	ClCorpse_ClassId,
+	ClCorpse_TeamId,
+	ClCorpse_PlayerId
+};
+
+/**
+ * Constants for the "Concuss" event's arguments
+ */
+enum ConcussArgs
+{
+	Concuss_Amount
+};
+
+/**
+ * Constants for the "Crosshair" event's arguments
+ */
+enum CrosshairArgs
+{
+	Crosshair_Flag
+};
+
+/**
+ * Constants for the "CurWeapon" event's arguments
+ */
+enum CurWeaponArgs
+{
+	CurWeapon_IsActive,
+	CurWeapon_WeaponId,
+	CurWeapon_ClipAmmo
+};
+
+/**
+ * Constants for the "CZCareer" event's arguments
+ */
+enum CZCareerArgs
+{
+	CZCareer_Type
+};
+
+/**
+ * Constants for the "CZCareerHUD" event's arguments
+ */
+enum CZCareerHUDArgs
+{
+	CZCareerHUD_Type
+};
+
+/**
+ * Constants for the "Damage" event's arguments
+ */
+enum DamageArgs
+{
+	Damage_Save,
+	Damage_Take,
+	Damage_Type,
+	Damage_CoordX,
+	Damage_CoordY,
+	Damage_CoordZ
+};
+
+/**
+ * Constants for the "DeathMsg" event's arguments (all games)
+ */
+enum DeathMsgArgs
+{
+	DeathMsg_KillerId,
+	DeathMsg_VictimId,
+	DeathMsg_WeaponName
+};
+
+/**
+ * Constants for the "DeathMsg" event's arguments (Counter-Strike)
+ */
+enum DeathMsgArgs_CS
+{
+	DeathMsg_CS_KillerId,
+	DeathMsg_CS_VictimId,
+	DeathMsg_CS_IsHeadshot,
+	DeathMsg_CS_WeaponName
+};
+
+/**
+ * Constants for the "DeathMsg" event's arguments (Day of Defeat)
+ */
+enum DeathMsgArgs_DoD
+{
+	DeathMsg_DoD_KillerId,
+	DeathMsg_DoD_VictimId,
+	DeathMsg_DoD_WeaponId
+};
+
+/**
+ * Constants for the "FlashBat" event's arguments
+ */
+enum FlashBatArgs
+{
+	FlashBat_ChargePercent
+};
+
+/**
+ * Constants for the "Flashlight" event's arguments
+ */
+enum FlashlightArgs
+{
+	Flashlight_Flag,
+	Flashlight_ChargePercent
+};
+
+/**
+ * Constants for the "Fog" event's arguments
+ */
+enum FogArgs
+{
+	Fog_Value1,
+	Fog_Value2,
+	Fog_Unknown
+};
+
+/**
+ * Constants for the "ForceCam" event's arguments
+ */
+enum ForceCamArgs
+{
+	ForceCam_Value,
+	ForceCam_ChaseCamValue,
+	ForceCam_Unknown
+};
+
+/**
+ * Constants for the "Frags" event's arguments
+ */
+enum FragsArgs
+{
+	Frags_PlayerId,
+	Frags_Amount
+};
+
+/**
+ * Constants for the "GameMode" event's arguments
+ */
+enum GameModeArgs
+{
+	GameMode_Type
+};
+
+/**
+ * Constants for the "GameTitle" event's arguments
+ */
+enum GameTitleArgs
+{
+	GameTitle_Unknown
+};
+
+/**
+ * Constants for the "Geiger" event's arguments
+ */
+enum GeigerArgs
+{
+	Geiger_Distance
+};
+
+/**
+ * Constants for the "Health" event's arguments
+ */
+enum HealthArgs
+{
+	Health_Amount
+};
+
+/**
+ * Constants for the "HideWeapon" event's arguments
+ */
+enum HideWeaponArgs
+{
+	HideWeapon_Flags
+};
+
+/**
+ * Constants for the "HLTV" event's arguments
+ */
+enum HLTVArgs
+{
+	HLTV_ClientId,
+	HLTV_Flags
+};
+
+/**
+ * Constants for the "HostageK" event's arguments
+ */
+enum HostageKArgs
+{
+	HostageK_HostageId
+};
+
+/**
+ * Constants for the "HostagePos" event's arguments
+ */
+enum HostagePosArgs
+{
+	HostagePos_Flag,
+	HostagePos_HostageId,
+	HostagePos_CoordX,
+	HostagePos_CoordY,
+	HostagePos_CoordZ
+};
+
+/**
+ * Constants for the "HudText" event's arguments
+ */
+enum HudTextArgs
+{
+	HudText_TextCode,
+	HudText_InitHUDStyle
+};
+
+/**
+ * Constants for the "HudTextArgs" event's arguments
+ */
+enum HudTextArgsArgs
+{
+	HudTextArgs_TextCode,
+	HudTextArgs_InitHUDStyle,
+	HudTextArgs_NumberOfSubMessages,
+	HudTextArgs_SubMsg1,
+	HudTextArgs_SubMsg2
+};
+
+/**
+ * Constants for the "HudTextPro" event's arguments
+ */
+enum HudTextProArgs
+{
+	HudTextPro_TextCode,
+	HudTextPro_InitHUDStyle
+};
+
+/**
+ * Constants for the "InitObj" event's arguments
+ */
+enum InitObjArgs
+{
+	InitObj_TotalObjectives
+};
+
+/**
+ * Constants for the "TotalObjectives" argument in the InitObj" event
+ */
+enum InitObj_TotalObjectivesArgs
+{
+	InitObj_TotalObjectives_EntityId,
+	InitObj_TotalObjectives_ObjectiveId,
+	InitObj_TotalObjectives_TeamId,
+	InitObj_TotalObjectives_Unknown1,
+	InitObj_TotalObjectives_Unknown2,
+	InitObj_TotalObjectives_Unknown3,
+	InitObj_TotalObjectives_Unknown4,
+	InitObj_TotalObjectives_CoordX,
+	InitObj_TotalObjectives_CoordY
+};
+
+/**
+ * Constants for the "ItemPickup" event's arguments
+ */
+enum ItemPickupArgs
+{
+	ItemPickup_ItemName
+};
+
+/**
+ * Constants for the "ItemStatus" event's arguments
+ */
+enum ItemStatusArgs
+{
+	ItemStatus_ItemsBitSum
+};
+
+/**
+ * Constants for the "Location" event's arguments
+ */
+enum LocationArgs
+{
+	Location_PlayerId,
+	Location_Name
+};
+
+/**
+ * Constants for the "Money" event's arguments
+ */
+enum MoneyArgs
+{
+	Money_Amount,
+	Money_Flag
+};
+
+/**
+ * Constants for the "MOTD" event's arguments
+ */
+enum MOTDArgs
+{
+	MOTD_Flag,
+	MOTD_Text
+};
+
+/**
+ * Constants for the "NVGToggle" event's arguments
+ */
+enum NVGToggleArgs
+{
+	NVGToggle_Flag
+};
+
+/**
+ * Constants for the "Object" event's arguments
+ */
+enum ObjectArgs
+{
+	Object_Sprite
+};
+
+/**
+ * Constants for the "ObjScore" event's arguments
+ */
+enum ObjScoreArgs
+{
+	ObjScore_PlayerId,
+	ObjScore_Score
+};
+
+/**
+ * Constants for the "PClass" event's arguments
+ */
+enum PClassArgs
+{
+	PClass_PlayerId,
+	PClass_Unknown
+};
+
+/**
+ * Constants for the "PStatus" event's arguments
+ */
+enum PStatusArgs
+{
+	PStatus_PlayerId,
+	PStatus_Unknown
+};
+
+/**
+ * Constants for the "Radar" event's arguments
+ */
+enum RadarArgs
+{
+	Radar_PlayerId,
+	Radar_CoordX,
+	Radar_CoordY,
+	Radar_CoordZ
+};
+
+/**
+ * Constants for the "ReceiveW" event's arguments
+ */
+enum ReceiveWArgs
+{
+	ReceiveW_Mode
+};
+
+/**
+ * Constants for the "ReloadSound" event's arguments
+ */
+enum ReloadSoundArgs
+{
+	ReloadSound_Volume,
+	ReloadSound_IsNotShotgun
+};
+
+/**
+ * Constants for the "RoundTime" event's arguments
+ */
+enum RoundTimeArgs
+{
+	RoundTime_Time
+};
+
+/**
+ * Constants for the "SayText" event's arguments
+ */
+enum SayTextArgs
+{
+	SayText_SenderId,
+	SayText_String1,
+	SayText_String2,
+	SayText_String3
+};
+
+/**
+ * Constants for the "Scenario" event's arguments
+ */
+enum ScenarioArgs
+{
+	Scenario_IsActive,
+	Scenario_Sprite,
+	Scenario_Alpha,
+	Scenario_FlashRate,
+	Scenario_FlashDelay
+};
+
+/**
+ * Constants for the "Scope" event's arguments
+ */
+enum ScopeArgs
+{
+	Scope_Unknown
+};
+
+/**
+ * Constants for the "ScoreAttrib" event's arguments
+ */
+enum ScoreAttribArgs
+{
+	ScoreAttrib_PlayerId,
+	ScoreAttrib_Flags
+};
+
+/**
+ * Constants for the "ScoreInfo" event's arguments
+ */
+enum ScoreInfoArgs
+{
+	ScoreInfo_PlayerId,
+	ScoreInfo_Score,
+	ScoreInfo_Deaths,
+	ScoreInfo_ClassId,
+	ScoreInfo_TeamId,
+};
+
+/**
+ * Constants for the "ScoreShort" event's arguments
+ */
+enum ScoreShortArgs
+{
+	ScoreShort_PlayerId,
+	ScoreShort_Score,
+	ScoreShort_Kills,
+	ScoreShort_Deaths,
+	ScoreShort_Refresh
+};
+
+/**
+ * Constants for the "ScreenFade" event's arguments
+ */
+enum ScreenFadeArgs
+{
+	ScreenFade_Duration,
+	ScreenFade_HoldTime,
+	ScreenFade_Flags,
+	ScreenFade_ColorR,
+	ScreenFade_ColorG,
+	ScreenFade_ColorB,
+	ScreenFade_Alpha
+};
+
+/**
+ * Constants for the "ScreenShake" event's arguments
+ */
+enum ScreenShakeArgs
+{
+	ScreenShake_Amplitude,
+	ScreenShake_Duration,
+	ScreenShake_Frequency
+};
+
+/**
+ * Constants for the "SecAmmoIcon" event's arguments
+ */
+enum SecAmmoIconArgs
+{
+	SecAmmoIcon_Icon
+};
+
+/**
+ * Constants for the "SecAmmoVal" event's arguments
+ */
+enum SecAmmoValArgs
+{
+	SecAmmoVal_Slot,
+	SecAmmoVal_Amount
+};
+
+/**
+ * Constants for the "SendAudio" event's arguments
+ */
+enum SendAudioArgs
+{
+	SendAudio_SenderId,
+	SendAudio_AudioCode,
+	SendAudio_Pitch
+};
+
+/**
+ * Constants for the "ServerName" event's arguments
+ */
+enum ServerNameArgs
+{
+	ServerName_Name
+};
+
+/**
+ * Constants for the "SetFOV" event's arguments
+ */
+enum SetFOVArgs
+{
+	SetFOV_Degrees
+};
+
+/**
+ * Constants for the "SetObj" event's arguments
+ */
+enum SetObjArgs
+{
+	SetObj_Unknown1,
+	SetObj_Unknown2,
+	SetObj_Unknown3
+};
+
+/**
+ * Constants for the "ShadowIdx" event's arguments
+ */
+enum ShadowIdxArgs
+{
+	ShadowIdx_SpriteId
+};
+
+/**
+ * Constants for the "ShowMenu" event's arguments
+ */
+enum ShowMenuArgs
+{
+	ShowMenu_KeysBitSum,
+	ShowMenu_Time,
+	ShowMenu_Multipart,
+	ShowMenu_Text
+};
+
+/**
+ * Constants for the "SpecHealth" event's arguments
+ */
+enum SpecHealthArgs
+{
+	SpecHealth_Health
+};
+
+/**
+ * Constants for the "SpecHealth2" event's arguments
+ */
+enum SpecHealth2Args
+{
+	SpecHealth2_Health,
+	SpecHealth2_PlayerId
+};
+
+/**
+ * Constants for the "Spectator" event's arguments
+ */
+enum SpectatorArgs
+{
+	Spectator_ClientId,
+	Spectator_Unknown
+};
+
+/**
+ * Constants for the "StatusIcon" event's arguments
+ */
+enum StatusIconArgs
+{
+	StatusIcon_Status,
+	StatusIcon_SpriteName,
+	StatusIcon_ColorR,
+	StatusIcon_ColorG,
+	StatusIcon_ColorB
+};
+
+/**
+ * Constants for the "StatusText" event's arguments
+ */
+enum StatusTextArgs
+{
+	StatusText_Unknown,
+	StatusText_Text
+};
+
+/**
+ * Constants for the "StatusValue" event's arguments
+ */
+enum StatusValueArgs
+{
+	StatusValue_Flag,
+	StatusValue_Value
+};
+
+/**
+ * Constants for the "TaskTime" event's arguments
+ */
+enum TaskTimeArgs
+{
+	TaskTime_Time,
+	TaskTime_Active,
+	TaskTime_Fade
+};
+
+/**
+ * Constants for the "TeamInfo" event's arguments
+ */
+enum TeamInfoArgs
+{
+	TeamInfo_PlayerId,
+	TeamInfo_TeamName
+};
+
+/**
+ * Constants for the "TeamScore" event's arguments (all games)
+ */
+enum TeamScoreArgs
+{
+	TeamScore_TeamName,
+	TeamScore_Score
+};
+
+/**
+ * Constants for the "TeamScore" event's arguments (Day of Defeat)
+ */
+enum TeamScoreArgs_DoD
+{
+	TeamScore_DoD_TeamId,
+	TeamScore_DoD_Score
+};
+
+/**
+ * Constants for the "TextMsg" event's arguments
+ */
+enum TextMsgArgs
+{
+	TextMsg_DestinationType,
+	TextMsg_Message,
+	TextMsg_SubMsg1,
+	TextMsg_SubMsg2,
+	TextMsg_SubMsg3,
+	TextMsg_SubMsg4
+};
+
+/**
+ * Constants for the "Train" event's arguments
+ */
+enum TrainArgs
+{
+	Train_Speed
+};
+
+/**
+ * Constants for the "TutorState" event's arguments
+ */
+enum TutorStateArgs
+{
+	TutorState_Unknown
+};
+
+/**
+ * Constants for the "VGUIMenu" event's arguments
+ */
+enum VGUIMenuArgs
+{
+	VGUIMenu_MenuId,
+	VGUIMenu_KeysBitSum,
+	VGUIMenu_Time,
+	VGUIMenu_Multipart,
+	VGUIMenu_Name
+};
+
+/**
+ * Constants for the "VoiceMask" event's arguments
+ */
+enum VoiceMaskArgs
+{
+	VoiceMask_AudiblePlayersBitSum,
+	VoiceMask_BannedPlayersBitSum
+};
+
+/**
+ * Constants for the "WeaponList" event's arguments
+ */
+enum WeaponListArgs
+{
+	WeaponList_WeaponName,
+	WeaponList_PrimaryAmmoId,
+	WeaponList_PrimaryAmmoMaxAmount,
+	WeaponList_SecondaryAmmoId,
+	WeaponList_SecondaryAmmoMaxAmount,
+	WeaponList_SlotId,
+	WeaponList_NumberInSlot,
+	WeaponList_WeaponId,
+	WeaponList_Flags
+};
+
+/**
+ * Constants for the "WeapPickup" event's arguments
+ */
+enum WeapPickupArgs
+{
+	WeapPickup_WeaponId
+};
+
+/**
+ * Constants for the "YouDied" event's arguments
+ */
+enum YouDiedArgs
+{
+	YouDied_Unknown
+};

--- a/plugins/include/messages.inc
+++ b/plugins/include/messages.inc
@@ -496,7 +496,7 @@ native get_msg_args();
  *
  * @return               Argument type (see ARG_* constants in message_const.inc)
  */
-native get_msg_argtype(argn);
+native get_msg_argtype(any:argn);
 
 /**
  * Gets the integer value of a specified argument.
@@ -510,7 +510,7 @@ native get_msg_argtype(argn);
  * @error                If an invalid message argument is passed, an
  *                       error will be thrown.
  */
-native get_msg_arg_int(argn);
+native get_msg_arg_int(any:argn);
 
 /**
  * Gets the float value of a specified argument.
@@ -524,7 +524,7 @@ native get_msg_arg_int(argn);
  * @error                If an invalid message argument is passed, an
  *                       error will be thrown.
  */
-native Float:get_msg_arg_float(argn);
+native Float:get_msg_arg_float(any:argn);
 
 /**
  * Gets the string value from a specified argument.
@@ -540,7 +540,7 @@ native Float:get_msg_arg_float(argn);
  * @error                If an invalid message argument is passed, an
  *                       error will be thrown.
  */
-native get_msg_arg_string(argn, szReturn[], iLength);
+native get_msg_arg_string(any:argn, szReturn[], iLength);
 
 /**
  * Sets the integer value of a specified argument.
@@ -556,7 +556,7 @@ native get_msg_arg_string(argn, szReturn[], iLength);
  * @error                If an invalid message argument is passed, an
  *                       error will be thrown.
  */
-native set_msg_arg_int(argn, argtype, iValue);
+native set_msg_arg_int(any:argn, argtype, iValue);
 
 /**
  * Sets the float value of a specified argument.
@@ -572,7 +572,7 @@ native set_msg_arg_int(argn, argtype, iValue);
  * @error                If an invalid message argument is passed, an
  *                       error will be thrown.
  */
-native set_msg_arg_float(argn, argtype, Float:fValue);
+native set_msg_arg_float(any:argn, argtype, Float:fValue);
 
 /**
  * Sets the string value of a specified argument.
@@ -587,7 +587,7 @@ native set_msg_arg_float(argn, argtype, Float:fValue);
  * @error                If an invalid message argument is passed, an
  *                       error will be thrown.
  */
-native set_msg_arg_string(argn, const szString[]);
+native set_msg_arg_string(any:argn, const szString[]);
 
 /**
  * Gets the origin of a message.


### PR DESCRIPTION
The goal of this PR is to prevent usage of "magic numbers" when using events which is the case in almost every plugin.

Instead of doing this:

```pawn
public DeathMsg()
{
	new iKiller = read_data(1)
	new iVictim = read_data(2)
	new iHeadshot = read_data(3)

	new szWeapon[20]
	read_data(4, szWeapon, charsmax(szWeapon))
}
```

We can now do this:

```pawn
public DeathMsg()
{
	new iKiller = read_data(DeathMsg_CS_KillerId)
	new iVictim = read_data(DeathMsg_CS_VictimId)
	new iHeadshot = read_data(DeathMsg_CS_IsHeadshot)

	new szWeapon[20]
	read_data(DeathMsg_CS_WeaponName, szWeapon, charsmax(szWeapon))
}
```

I added all arguments listed [here](https://wiki.alliedmods.net/Half-life_1_game_events).