### PR TITLE
Remove additional parameter

### DIFF
--- a/plugins/include/message_const.inc
+++ b/plugins/include/message_const.inc
@@ -565,7 +565,6 @@ enum
  * write_byte(red)
  * write_byte(green)
  * write_byte(blue)
- * write_byte(brightness)
  * write_byte(life in 10's)
  * write_byte(decay rate in 10's)
  */


### PR DESCRIPTION
There's no "brightness" parameter in TE_DLIGHT. Probably will cause server crash if it be passed.
https://github.com/alliedmodders/hlsdk/blob/master/dlls/islave.cpp#L367