### PR TITLE
Fix newmenus.inc documentation

### DIFF
--- a/plugins/include/newmenus.inc
+++ b/plugins/include/newmenus.inc
@@ -98,21 +98,21 @@
 /** @endsection */
 
 /**
- * @brief Creates a new menu object.
+ * Creates a new menu object.
  *
- * The handler function should be prototyped as:
+ * @note The handler function should be prototyped as:
  *
  * public <function>(id, menu, item)
- *  id     - Client the menu is being acted upon.
- *  menu   - Menu resource identifier.
- *  item   - Item the client selected.  If less than 0, the menu was 
- *           cancelled and the item is a status code.  menu_display 
- *			 should never be called immediately if the item is a status 
- *			 code, for re-entrancy reasons.
+ *   id     - Client the menu is being acted upon.
+ *   menu   - Menu resource identifier.
+ *   item   - Item the client selected.  If less than 0, the menu was 
+ *            cancelled and the item is a status code.  menu_display 
+ *			  should never be called immediately if the item is a status 
+ *			  code, for re-entrancy reasons.
  *
- * The handler function should always return PLUGIN_HANDLED to block 
- * any old menu handlers from potentially feeding on the menu, unless 
- * that is the desired functionality.
+ * @note The handler function should always return PLUGIN_HANDLED to block 
+ *       any old menu handlers from potentially feeding on the menu, unless 
+ *       that is the desired functionality.
  *
  * @param title 		Title the menu should use.
  * @param handler		Name of the handler function.  The function will be invoked 
@@ -127,16 +127,16 @@
 native menu_create(const title[], const handler[], bool:ml = false);
 
 /**
- * Creates a menu item callback handler.  
+ * Creates a menu item callback handler.
  *
- * The handler function should be prototyped as:
+ * @note The handler function should be prototyped as:
  *
  * public <function>(id, menu, item)
- *  id      - Client index being displayed to.
- *  menu    - Menu resource identifier.
- *  item    - Item being drawn.
- * <return> - ITEM_IGNORE to use the default functionality.  ITEM_ENABLED to 
- *            explicitly enable or ITEM_DISABLED to explicitly disable.
+ *   id      - Client index being displayed to.
+ *   menu    - Menu resource identifier.
+ *   item    - Item being drawn.
+ *   <return> - ITEM_IGNORE to use the default functionality.
+ *              ITEM_ENABLED to explicitly enable or ITEM_DISABLED to explicitly disable.
  *
  * @param function		Function name.
  * @return				Menu callback ID.
@@ -287,11 +287,11 @@ native menu_destroy(menu);
 /**
  * Returns information about a menu (if any) the client is currently viewing.
  *
- * If newmenu is valid, then the menu will refer to the menuid associated with 
- * the title.  If newmenu is not valid, and the menu is valid, then the player 
- * is viewing a menu displayed with show_menu().
+ * @note If newmenu is valid, then the menu will refer to the menuid associated with 
+ *       the title. If newmenu is not valid, and the menu is valid, then the player 
+ *       is viewing a menu displayed with show_menu().
  *
- * Both may be invalid if the player is not viewing a menu.
+ * @note Both may be invalid if the player is not viewing a menu.
  *
  * @param id			Client index.
  * @param menu			Variable to store old menu id.  If none, then <1 will be 
@@ -307,8 +307,8 @@ native player_menu_info(id, &menu, &newmenu, &menupage=0);
 /**
  * Adds a blank line to a menu.
  * 
- * When using slot=1 this might break your menu. To achieve this functionality
- * menu_addblank2 should be used.
+ * @note When using slot=1 this might break your menu. To achieve this functionality
+ *       menu_addblank2 should be used.
  * 
  * @param menu			Menu resource identifier.
  * @param slot			1 (default) if the line should shift the numbering down.
@@ -319,10 +319,10 @@ native player_menu_info(id, &menu, &newmenu, &menupage=0);
 native menu_addblank(menu, slot=1);
 
 /**
- * Adds a text line to a menu.  Only available in amxmodx 1.8.1 and above.
+ * Adds a text line to a menu.
  *
- * When using slot=1 this might break your menu. To achieve this functionality
- * menu_addtext2 should be used.
+ * @note When using slot=1 this might break your menu. To achieve this functionality
+ *       menu_addtext2 should be used.
  * 
  * @param menu			Menu resource identifier.
  * @param text			Text to add.
@@ -336,11 +336,9 @@ native menu_addtext(menu, const text[], slot=1);
 /**
  * Adds a blank line to a menu, always shifting the numbering down.
  * 
- * This will add a special item to create a blank line. It will affect the menu
- * item count and pagination. These items can be modified later but will ignore 
- * access and item callback results.
- * 
- * Only available in 1.8.3 and above.
+ * @note This will add a special item to create a blank line. It will affect the menu
+ *       item count and pagination. These items can be modified later but will ignore 
+ *       access and item callback results.
  * 
  * @param menu          Menu resource identifier.
  * 
@@ -353,11 +351,9 @@ native menu_addblank2( menu );
 /**
  * Adds a text line to a menu, always shifting the numbering down.
  * 
- * This will add a special item to create a blank line. It will affect the menu
- * item count and pagination. These items can be modified later but will ignore 
- * access and item callback results.
- * 
- * Only available in 1.8.3 and above.
+ * @note This will add a special item to create a blank line. It will affect the menu
+ *       item count and pagination. These items can be modified later but will ignore 
+ *       access and item callback results.
  *
  * @param menu          Menu resource identifier.
  * @param text          Text to add.


### PR DESCRIPTION
`@brief` does not exist
`@param` wasn't generating because of it
Move some text to `@note`
Remove "only available in 1.8.1/1.8.3"

Before: https://www.amxmodx.org/api/newmenus/menu_create
After: https://amxx-bg.info/api/newmenus/menu_create