### PR TITLE
Added MENU_KEY_ALL to amxconst.inc

### DIFF
--- a/amxmodx/CFlagManager.h
+++ b/amxmodx/CFlagManager.h
@@ -143,6 +143,10 @@ private:
 				fclose(fp);
 			};
 		}
+		else
+		{
+			fclose(fp);
+		}
 	};
 	/**
 	 * Returns 1 if the timestamp for the file is different than the one we have loaded

--- a/plugins/include/amxconst.inc
+++ b/plugins/include/amxconst.inc
@@ -260,6 +260,7 @@ public stock const Float:NULL_VECTOR[3];
 #define MENU_KEY_8      (1<<7)
 #define MENU_KEY_9      (1<<8)
 #define MENU_KEY_0      (1<<9)
+#define MENU_KEY_ALL    MENU_KEY_1|MENU_KEY_2|MENU_KEY_3|MENU_KEY_4|MENU_KEY_5|MENU_KEY_6|MENU_KEY_7|MENU_KEY_8|MENU_KEY_9|MENU_KEY_0
 
 /**
  * Language constants


### PR DESCRIPTION
This add the MENU_KEY_ALL to handle all keys in old menus, used in some situations to avoid terrible 1023 constant