### PR TITLE
Improve AdminSlot plugin

### DIFF
--- a/plugins/adminslots.sma
+++ b/plugins/adminslots.sma
@@ -49,7 +49,9 @@ public client_authorized(id)
 	if (access(id, ADMIN_RESERVATION) || (players <= limit))
 	{
 		if (get_pcvar_num(g_HidePtr))
+		{
 			setVisibleSlots(players, limit);
+		}
 		return;
 	}
 
@@ -69,9 +71,13 @@ setVisibleSlots(players, limit)
 	new num = players + 1;
 
 	if (players == MaxClients)
+	{
 		num = MaxClients;
+	}
 	else if (players < limit)
+	{
 		num = limit;
+	}
 
 	set_pcvar_num(g_sv_visiblemaxplayers, num);
 }

--- a/plugins/adminslots.sma
+++ b/plugins/adminslots.sma
@@ -52,7 +52,7 @@ public client_authorized(id)
 			setVisibleSlots(players, limit)
 		return
 	}
-	
+
  	server_cmd("kick #%d ^"%L^"", get_user_userid(id), id, "DROPPED_RES")
 }
 
@@ -72,6 +72,6 @@ setVisibleSlots(players, limit)
 		num = MaxClients
 	else if (players < limit)
 		num = limit
-	
+
 	set_pcvar_num(g_sv_visiblemaxplayers, num)
 }

--- a/plugins/adminslots.sma
+++ b/plugins/adminslots.sma
@@ -14,41 +14,51 @@
 #include <amxmodx>
 #include <amxmisc>
 
-new g_ResPtr;
-new g_HidePtr;
+new CvarReservation;
+new CvarHideSlots;
 new g_sv_visiblemaxplayers;
 
 public plugin_init()
 {
 	register_plugin("Slots Reservation", AMXX_VERSION_STR, "AMXX Dev Team");
+
 	register_dictionary("adminslots.txt");
 	register_dictionary("common.txt");
-	g_ResPtr = register_cvar("amx_reservation", "0", FCVAR_PROTECTED);
-	g_HidePtr = register_cvar("amx_hideslots", "0");
+
+	hook_cvar_change(register_cvar("amx_reservation", "0", FCVAR_PROTECTED), "@OnReservationChange");
+	hook_cvar_change(register_cvar("amx_hideslots", "0"), "@OnHideSlotsChange");
+
 	g_sv_visiblemaxplayers = get_cvar_pointer("sv_visiblemaxplayers");
 }
 
-public plugin_cfg()
+@OnReservationChange(const handle, const oldValue[], const newValue[])
 {
-	set_task(3.0, "MapLoaded");
+	CvarReservation = strtol(newValue);
+
+	if (CvarHideSlots)
+	{
+		setVisibleSlots(get_playersnum(1), MaxClients - CvarReservation);
+	}
 }
 
-public MapLoaded()
+@OnHideSlotsChange(const handle, const oldValue[], const newValue[])
 {
-	if (get_pcvar_num(g_HidePtr))
+	CvarHideSlots = strtol(newValue);
+
+	if (CvarReservation)
 	{
-		setVisibleSlots(get_playersnum(1), MaxClients - get_pcvar_num(g_ResPtr));
+		setVisibleSlots(get_playersnum(1), MaxClients - CvarReservation);
 	}
 }
 
 public client_authorized(id)
 {
 	new players = get_playersnum(1);
-	new limit = MaxClients - get_pcvar_num(g_ResPtr);
+	new limit = MaxClients - CvarReservation;
 
 	if (access(id, ADMIN_RESERVATION) || (players <= limit))
 	{
-		if (get_pcvar_num(g_HidePtr))
+		if (CvarHideSlots)
 		{
 			setVisibleSlots(players, limit);
 		}
@@ -60,9 +70,9 @@ public client_authorized(id)
 
 public client_remove(id)
 {
-	if (get_pcvar_num(g_HidePtr))
+	if (CvarHideSlots)
 	{
-		setVisibleSlots(get_playersnum(1), MaxClients - get_pcvar_num(g_ResPtr));
+		setVisibleSlots(get_playersnum(1), MaxClients - CvarReservation);
 	}
 }
 

--- a/plugins/adminslots.sma
+++ b/plugins/adminslots.sma
@@ -26,8 +26,8 @@ public plugin_init()
 	register_dictionary("adminslots.txt");
 	register_dictionary("common.txt");
 
-	hook_cvar_change(create_cvar("amx_reservation", "0", FCVAR_PROTECTED, .has_min = true, .min_val = 0.0, .has_max = true, .max_val = float(MaxClients - 1)), "@OnReservationChange");
-	hook_cvar_change(create_cvar("amx_hideslots"  , "0", FCVAR_NONE     , .has_min = true, .min_val = 0.0, .has_max = true, .max_val = 1.0), "@OnHideSlotsChange");
+	hook_cvar_change(create_cvar("amx_reservation", "0", FCVAR_PROTECTED, fmt("%L", LANG_SERVER, "CVAR_RESERVATION"), .has_min = true, .min_val = 0.0, .has_max = true, .max_val = float(MaxClients - 1)), "@OnReservationChange");
+	hook_cvar_change(create_cvar("amx_hideslots"  , "0", FCVAR_NONE     , fmt("%L", LANG_SERVER, "CVAR_HIDESLOTS")  , .has_min = true, .min_val = 0.0, .has_max = true, .max_val = 1.0), "@OnHideSlotsChange");
 
 	CvarHandleMaxVisiblePlayers = get_cvar_pointer("sv_visiblemaxplayers");
 }

--- a/plugins/adminslots.sma
+++ b/plugins/adminslots.sma
@@ -68,7 +68,7 @@ setVisibleSlots(id = 0)
 		return;
 	}
 
-	new players = get_playersnum(1);
+	new players = get_playersnum_ex(GetPlayers_IncludeConnecting);
 	new limit   = freeVisibleSlots();
 
 	if (id != 0)

--- a/plugins/adminslots.sma
+++ b/plugins/adminslots.sma
@@ -14,64 +14,64 @@
 #include <amxmodx>
 #include <amxmisc>
 
-new g_ResPtr
-new g_HidePtr
-new g_sv_visiblemaxplayers
+new g_ResPtr;
+new g_HidePtr;
+new g_sv_visiblemaxplayers;
 
 public plugin_init()
 {
-	register_plugin("Slots Reservation", AMXX_VERSION_STR, "AMXX Dev Team")
-	register_dictionary("adminslots.txt")
-	register_dictionary("common.txt")
-	g_ResPtr = register_cvar("amx_reservation", "0", FCVAR_PROTECTED)
-	g_HidePtr = register_cvar("amx_hideslots", "0")
-	g_sv_visiblemaxplayers = get_cvar_pointer("sv_visiblemaxplayers")
+	register_plugin("Slots Reservation", AMXX_VERSION_STR, "AMXX Dev Team");
+	register_dictionary("adminslots.txt");
+	register_dictionary("common.txt");
+	g_ResPtr = register_cvar("amx_reservation", "0", FCVAR_PROTECTED);
+	g_HidePtr = register_cvar("amx_hideslots", "0");
+	g_sv_visiblemaxplayers = get_cvar_pointer("sv_visiblemaxplayers");
 }
 
 public plugin_cfg()
 {
-	set_task(3.0, "MapLoaded")
+	set_task(3.0, "MapLoaded");
 }
 
 public MapLoaded()
 {
 	if (get_pcvar_num(g_HidePtr))
 	{
-		setVisibleSlots(get_playersnum(1), MaxClients - get_pcvar_num(g_ResPtr))
+		setVisibleSlots(get_playersnum(1), MaxClients - get_pcvar_num(g_ResPtr));
 	}
 }
 
 public client_authorized(id)
 {
-	new players = get_playersnum(1)
-	new limit = MaxClients - get_pcvar_num(g_ResPtr)
+	new players = get_playersnum(1);
+	new limit = MaxClients - get_pcvar_num(g_ResPtr);
 
 	if (access(id, ADMIN_RESERVATION) || (players <= limit))
 	{
 		if (get_pcvar_num(g_HidePtr))
-			setVisibleSlots(players, limit)
-		return
+			setVisibleSlots(players, limit);
+		return;
 	}
 
- 	server_cmd("kick #%d ^"%L^"", get_user_userid(id), id, "DROPPED_RES")
+ 	server_cmd("kick #%d ^"%L^"", get_user_userid(id), id, "DROPPED_RES");
 }
 
 public client_remove(id)
 {
 	if (get_pcvar_num(g_HidePtr))
 	{
-		setVisibleSlots(get_playersnum(1), MaxClients - get_pcvar_num(g_ResPtr))
+		setVisibleSlots(get_playersnum(1), MaxClients - get_pcvar_num(g_ResPtr));
 	}
 }
 
 setVisibleSlots(players, limit)
 {
-	new num = players + 1
+	new num = players + 1;
 
 	if (players == MaxClients)
-		num = MaxClients
+		num = MaxClients;
 	else if (players < limit)
-		num = limit
+		num = limit;
 
-	set_pcvar_num(g_sv_visiblemaxplayers, num)
+	set_pcvar_num(g_sv_visiblemaxplayers, num);
 }

--- a/plugins/adminslots.sma
+++ b/plugins/adminslots.sma
@@ -16,7 +16,8 @@
 
 new CvarReservation;
 new CvarHideSlots;
-new g_sv_visiblemaxplayers;
+
+new CvarHandleMaxVisiblePlayers;
 
 public plugin_init()
 {
@@ -28,7 +29,7 @@ public plugin_init()
 	hook_cvar_change(register_cvar("amx_reservation", "0", FCVAR_PROTECTED), "@OnReservationChange");
 	hook_cvar_change(register_cvar("amx_hideslots", "0"), "@OnHideSlotsChange");
 
-	g_sv_visiblemaxplayers = get_cvar_pointer("sv_visiblemaxplayers");
+	CvarHandleMaxVisiblePlayers = get_cvar_pointer("sv_visiblemaxplayers");
 }
 
 @OnReservationChange(const handle, const oldValue[], const newValue[])
@@ -89,5 +90,5 @@ setVisibleSlots(players, limit)
 		num = limit;
 	}
 
-	set_pcvar_num(g_sv_visiblemaxplayers, num);
+	set_pcvar_num(CvarHandleMaxVisiblePlayers, num);
 }

--- a/plugins/adminslots.sma
+++ b/plugins/adminslots.sma
@@ -56,9 +56,9 @@ public client_remove(id)
 	setVisibleSlots();
 }
 
-setVisibleSlots(id = 0)
+setVisibleSlots(const playerId = 0)
 {
-	if ((id == 0 && !CvarHideSlots) || !CvarReservation)
+	if ((playerId == 0 && !CvarHideSlots) || !CvarReservation)
 	{
 		if (get_pcvar_num(CvarHandleMaxVisiblePlayers) > 0)
 		{
@@ -68,14 +68,14 @@ setVisibleSlots(id = 0)
 		return;
 	}
 
-	new players = get_playersnum_ex(GetPlayers_IncludeConnecting);
-	new limit   = freeVisibleSlots();
+	new const playersCount = get_playersnum_ex(GetPlayers_IncludeConnecting);
+	new const freeVisibleSlots = MaxClients - CvarReservation;
 
-	if (id != 0)
+ 	if (playerId != 0)
 	{
-		if (players > limit && !access(id, ADMIN_RESERVATION))
+		if (playersCount > freeVisibleSlots && !access(playerId, ADMIN_RESERVATION))
 		{
-			server_cmd("kick #%d ^"%L^"", get_user_userid(id), id, "DROPPED_RES");
+			server_cmd("kick #%d ^"%L^"", get_user_userid(playerId), playerId, "DROPPED_RES");
 			return;
 		}
 
@@ -85,18 +85,18 @@ setVisibleSlots(id = 0)
 		}
 	}
 
-	new num = players + 1;
+	new maxVisiblePlayers = playersCount + 1;
 
-	if (players == MaxClients)
+	if (playersCount == MaxClients)
 	{
-		num = MaxClients;
+		maxVisiblePlayers = MaxClients;
 	}
-	else if (players < limit)
+	else if (playersCount < freeVisibleSlots)
 	{
-		num = limit;
+		maxVisiblePlayers = freeVisibleSlots;
 	}
 
-	resetVisibleSlots(num);
+	resetVisibleSlots(maxVisiblePlayers);
 }
 
 resetVisibleSlots(value)
@@ -107,9 +107,4 @@ resetVisibleSlots(value)
 	}
 
 	set_pcvar_num(CvarHandleMaxVisiblePlayers, value);
-}
-
-freeVisibleSlots()
-{
-	return MaxClients - CvarReservation;
 }

--- a/plugins/adminslots.sma
+++ b/plugins/adminslots.sma
@@ -38,7 +38,7 @@ public plugin_init()
 
 	if (CvarHideSlots)
 	{
-		setVisibleSlots(get_playersnum(1), MaxClients - CvarReservation);
+		setVisibleSlots(get_playersnum(1), freeVisibleSlots());
 	}
 }
 
@@ -48,14 +48,14 @@ public plugin_init()
 
 	if (CvarReservation)
 	{
-		setVisibleSlots(get_playersnum(1), MaxClients - CvarReservation);
+		setVisibleSlots(get_playersnum(1), freeVisibleSlots());
 	}
 }
 
 public client_authorized(id)
 {
 	new players = get_playersnum(1);
-	new limit = MaxClients - CvarReservation;
+	new limit = freeVisibleSlots();
 
 	if (access(id, ADMIN_RESERVATION) || (players <= limit))
 	{
@@ -73,7 +73,7 @@ public client_remove(id)
 {
 	if (CvarHideSlots)
 	{
-		setVisibleSlots(get_playersnum(1), MaxClients - CvarReservation);
+		setVisibleSlots(get_playersnum(1), freeVisibleSlots());
 	}
 }
 
@@ -91,4 +91,9 @@ setVisibleSlots(players, limit)
 	}
 
 	set_pcvar_num(CvarHandleMaxVisiblePlayers, num);
+}
+
+freeVisibleSlots()
+{
+	return MaxClients - CvarReservation;
 }

--- a/plugins/adminslots.sma
+++ b/plugins/adminslots.sma
@@ -26,8 +26,8 @@ public plugin_init()
 	register_dictionary("adminslots.txt");
 	register_dictionary("common.txt");
 
-	hook_cvar_change(register_cvar("amx_reservation", "0", FCVAR_PROTECTED), "@OnReservationChange");
-	hook_cvar_change(register_cvar("amx_hideslots", "0"), "@OnHideSlotsChange");
+	hook_cvar_change(create_cvar("amx_reservation", "0", FCVAR_PROTECTED, .has_min = true, .min_val = 0.0, .has_max = true, .max_val = float(MaxClients - 1)), "@OnReservationChange");
+	hook_cvar_change(create_cvar("amx_hideslots"  , "0", FCVAR_NONE     , .has_min = true, .min_val = 0.0, .has_max = true, .max_val = 1.0), "@OnHideSlotsChange");
 
 	CvarHandleMaxVisiblePlayers = get_cvar_pointer("sv_visiblemaxplayers");
 }

--- a/plugins/lang/adminslots.txt
+++ b/plugins/lang/adminslots.txt
@@ -1,5 +1,7 @@
 [en]
 DROPPED_RES = Dropped due to slot reservation
+CVAR_RESERVATION = Amount of slots to reserve
+CVAR_HIDESLOTS = If you set this to 1, you can hide slots on your server.^nIf server "full" of public slots and slots hidden, you must manually connect with connect console command.
 
 [de]
 DROPPED_RES = Sorry, dieser Slot ist reserviert

--- a/plugins/lang/adminslots.txt
+++ b/plugins/lang/adminslots.txt
@@ -1,7 +1,7 @@
 [en]
 DROPPED_RES = Dropped due to slot reservation
 CVAR_RESERVATION = Amount of slots to reserve
-CVAR_HIDESLOTS = If you set this to 1, you can hide slots on your server.^nIf server "full" of public slots and slots hidden, you must manually connect with connect console command.
+CVAR_HIDESLOTS = If you set this to 1, you can hide slots on your server.^nIf the server's public and hidden slots are full, you must manually connect with the "connect" console command.
 
 [de]
 DROPPED_RES = Sorry, dieser Slot ist reserviert

--- a/plugins/lang/adminslots.txt
+++ b/plugins/lang/adminslots.txt
@@ -5,6 +5,8 @@ CVAR_HIDESLOTS = If you set this to 1, you can hide slots on your server.^nIf th
 
 [de]
 DROPPED_RES = Sorry, dieser Slot ist reserviert
+CVAR_RESERVATION = Anzahl der zu reservierenden Slots
+CVAR_HIDESLOTS = Wenn diese CVAR auf 1 gesetzt wird, können Slots auf Ihrem Server ausgeblendet werden.^nWenn die öffentlichen Slots auf dem Server "voll" sind und weitere freie Slots ausgeblendet sind, müssen Sie die Verbindung manuell über den Konsolenbefehl "connect" herstellen.
 
 [sr]
 DROPPED_RES = Server je pun, nemate pristup rezervisanim mestima


### PR DESCRIPTION
Originally initiated by @wopox1337 but took over because incomplete and it needed to be to split in multiple commits.

Notable changes:
* Cvars behavior. This is not really a bug, but before if you play with the cvars  `sv_visiblemaxplayers` is not adjusted (or not immediately). E.g. both cvars is set, if you don't hide the slots anymore,  `sv_visiblemaxplayers` is not updated.  Now, when a cvar change is detected and if required, `sv_visiblemaxplayers` update is immediate. This removes the ugly task as well.
* When `sv_visiblemaxplayers` needs to be reset, this will use -1 (default value), and not max clients.
* The cvars have now a min/max bounds. This will reduce the chance of abuse.
* If `amx_reservation` or `amx_hideslots` is set to 0, and if `sv_visiblemaxplayers` is set with a positive value, then it will be reset to -1.
* Added description to cvar. Same as the command, ML should be used for cvar. Ideally, a new param should exist, but it's fine to use `LANG_SERVER` for now.


 