### PR TITLE
Update get_user_userid documentation

### DIFF
--- a/plugins/include/amxmodx.inc
+++ b/plugins/include/amxmodx.inc
@@ -1278,7 +1278,7 @@ native get_user_authid(index, authid[], len);
  *
  * @param index     Client index
  *
- * @return          Client userid, 0 if the userid is not available or the
+ * @return          Client userid, -1 if the userid is not available or the
  *                  client index is invalid
  */
 native get_user_userid(index);


### PR DESCRIPTION
It says the native will return 0 if the userid is not available or the client index is invalid, but in fact it returns -1.

https://github.com/alliedmodders/amxmodx/blob/master/amxmodx/amxmodx.cpp#L942
https://github.com/alliedmodders/amxmodx/blob/1.9-dev/amxmodx/amxmodx.cpp#L927