### PR TITLE
Fix for loop index out of bounds error

### DIFF
--- a/plugins/cstrike/restmenu.sma
+++ b/plugins/cstrike/restmenu.sma
@@ -495,8 +495,10 @@ findAdminsWithMenu(playersList[MAX_PLAYERS], &playersCount, const commandLevel =
 
 	get_players(playersList, playersCount, "ch");
 
-	for (new i = 0; i < playersCount, (player = playersList[i]); ++i)
+	for (new i = 0; i < playersCount; ++i)
 	{
+		player = playersList[i]
+		
 		if (player_menu_info(player, menu, newmenu) && newmenu != -1 && newmenu == MenuHandle[player])
 		{
 			if (commandLevel == -1 || access(player, commandLevel)) // extra safety
@@ -519,8 +521,10 @@ refreshMenus(const commandLevel = 0, const bool:displaySaveMessage = false)
 		return;
 	}
 
-	for (new i = 0, player; i < playersCount, (player = playersList[i]); ++i)
+	for (new i = 0, player; i < playersCount; ++i)
 	{
+		player = playersList[i]
+		
 		MenuHandle[player] = displayMenu(player, MenuPosition[player]);
 
 		if (displaySaveMessage)


### PR DESCRIPTION
Fixes an index out of bounds error when refreshMenus() and subsequently findAdminsWithMenu() is called when there is 32 players in the server. Indexing the playersList array in the for loop condition causes it to try to index with a value of 32 on the very last condition check which is not valid for this array.