### PR TITLE
Add info about callback function

### DIFF
--- a/plugins/include/amxmodx.inc
+++ b/plugins/include/amxmodx.inc
@@ -1894,6 +1894,11 @@ native remove_user_flags(index, flags = -1, id = 0);
  * Registers a callback to be called when the client executes a command from the
  * console.
  *
+ * @note The function is called in the following manner:
+ *   id              - Client index
+ *   flags           - Admin privilege flags set in the "flags" argument
+ *   cmd_id          - Command index (same as the function's return value)
+ *
  * @note For a list of possible access flags, see the ADMIN_* constants in
  *       amxconst.inc
  * @note Opting in to FlagManager enables the admin privileges to be overwritten
@@ -1920,6 +1925,11 @@ native register_clcmd(const client_cmd[], const function[], flags = -1, const in
  * Registers a callback to be called when the client or server executes a
  * command from the console.
  *
+ * @note The function is called in the following manner:
+ *   id              - Client index
+ *   flags           - Admin privilege flags set in the "flags" argument
+ *   cmd_id          - Command index (same as the function's return value)
+ *
  * @note For a list of possible access flags, see the ADMIN_* constants in
  *       amxconst.inc
  * @note Opting in to FlagManager enables the admin privileges to be overwritten
@@ -1945,6 +1955,11 @@ native register_concmd(const cmd[], const function[], flags = -1, const info[] =
 /**
  * Registers a callback to be called when the server executes a command from the
  * console.
+ *
+ * @note The function is called in the following manner:
+ *   id              - Client index
+ *   flags           - Admin privilege flags set in the "flags" argument
+ *   cmd_id          - Command index (same as the function's return value)
  *
  * @note For a list of possible access flags, see the ADMIN_* constants in
  *       amxconst.inc


### PR DESCRIPTION
Add missing information about the callback function structure for `register_*cmd`.