### PR TITLE
Port bugfix for incorrect heap deallocation on conditional operator

### DIFF
--- a/compiler/libpc300/sc.h
+++ b/compiler/libpc300/sc.h
@@ -280,6 +280,12 @@ typedef struct s_stringpair {
   char *documentation;
 } stringpair;
 
+typedef struct s_valuepair {
+  struct s_valuepair *next;
+  long first;
+  long second;
+} valuepair;
+
 /* macros for code generation */
 #define opcodes(n)      ((n)*sizeof(cell))      /* opcode size */
 #define opargs(n)       ((n)*sizeof(cell))      /* size of typical argument */
@@ -700,6 +706,9 @@ SC_FUNC void delete_docstringtable(void);
 SC_FUNC stringlist *insert_autolist(char *string);
 SC_FUNC char *get_autolist(int index);
 SC_FUNC void delete_autolisttable(void);
+SC_FUNC valuepair *push_heaplist(long first, long second);
+SC_FUNC int popfront_heaplist(long *first, long *second);
+SC_FUNC void delete_heaplisttable(void);
 SC_FUNC stringlist *insert_dbgfile(const char *filename);
 SC_FUNC stringlist *insert_dbgline(int linenr);
 SC_FUNC stringlist *insert_dbgsymbol(symbol *sym);

--- a/compiler/libpc300/sc1.c
+++ b/compiler/libpc300/sc1.c
@@ -5457,6 +5457,16 @@ static void doreturn(void)
           /* nothing */;
         sub=addvariable(curfunc->name,(argcount+3)*sizeof(cell),iREFARRAY,sGLOBAL,curfunc->tag,dim,numdim,idxtag);
         sub->parent=curfunc;
+        /* Function that returns array can be used before it is defined, so at
+         * the call point (if it is before definition) we may not know if this
+         * function returns array and what is its size (for example inside the
+         * conditional operator), so we don't know how many cells on the heap
+         * we need. Calculating heap consumption is required for the fix of
+         * incorrect heap deallocation on conditional operator. That's why we
+         * need an additional pass.
+         */
+        if ((curfunc->usage & uREAD)!=0)
+          sc_reparse=TRUE;
       } /* if */
       /* get the hidden parameter, copy the array (the array is on the heap;
        * it stays on the heap for the moment, and it is removed -usually- at

--- a/compiler/libpc300/sc1.c
+++ b/compiler/libpc300/sc1.c
@@ -628,6 +628,7 @@ int pc_compile(int argc, char *argv[])
     /* reset "defined" flag of all functions and global variables */
     reduce_referrers(&glbtab);
     delete_symbols(&glbtab,0,TRUE,FALSE);
+    delete_heaplisttable();
     #if !defined NO_DEFINE
       delete_substtable();
       inst_datetime_defines();
@@ -805,6 +806,7 @@ cleanup:
       free(sc_documentation);
   #endif
   delete_autolisttable();
+  delete_heaplisttable();
   if (errnum!=0) {
     if (strlen(errfname)==0)
       pc_printf("\n%d Error%s.\n",errnum,(errnum>1) ? "s" : "");

--- a/compiler/libpc300/sc3.c
+++ b/compiler/libpc300/sc3.c
@@ -1015,8 +1015,6 @@ static int hier13(value *lval)
     value lval2 = {0};
     int array1,array2;
 
-    int orig_heap=decl_heap;
-    int diff1=0,diff2=0;
     if (lvalue) {
       rvalue(lval);
     } else if (lval->ident==iCONSTEXPR) {
@@ -1033,10 +1031,6 @@ static int hier13(value *lval)
     sc_allowtags=(short)POPSTK_I();     /* restore */
     jumplabel(flab2);
     setlabel(flab1);
-    if (orig_heap!=decl_heap) {
-      diff1=abs(decl_heap-orig_heap);
-      decl_heap=orig_heap;
-    }
     needtoken(':');
     if (hier13(&lval2))
       rvalue(&lval2);
@@ -1059,15 +1053,6 @@ static int hier13(value *lval)
       lval->ident=iREFARRAY;    /* iARRAY becomes iREFARRAY */
     else if (lval->ident!=iREFARRAY)
       lval->ident=iEXPRESSION;  /* iREFARRAY stays iREFARRAY, rest becomes iEXPRESSION */
-    if (orig_heap!=decl_heap) {
-      diff2=abs(decl_heap-orig_heap);
-      decl_heap=orig_heap;
-    }
-    if (diff1==diff2) {
-      decl_heap+=(diff1/2);
-    } else {
-      decl_heap+=(diff1+diff2);
-    }
     return FALSE;               /* conditional expression is no lvalue */
   } else {
     return lvalue;

--- a/compiler/libpc300/sclist.c
+++ b/compiler/libpc300/sclist.c
@@ -443,6 +443,52 @@ SC_FUNC void delete_autolisttable(void)
 }
 
 
+/* ----- value pair list ----------------------------------------- */
+static valuepair heaplist = {NULL, 0, 0};
+
+SC_FUNC valuepair *push_heaplist(long first, long second)
+{
+  valuepair *cur, *last;
+  if ((cur=malloc(sizeof(valuepair)))==NULL)
+    error(103);       /* insufficient memory (fatal error) */
+
+  cur->first=first;
+  cur->second=second;
+  cur->next=NULL;
+
+  for (last=&heaplist; last->next!=NULL; last=last->next)
+    /* nothing */;
+  last->next=cur;
+  return cur;
+}
+
+SC_FUNC int popfront_heaplist(long *first, long *second)
+{
+  valuepair *front=heaplist.next;
+  if (front==NULL)
+    return 0;
+
+  /* copy fields */
+  *first=front->first;
+  *second=front->second;
+
+  /* unlink and free */
+  heaplist.next=front->next;
+  free(front);
+  return 1;
+}
+
+SC_FUNC void delete_heaplisttable(void)
+{
+  valuepair *cur;
+  while (heaplist.next!=NULL) {
+    cur=heaplist.next;
+    heaplist.next=cur->next;
+    free(cur);
+  } /* while */
+}
+
+
 /* ----- debug information --------------------------------------- */
 
 static stringlist dbgstrings = {NULL, NULL};


### PR DESCRIPTION
Fixes #621.

There are another changes in `hier13`, but I've ported only fix.
I'm a bit worry that this fix doesn't save `ALT` register, maybe it is guaranteed that `ALT` isn't used across condition and branch body?

@rtxa test [it](https://github.com/alliedmodders/amxmodx/files/2474778/amxxpc32.zip) please.

Related to #623.