### PR TITLE
Config load fix

### DIFF
--- a/amxmodx/CoreConfig.cpp
+++ b/amxmodx/CoreConfig.cpp
@@ -53,7 +53,7 @@ void CoreConfig::ExecuteMainConfig()
 	char path[PLATFORM_MAX_PATH];
 	char command[PLATFORM_MAX_PATH + sizeof(CommandFormat)];
 
-	ke::SafeSprintf(path, sizeof(path), "%s/%s/%s", g_mod_name.chars(), get_localinfo("amxx_configsdir", "addons/amxmodx/configs"), MainConfigFile);
+	ke::SafeSprintf(path, sizeof(path), "%s/%s", get_localinfo("amxx_configsdir", "addons/amxmodx/configs"), MainConfigFile);
 	ke::SafeSprintf(command, sizeof(command), CommandFormat, path);
 
 	SERVER_COMMAND(command);
@@ -140,11 +140,11 @@ bool CoreConfig::ExecuteAutoConfig(CPluginMngr::CPlugin *plugin, AutoConfig *con
 
 	if (config->folder.length())
 	{
-		ke::SafeSprintf(file, sizeof(file), "%s/%s%s/%s/%s.cfg", g_mod_name.chars(), configsDir, AutoConfigDir, config->folder.chars(), config->autocfg.chars());
+		ke::SafeSprintf(file, sizeof(file), "%s%s/%s/%s.cfg", configsDir, AutoConfigDir, config->folder.chars(), config->autocfg.chars());
 	}
 	else
 	{
-		ke::SafeSprintf(file, sizeof(file), "%s/%s%s/%s.cfg", g_mod_name.chars(), configsDir, AutoConfigDir, config->autocfg.chars());
+		ke::SafeSprintf(file, sizeof(file), "%s%s/%s.cfg", configsDir, AutoConfigDir, config->autocfg.chars());
 	}
 
 	bool file_exists = g_LibSys.IsPathFile(file);
@@ -266,7 +266,7 @@ void CoreConfig::ExecuteMapConfig()
 
 	if ((mapPrefix = strtok(mapName, "_")))
 	{
-		ke::SafeSprintf(cfgPath, sizeof(cfgPath), "%s/%s%s/prefix_%s.cfg", g_mod_name.chars(), configsDir, MapConfigDir, mapPrefix);
+		ke::SafeSprintf(cfgPath, sizeof(cfgPath), "%s%s/prefix_%s.cfg", configsDir, MapConfigDir, mapPrefix);
 
 		if (g_LibSys.IsPathFile(cfgPath))
 		{
@@ -276,7 +276,7 @@ void CoreConfig::ExecuteMapConfig()
 	}
 
 	strncopy(mapName, STRING(gpGlobals->mapname), sizeof(mapName));
-	ke::SafeSprintf(cfgPath, sizeof(cfgPath), "%s/%s%s/%s.cfg", g_mod_name.chars(), configsDir, MapConfigDir, mapName);
+	ke::SafeSprintf(cfgPath, sizeof(cfgPath), "%s%s/%s.cfg", configsDir, MapConfigDir, mapName);
 
 	if (g_LibSys.IsPathFile(cfgPath))
 	{


### PR DESCRIPTION
I think `g_mod_name.chars() `is not needed.

`exec cstrike/addons/amxmodx/configs/amxx.cfg`
**result:**
`couldn't exec cstrike/addons/amxmodx/configs/amxx.cfg`

---------------------------------------------------------------------------------------------------

`exec addons/amxmodx/configs/amxx.cfg`
**result:**
`Executing AMX Mod X Configuration File`
