### PR TITLE
Fix typo on engine.inc documentation

### DIFF
--- a/plugins/include/engine.inc
+++ b/plugins/include/engine.inc
@@ -117,8 +117,8 @@ native register_touch(const Touched[], const Toucher[], const function[]);
  *       blocking the think. To immediately block return PLUGIN_HANDLED_MAIN
  *       instead.
  *
- * @param Touched   Entity classname to hook
- * @param function  Name of callback function
+ * @param Classname	Entity classname to hook
+ * @param function	Name of callback function
  *
  * @return 	        Think forward id
  */


### PR DESCRIPTION
`register_think` first parameter is `Classname[]`, but, it's written `Touched` on its description.