### PR TITLE
Fix internal player's team id returning -1 in a specific but valid situation

### DIFF
--- a/amxmodx/CGameConfigs.h
+++ b/amxmodx/CGameConfigs.h
@@ -180,15 +180,15 @@ class CGameConfigManager : public IGameConfigManager
 		member = type.fieldOffset;                                                  \
 	}
 
-#define GET_OFFSET_NO_ERROR(classname, member)										\
-	static int member = -1;															\
-	if (member == -1)																\
+#define GET_OFFSET_NO_ERROR(classname, member)                                      \
+	static int member = -1;                                                         \
+	if (member == -1)                                                               \
 	{                                                                               \
 		TypeDescription type;                                                       \
 		if (!CommonConfig->GetOffsetByClass(classname, #member, &type) || type.fieldOffset < 0)\
-		{																			\
-			return;																    \
-		}																			\
+		{                                                                           \
+			return;                                                                 \
+		}                                                                           \
 		member = type.fieldOffset;                                                  \
 	}
 

--- a/amxmodx/CGameConfigs.h
+++ b/amxmodx/CGameConfigs.h
@@ -180,6 +180,18 @@ class CGameConfigManager : public IGameConfigManager
 		member = type.fieldOffset;                                                  \
 	}
 
+#define GET_OFFSET_NO_ERROR(classname, member)										\
+	static int member = -1;															\
+	if (member == -1)																\
+	{                                                                               \
+		TypeDescription type;                                                       \
+		if (!CommonConfig->GetOffsetByClass(classname, #member, &type) || type.fieldOffset < 0)\
+		{																			\
+			return;																    \
+		}																			\
+		member = type.fieldOffset;                                                  \
+	}
+
 extern CGameConfigManager ConfigManager;
 extern IGameConfig *CommonConfig;
 

--- a/amxmodx/emsg.cpp
+++ b/amxmodx/emsg.cpp
@@ -88,11 +88,14 @@ void Client_TeamInfo(void* mValue)
 			if (index < 1 || index > gpGlobals->maxClients) break;
 			char* msg = (char*)mValue;
 			if (!msg) break;
-			g_players[index].team = msg;
+
+			auto pPlayer = GET_PLAYER_POINTER_I(index);
+		
+			pPlayer->team = msg;
 			g_teamsIds.registerTeam(msg, -1);
-			g_players[index].teamId = g_teamsIds.findTeamId(msg);
+			pPlayer->teamId = g_teamsIds.findTeamId(msg);
 						
-			if (g_players[index].teamId == -1)
+			if (pPlayer->teamId == -1)
 			{
 				/**
 				 * CS fix for SPECTATOR team. 
@@ -103,7 +106,7 @@ void Client_TeamInfo(void* mValue)
 				 */
 				if (g_bmod_cstrike && !strcmp(msg, "SPECTATOR"))
 				{
-					g_players[index].teamId = 3;
+					pPlayer->teamId = 3;
 					g_teamsIds.registerTeam(msg, 3);
 				}
 
@@ -113,14 +116,14 @@ void Client_TeamInfo(void* mValue)
 				 * then changes team. Index will return -1 until ScoreInfo is sent, usually at the next spawn.
 				 */
 				else if ((g_bmod_cstrike || g_bmod_dod || g_bmod_tfc || g_bmod_gearbox || g_bmod_valve) 
-					&&  g_players[index].pEdict->pvPrivateData 
-					&& !g_players[index].IsAlive())
+					&&  pPlayer->pEdict->pvPrivateData 
+					&& !pPlayer->IsAlive())
 				{
 					GET_OFFSET_NO_ERROR("CBasePlayer", m_iTeam);
 
-					const auto teamId = get_pdata<int>(g_players[index].pEdict, m_iTeam);
+					const auto teamId = get_pdata<int>(pPlayer->pEdict, m_iTeam);
 					
-					g_players[index].teamId = teamId;
+					pPlayer->teamId = teamId;
 					g_teamsIds.registerTeam(msg, teamId);
 				}
 			}

--- a/amxmodx/emsg.cpp
+++ b/amxmodx/emsg.cpp
@@ -91,18 +91,38 @@ void Client_TeamInfo(void* mValue)
 			g_players[index].team = msg;
 			g_teamsIds.registerTeam(msg, -1);
 			g_players[index].teamId = g_teamsIds.findTeamId(msg);
-
-			/**
-			* CS fix for SPECTATOR team. 
-			* -
-			* When a player chooses spectator, ScoreInfo is sent before TeamInfo and with 0 as index.
-			* This means for the first round of first spectator, SPECTATOR name is not associated with its index.
-			* The following fix manually sets the team index when we hit SPECTATOR team.
-			*/
-			if (g_players[index].teamId == -1 && g_bmod_cstrike && !strcmp(msg, "SPECTATOR"))
+						
+			if (g_players[index].teamId == -1)
 			{
-				g_players[index].teamId = 3;
-				g_teamsIds.registerTeam(msg, 3);
+				/**
+				 * CS fix for SPECTATOR team. 
+				 * -
+				 * When a player chooses spectator, ScoreInfo is sent before TeamInfo and with 0 as index.
+				 * This means for the first round of first spectator, SPECTATOR name is not associated with its index.
+				 *  The following fix manually sets the team index when we hit SPECTATOR team.
+				 */
+				if (g_bmod_cstrike && !strcmp(msg, "SPECTATOR"))
+				{
+					g_players[index].teamId = 3;
+					g_teamsIds.registerTeam(msg, 3);
+				}
+
+				/**
+				 * Fixes in-between situation where the team name is not yet associated with a valid index
+				 * and ScoreInfo is executed later (used to retrieve the index). E.g. a player is dead,
+				 * then changes team. Index will return -1 until ScoreInfo is sent, usually at the next spawn.
+				 */
+				else if ((g_bmod_cstrike || g_bmod_dod || g_bmod_tfc || g_bmod_gearbox || g_bmod_valve) 
+					&&  g_players[index].pEdict->pvPrivateData 
+					&& !g_players[index].IsAlive())
+				{
+					GET_OFFSET_NO_ERROR("CBasePlayer", m_iTeam);
+
+					const auto teamId = get_pdata<int>(g_players[index].pEdict, m_iTeam);
+					
+					g_players[index].teamId = teamId;
+					g_teamsIds.registerTeam(msg, teamId);
+				}
 			}
 
 			break;


### PR DESCRIPTION
Fixes #757 
^ More technical info there.

This fixes the situation where a player is dead and changes team. At this point, if the new team name is not yet associated with a valid index, retrieving such index will return -1 until usually the player spawns.

The proposed fix relies on `CBasePlayer::m_iTeam` and is only available to mods where gamedata files are available (CS, CZ, DoD, TFC, OPFor and HLDM).