### PR TITLE
Fix geoip_latitude/longitude natives returning incorrect values under linux/osx

### DIFF
--- a/modules/geoip/AMBuilder
+++ b/modules/geoip/AMBuilder
@@ -3,7 +3,8 @@ import os.path
 
 binary = AMXX.MetaModule(builder, 'geoip')
 
-binary.compiler.cxxincludes += [
+binary.compiler.includes += [
+  os.path.join(builder.currentSourcePath, '..', '..', 'amxmodx'),
   os.path.join(builder.currentSourcePath, '..', '..', 'third_party', 'libmaxminddb')
 ]
 

--- a/modules/geoip/msvc12/geoip.vcxproj
+++ b/modules/geoip/msvc12/geoip.vcxproj
@@ -54,7 +54,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\;..\sdk;..\..\..\public;..\..\..\public\amtl;..\..\..\third_party\libmaxminddb;..\..\third_party\hashing;..\..\..\public\sdk;..\GeoIP2;$(METAMOD)\metamod;$(HLSDK)\common;$(HLSDK)\engine;$(HLSDK)\dlls;$(HLSDK)\pm_shared;$(HLSDK)\public;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;..\sdk;..\..\..\amxmodx;..\..\..\public;..\..\..\public\amtl;..\..\..\third_party\libmaxminddb;..\..\third_party\hashing;..\..\..\public\sdk;..\GeoIP2;$(METAMOD)\metamod;$(HLSDK)\common;$(HLSDK)\engine;$(HLSDK)\dlls;$(HLSDK)\pm_shared;$(HLSDK)\public;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;GEOIP_EXPORTS;HAVE_STDINT_H;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -80,7 +80,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\;..\sdk;..\..\..\public;..\..\..\public\amtl;..\..\..\third_party\libmaxminddb;..\..\third_party\hashing;..\..\..\public\sdk;..\GeoIP2;$(METAMOD)\metamod;$(HLSDK)\common;$(HLSDK)\engine;$(HLSDK)\dlls;$(HLSDK)\pm_shared;$(HLSDK)\public;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\;..\sdk;..\..\..\amxmodx;..\..\..\public;..\..\..\public\amtl;..\..\..\third_party\libmaxminddb;..\..\third_party\hashing;..\..\..\public\sdk;..\GeoIP2;$(METAMOD)\metamod;$(HLSDK)\common;$(HLSDK)\engine;$(HLSDK)\dlls;$(HLSDK)\pm_shared;$(HLSDK)\public;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;GEOIP_EXPORTS;HAVE_STDINT_H;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>

--- a/third_party/libmaxminddb/maxminddb_config.h
+++ b/third_party/libmaxminddb/maxminddb_config.h
@@ -1,6 +1,13 @@
 #ifndef MAXMINDDB_CONFIG_H
 #define MAXMINDDB_CONFIG_H
 
+#include <osdefs.h> // BYTE_ORDER, LITTLE_ENDIAN
+
+/* This fixes a behavior change in after https://github.com/maxmind/libmaxminddb/pull/123. */
+#if defined(BYTE_ORDER) && BYTE_ORDER == LITTLE_ENDIAN
+	#define MMDB_LITTLE_ENDIAN 1
+#endif
+
 #ifndef MMDB_UINT128_USING_MODE
 /* Define as 1 if we we use unsigned int __atribute__ ((__mode__(TI))) for uint128 values */
 #define MMDB_UINT128_USING_MODE 0


### PR DESCRIPTION
Fixes #768 

This is due to a behavior change in the GeoIP library https://github.com/maxmind/libmaxminddb/pull/123. They moved a critical check to their configuration tool that we don't use (we are using AMBuild to compile). As result, some value extracted from the database were incorrectly converted and would be displayed as 0 in a AMXX plugin.
