### PR TITLE
adminvote.sma exploit fix

### DIFF
--- a/plugins/adminvote.sma
+++ b/plugins/adminvote.sma
@@ -238,7 +238,10 @@ public cmdVoteMap(id, level, cid)
 	for (new i = 1; i < argc; ++i)
 	{
 		read_argv(i, g_optionName[g_validMaps], 31)
-		
+
+		if (containi(g_optionName[g_validMaps], "..") != -1)
+			continue
+
 		if (is_map_valid(g_optionName[g_validMaps]))
 			g_validMaps++
 	}

--- a/plugins/adminvote.sma
+++ b/plugins/adminvote.sma
@@ -239,7 +239,7 @@ public cmdVoteMap(id, level, cid)
 	{
 		read_argv(i, g_optionName[g_validMaps], 31)
 
-		if (containi(g_optionName[g_validMaps], "..") != -1)
+		if (contain(g_optionName[g_validMaps], "..") != -1)
 			continue
 
 		if (is_map_valid(g_optionName[g_validMaps]))


### PR DESCRIPTION
### Restrict having ".." character sequence in amx_votemap command arguments
Fixes exploit on Windows servers that allows executing potentially dangerous console commands