### PR TITLE
Add missing kRenderFx constant

### DIFF
--- a/plugins/include/amxconst.inc
+++ b/plugins/include/amxconst.inc
@@ -351,7 +351,7 @@ enum
 	kRenderFxExplode,           /* Scale up really big! */
 	kRenderFxGlowShell,         /* Glowing Shell */
 	kRenderFxClampMinScale,     /* Keep this sprite from getting very small (SPRITES only!) */
-	kRenderFxBlackout
+	kRenderFxLightMultiplier,   /* CTM !!!CZERO added to tell the studiorender that the value in iuser2 is a lightmultiplier */
 };
 
 /**

--- a/plugins/include/amxconst.inc
+++ b/plugins/include/amxconst.inc
@@ -351,6 +351,7 @@ enum
 	kRenderFxExplode,           /* Scale up really big! */
 	kRenderFxGlowShell,         /* Glowing Shell */
 	kRenderFxClampMinScale,     /* Keep this sprite from getting very small (SPRITES only!) */
+	kRenderFxBlackout
 };
 
 /**


### PR DESCRIPTION
I accidentally discovered that there's another kRenderFx value that can be used - 21.

> set_pev(iEnt, pev_renderfx, 21)

Not sure about how it should be named and I'm open to ideas if mine doesn't make sense.
It simply makes the entity black and its texture is barely visible. Changing color or amount doesn't seem to have any effect.
Here's what this looks like when used on an entity.

![21](https://i.imgur.com/5UzBBGt.png)