### PR TITLE
Add ignore for amxx binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,5 +84,7 @@ Thumbs.db
 # AMXX plugin build related files
 plugins/compile.dat
 plugins/compiled/
+*.amx
+*.amxx
 
 build_deps/


### PR DESCRIPTION
Plugin binaries don't always end up in plugins/compiled/ depending on how you are compiling them.  Adding them to the ignore list will account for any custom tools used to compile plugins.