### PR TITLE
Add player validation for menu_display

### DIFF
--- a/amxmodx/newmenus.cpp
+++ b/amxmodx/newmenus.cpp
@@ -844,7 +844,20 @@ static cell AMX_NATIVE_CALL menu_display(AMX *amx, cell *params)
 
 	int player = params[1];
 	int page = params[3];
+	
+	if (player < 1 || player > gpGlobals->maxClients)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Invalid player id %d.", player);
+		return 0;
+	}
+	
 	CPlayer* pPlayer = GET_PLAYER_POINTER_I(player);
+	
+	if (!pPlayer->ingame)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Player %d is not in game.", player);
+		return 0;
+	}
 
 	if (!CloseNewMenus(pPlayer))
 	{


### PR DESCRIPTION
Invalid player triggered crash because get/set_pdata is unsafe