### PR TITLE
String formatted incorrectly at checkKills() fix

### DIFF
--- a/plugins/cstrike/miscstats.sma
+++ b/plugins/cstrike/miscstats.sma
@@ -91,7 +91,7 @@ new g_MultiKillMsg[7][] =
 	"Multi-Kill! %s^n%L %d %L (%d %L)", 
 	"Ultra-Kill!!! %s^n%L %d %L (%d %L)", 
 	"%s IS ON A KILLING SPREE!!!^n%L %d %L (%d %L)", 
-	"RAMPAGE!!! %s^n%L %d %L (%d hs)", 
+	"RAMPAGE!!! %s^n%L %d %L (%d %L)", 
 	"%s IS UNSTOPPABLE!!!^n%L %d %L (%d %L)", 
 	"%s IS A MONSTER!^n%L %d %L (%d %L)", 
 	"%s IS GODLIKE!!!!^n%L %d %L (%d %L)"


### PR DESCRIPTION
Recently, I got a quite big amount of errors on logs after multikill feature is activated on `miscstats.amxx`:
```
String formatted incorrectly - parameter 12 (total 12)
L 04/29/2019 - 23:24:40: [AMXX] Displaying debug trace (plugin "miscstats.amxx", version "1.8.3-dev+5154")
L 04/29/2019 - 23:24:40: [AMXX] Run time error 25: parameter error 
L 04/29/2019 - 23:24:40: [AMXX]    [0] miscstats.sma::checkKills (line 922)
```

It just looks like `"RAMPAGE!!! %s^n%L %d %L (%d hs)"` misses last format rule, which should be `"%L"` pointing to `HS` lang key.