### PR TITLE
Revert RETURN_META(MRES_HANDLED);

### DIFF
--- a/modules/fun/fun.cpp
+++ b/modules/fun/fun.cpp
@@ -495,7 +495,6 @@ void TraceLine(const float *v1, const float *v2, int fNoMonsters, edict_t *shoot
 		if (!(Players[shooterIndex].GetBodyHits(targetIndex) & (1 << ptr->iHitgroup)))
 		{
 			ptr->flFraction = 1.0;
-			RETURN_META(MRES_HANDLED);
 		}
 	}
 


### PR DESCRIPTION
#554 did not fully revert back TraceLine. RETURN_META(MRES_HANDLED); was added by #421 but still remains there.