### PR TITLE
Use precache_generic() for sounds that are played client-side

### DIFF
--- a/plugins/cmdmenu.sma
+++ b/plugins/cmdmenu.sma
@@ -175,15 +175,7 @@ public plugin_precache( )
 			}
 			if ( file_exists( szSound ) )
 			{
-				if ( sndExt[1] == 'm')
-				{
-					precache_generic( szSound );		// mp3
-				}
-				else
-				{
-					replace( szSound, charsmax(szSound), "sound/", "" );	// wav, strip the leading sound/ we added for our file_exists check
-					precache_sound( szSound );
-				}
+				precache_generic( szSound );
 			}
 		}
 		line++;

--- a/plugins/cstrike/miscstats.sma
+++ b/plugins/cstrike/miscstats.sma
@@ -379,7 +379,7 @@ precache_sound_custom( const sound[] )
 	formatex(fullpathsound, charsmax(fullpathsound), "sound/%s.wav", sound)
 	if( file_exists(fullpathsound) )
 	{
-		precache_sound(fullpathsound[6])
+		precache_generic(fullpathsound)
 	}
 	else
 	{

--- a/plugins/dod/statssounds.sma
+++ b/plugins/dod/statssounds.sma
@@ -14,21 +14,21 @@
 #include <amxmodx>
 
 public plugin_precache(){
-	precache_sound( "misc/impressive.wav")
-	precache_sound( "misc/headshot.wav")
-	precache_sound( "misc/multikill.wav")
-	precache_sound( "misc/doublekill.wav")
-	precache_sound( "misc/godlike.wav")
-	precache_sound( "misc/ultrakill.wav")
-	precache_sound( "misc/killingspree.wav")
-	precache_sound( "misc/rampage.wav")
-	precache_sound( "misc/unstoppable.wav")
-	precache_sound( "misc/monsterkill.wav")
-	precache_sound( "misc/humiliation.wav")
+	precache_generic( "sound/misc/impressive.wav")
+	precache_generic( "sound/misc/headshot.wav")
+	precache_generic( "sound/misc/multikill.wav")
+	precache_generic( "sound/misc/doublekill.wav")
+	precache_generic( "sound/misc/godlike.wav")
+	precache_generic( "sound/misc/ultrakill.wav")
+	precache_generic( "sound/misc/killingspree.wav")
+	precache_generic( "sound/misc/rampage.wav")
+	precache_generic( "sound/misc/unstoppable.wav")
+	precache_generic( "sound/misc/monsterkill.wav")
+	precache_generic( "sound/misc/humiliation.wav")
 
-	precache_sound( "misc/takenlead.wav" ) 
-	precache_sound( "misc/tiedlead.wav" ) 
-	precache_sound( "misc/lostlead.wav" ) 
+	precache_generic( "sound/misc/takenlead.wav" ) 
+	precache_generic( "sound/misc/tiedlead.wav" ) 
+	precache_generic( "sound/misc/lostlead.wav" ) 
 
 	return PLUGIN_CONTINUE
 }

--- a/plugins/tfc/statssounds.sma
+++ b/plugins/tfc/statssounds.sma
@@ -14,21 +14,21 @@
 #include <amxmodx>
 
 public plugin_precache(){
-	precache_sound( "misc/impressive.wav")
-	precache_sound( "misc/headshot.wav")
-	precache_sound( "misc/multikill.wav")
-	precache_sound( "misc/doublekill.wav")
-	precache_sound( "misc/godlike.wav")
-	precache_sound( "misc/ultrakill.wav")
-	precache_sound( "misc/killingspree.wav")
-	precache_sound( "misc/rampage.wav")
-	precache_sound( "misc/unstoppable.wav")
-	precache_sound( "misc/monsterkill.wav")
-	precache_sound( "misc/humiliation.wav")
+	precache_generic( "sound/misc/impressive.wav")
+	precache_generic( "sound/misc/headshot.wav")
+	precache_generic( "sound/misc/multikill.wav")
+	precache_generic( "sound/misc/doublekill.wav")
+	precache_generic( "sound/misc/godlike.wav")
+	precache_generic( "sound/misc/ultrakill.wav")
+	precache_generic( "sound/misc/killingspree.wav")
+	precache_generic( "sound/misc/rampage.wav")
+	precache_generic( "sound/misc/unstoppable.wav")
+	precache_generic( "sound/misc/monsterkill.wav")
+	precache_generic( "sound/misc/humiliation.wav")
 
-	precache_sound( "misc/takenlead.wav" ) 
-	precache_sound( "misc/tiedlead.wav" ) 
-	precache_sound( "misc/lostlead.wav" ) 
+	precache_generic( "sound/misc/takenlead.wav" ) 
+	precache_generic( "sound/misc/tiedlead.wav" ) 
+	precache_generic( "sound/misc/lostlead.wav" ) 
 
 	return PLUGIN_CONTINUE
 }

--- a/plugins/ts/stats.sma
+++ b/plugins/ts/stats.sma
@@ -92,8 +92,8 @@ new g_HeadShots[7][] = {
 }
 
 public plugin_precache(){
-  precache_sound( "misc/headshot.wav")
-  precache_sound( "misc/doublekill.wav")
+  precache_generic( "sound/misc/headshot.wav")
+  precache_generic( "sound/misc/doublekill.wav")
   return PLUGIN_CONTINUE
 }
 

--- a/plugins/ts/statssounds.sma
+++ b/plugins/ts/statssounds.sma
@@ -14,21 +14,21 @@
 #include <amxmodx>
 
 public plugin_precache(){
-	precache_sound( "misc/impressive.wav")
-	precache_sound( "misc/headshot.wav")
-	precache_sound( "misc/multikill.wav")
-	precache_sound( "misc/doublekill.wav")
-	precache_sound( "misc/godlike.wav")
-	precache_sound( "misc/ultrakill.wav")
-	precache_sound( "misc/killingspree.wav")
-	precache_sound( "misc/rampage.wav")
-	precache_sound( "misc/unstoppable.wav")
-	precache_sound( "misc/monsterkill.wav")
-	precache_sound( "misc/humiliation.wav")
+	precache_generic( "sound/misc/impressive.wav")
+	precache_generic( "sound/misc/headshot.wav")
+	precache_generic( "sound/misc/multikill.wav")
+	precache_generic( "sound/misc/doublekill.wav")
+	precache_generic( "sound/misc/godlike.wav")
+	precache_generic( "sound/misc/ultrakill.wav")
+	precache_generic( "sound/misc/killingspree.wav")
+	precache_generic( "sound/misc/rampage.wav")
+	precache_generic( "sound/misc/unstoppable.wav")
+	precache_generic( "sound/misc/monsterkill.wav")
+	precache_generic( "sound/misc/humiliation.wav")
 
-	precache_sound( "misc/takenlead.wav" ) 
-	precache_sound( "misc/tiedlead.wav" ) 
-	precache_sound( "misc/lostlead.wav" ) 
+	precache_generic( "sound/misc/takenlead.wav" ) 
+	precache_generic( "sound/misc/tiedlead.wav" ) 
+	precache_generic( "sound/misc/lostlead.wav" ) 
 
 	return PLUGIN_CONTINUE
 }


### PR DESCRIPTION
Since files precached with precache_generic() don't add up to the 512 limit, it makes sense to use this precache method for sounds that are played client-side with "client_cmd spk" in order to save precious resource space.