### PR TITLE
Update pluginmenu.sma

### DIFF
--- a/plugins/pluginmenu.sma
+++ b/plugins/pluginmenu.sma
@@ -469,7 +469,7 @@ public CvarMenuSelection(id, menu, item)
 	{
 		menu_destroy(menu);
 		
-		if (ExplicitPlugin[id]==-1)
+		if (ExplicitPlugin[id]==-1 && is_user_connected(id)) // Fix
 		{
 			DisplayPluginMenu(id,"Plugin Cvar Menu:", "PluginMenuSelection","DisplayCvarMenu","GetNumberOfCvarsForPlid");
 		}


### PR DESCRIPTION
Fix for:

> Player 1 is not in game.
[AMXX] Displaying debug trace (plugin "pluginmenu.amxx", version "1.9.0.5263")
[AMXX] Run time error 10: native error (native "menu_display")
[AMXX] [0] pluginmenu.sma::DisplayPluginMenu (line 159)
[AMXX] [1] pluginmenu.sma::CvarMenuSelection (line 474)