### PR TITLE
Added get_event_state and get_logevent_state natives

### DIFF
--- a/amxmodx/CEvent.cpp
+++ b/amxmodx/CEvent.cpp
@@ -198,7 +198,7 @@ void EventsMngr::ClEvent::setForwardState(ForwardState state)
 
 ForwardState EventsMngr::ClEvent::getForwardState()
 {
-	return this->m_State;
+	return m_State;
 }
 
 int EventsMngr::registerEvent(CPluginMngr::CPlugin* plugin, int func, int flags, int msgid)

--- a/amxmodx/CEvent.cpp
+++ b/amxmodx/CEvent.cpp
@@ -196,6 +196,10 @@ void EventsMngr::ClEvent::setForwardState(ForwardState state)
 	m_State = state;
 }
 
+ForwardState EventsMngr::ClEvent::getForwardState()
+{
+	return this->m_State;
+}
 
 int EventsMngr::registerEvent(CPluginMngr::CPlugin* plugin, int func, int flags, int msgid)
 {

--- a/amxmodx/CEvent.h
+++ b/amxmodx/CEvent.h
@@ -91,6 +91,7 @@ public:
 		inline int getFunction();
 		void registerFilter(char* filter);			// add a condition
 		void setForwardState(ForwardState value);
+		ForwardState getForwardState();
 	};
 
 private:

--- a/amxmodx/CLogEvent.cpp
+++ b/amxmodx/CLogEvent.cpp
@@ -173,7 +173,7 @@ void LogEventsMngr::CLogEvent::setForwardState(ForwardState state)
 
 ForwardState LogEventsMngr::CLogEvent::getForwardState()
 {
-	return m_State = state;
+	return m_State;
 }
 
 int LogEventsMngr::registerLogEvent(CPluginMngr::CPlugin* plugin, int func, int pos)

--- a/amxmodx/CLogEvent.cpp
+++ b/amxmodx/CLogEvent.cpp
@@ -171,6 +171,11 @@ void LogEventsMngr::CLogEvent::setForwardState(ForwardState state)
 	m_State = state;
 }
 
+ForwardState LogEventsMngr::CLogEvent::getForwardState()
+{
+	return m_State = state;
+}
+
 int LogEventsMngr::registerLogEvent(CPluginMngr::CPlugin* plugin, int func, int pos)
 {
 	if (pos < 1 || pos > MAX_LOGARGS)

--- a/amxmodx/CLogEvent.h
+++ b/amxmodx/CLogEvent.h
@@ -106,6 +106,7 @@ public:
 		inline CPluginMngr::CPlugin *getPlugin() { return plugin; }
 		void registerFilter(char* filter);
 		void setForwardState(ForwardState value);
+		ForwardState getForwardState();
 		inline int getFunction() { return func; }
 	};
 

--- a/amxmodx/amxmodx.cpp
+++ b/amxmodx/amxmodx.cpp
@@ -1937,6 +1937,19 @@ static cell AMX_NATIVE_CALL disable_event(AMX *amx, cell *params)
 	return 1;
 }
 
+static cell AMX_NATIVE_CALL get_event_state(AMX *amx, cell *params)
+{
+	auto handle = EventHandles.lookup(params[1]);
+
+	if (!handle)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Invalid event handle: %d", params[1]);
+		return 0;
+	}
+
+	return handle->m_event->getForwardState() == FSTATE_ACTIVE ? 1 : 0;
+}
+
 static cell AMX_NATIVE_CALL user_kill(AMX *amx, cell *params) /* 2 param */
 {
 	int index = params[1];

--- a/amxmodx/amxmodx.cpp
+++ b/amxmodx/amxmodx.cpp
@@ -3356,6 +3356,19 @@ static cell AMX_NATIVE_CALL disable_logevent(AMX *amx, cell *params)
 	return 1;
 }
 
+static cell AMX_NATIVE_CALL get_logevent_state(AMX *amx, cell *params)
+{
+	auto handle = LogEventHandles.lookup(params[1]);
+
+	if (!handle)
+	{
+		LogError(amx, AMX_ERR_NATIVE, "Invalid log event handle: %d", params[1]);
+		return 0;
+	}
+
+	return handle->m_logevent->getForwardState() == FSTATE_ACTIVE ? 1 : 0;
+}
+
 // native is_module_loaded(const name[]);
 static cell AMX_NATIVE_CALL is_module_loaded(AMX *amx, cell *params)
 {

--- a/plugins/include/amxconst.inc
+++ b/plugins/include/amxconst.inc
@@ -510,6 +510,15 @@ enum SetTaskFlags (<<= 1)
 };
 
 /**
+ * Event states constants for get_event_state and get_logevent_state
+ */
+enum ForwardState
+{
+	FSTATE_STOP = 0,
+	FSTATE_ACTIVE = 1
+};
+
+/**
  * RegisterEventFlags constants for register_event_ex()
  */
 enum RegisterEventFlags (<<= 1)


### PR DESCRIPTION
I don't think I'll need to create variables in my plugin anymore to know if the event is active or inactive

:smiley: :birthday: 