### PR TITLE
Add missing menu functions callback information

### DIFF
--- a/plugins/include/amxmisc.inc
+++ b/plugins/include/amxmisc.inc
@@ -603,6 +603,13 @@ stock get_datadir(name[], len)
 /**
  * Provides a shorthand to register a working menu.
  *
+ * @note The function is called in the following manner:
+ *   id              - Client index
+ *   key             - Menu key pressed
+ *
+ * @note For a list of possible menu key, see the MENU_KEY_* constants in
+ *       amxconst.inc
+ *
  * @note Combines the necessary calls to register_menuid() and
  *       register_menucmd() into a single function.
  *

--- a/plugins/include/amxmodx.inc
+++ b/plugins/include/amxmodx.inc
@@ -2096,6 +2096,13 @@ native register_menuid(const menu[], outside = 0);
 /**
  * Registers a callback function to a menu id and keys.
  *
+ * @note The function is called in the following manner:
+ *   id              - Client index
+ *   key             - Menu key pressed
+ *
+ * @note For a list of possible menu key, see the MENU_KEY_* constants in
+ *       amxconst.inc
+ *
  * @param menuid        Menu id
  * @param keys          Key flags
  * @param function      Callback function


### PR DESCRIPTION
Callback information for `register_menu` & `register_menucmd`.

PS: if someone can please check if there's a third argument in the forward. I wasn't able to find what it is anywhere.

```cpp
static cell AMX_NATIVE_CALL register_menucmd(AMX *amx, cell *params) /* 3 param */
{
	CPluginMngr::CPlugin* plugin = g_plugins.findPluginFast(amx);
	int ilen, idx;
	char* sptemp = get_amxstring(amx, params[3], 0, ilen);

	idx = registerSPForwardByName(amx, sptemp, FP_CELL, FP_CELL, FP_CELL, FP_DONE);
```