### PR TITLE
Fix typo in open_dir native

### DIFF
--- a/amxmodx/file.cpp
+++ b/amxmodx/file.cpp
@@ -756,7 +756,7 @@ struct DirectoryHandle
 	bool valvefs;
 };
 
-// native open_dir(dir[], firstfile[], length, &FileType:type = FileType_Unknown, bool:use_valve_fs=false, const valve_path_id[] = "GAME");
+// native open_dir(const dir[], firstfile[], length, &FileType:type = FileType_Unknown, bool:use_valve_fs=false, const valve_path_id[] = "GAME");
 static cell AMX_NATIVE_CALL amx_open_dir(AMX *amx, cell *params)
 {
 	int length;

--- a/plugins/include/file.inc
+++ b/plugins/include/file.inc
@@ -519,7 +519,7 @@ native unlink(const filename[], bool:use_valve_fs = false, const valve_path_id[]
  *
  * @return              Handle to the directory, 0 otherwise
  */
-native open_dir(dir[], firstfile[], length, &FileType:type = FileType_Unknown, bool:use_valve_fs = false, const valve_path_id[] = "GAME");
+native open_dir(const dir[], firstfile[], length, &FileType:type = FileType_Unknown, bool:use_valve_fs = false, const valve_path_id[] = "GAME");
 
 /**
  * Reads the next directory entry as a local filename.


### PR DESCRIPTION
dir[] parameter is not const, but it never changes.