### PR TITLE
Send pre-formatted string in SayText and TextMSg as a parameter instead of as the format string

### DIFF
--- a/amxmodx/util.cpp
+++ b/amxmodx/util.cpp
@@ -276,6 +276,7 @@ void UTIL_ClientPrint(edict_t *pEntity, int msg_dest, char *msg)
 		MESSAGE_BEGIN(MSG_BROADCAST, gmsgTextMsg);
 	
 	WRITE_BYTE(msg_dest);
+	WRITE_STRING("%s");
 	WRITE_STRING(msg);
 	MESSAGE_END();
 	msg[190] = c;
@@ -291,6 +292,7 @@ void UTIL_ClientSayText(edict_t *pEntity, int sender, char *msg)
 
 	MESSAGE_BEGIN(MSG_ONE, gmsgSayText, NULL, pEntity);
 	WRITE_BYTE(sender);
+	WRITE_STRING("%s");
 	WRITE_STRING(msg);
 	MESSAGE_END();
 	msg[190] = c;


### PR DESCRIPTION

Related to https://github.com/ValveSoftware/halflife/issues/2611.

This a compatibility update now the HL stable version has been updated.
This change should be safe.

Fixes #762.