### PR TITLE
Fix typo in json_parse documentation

### DIFF
--- a/plugins/include/json.inc
+++ b/plugins/include/json.inc
@@ -64,7 +64,7 @@ enum JSON
  * @param is_file           True to treat string param as filename, false otherwise
  * @param with_comments     True if parsing JSON includes comments (it will ignore them), false otherwise
  *
- * @return                  JSON handle, Invalid_JSONValue if error occurred
+ * @return                  JSON handle, Invalid_JSON if error occurred
  */
 native JSON:json_parse(const string[], bool:is_file = false, bool:with_comments = false);
 


### PR DESCRIPTION
Just a small fix on json_parse return description. I'm sure its return was supposed to be `Invalid_JSON` instead of `Invalid_JSONValue`.
Thank you, guys, that's one of my favorites features.

PS: I'm really sorry if I did choose the wrong branch. If I did, please, do let me know.