### PR TITLE
Add native `arraycompare`.

### DIFF
--- a/amxmodx/amxmodx.cpp
+++ b/amxmodx/amxmodx.cpp
@@ -4453,6 +4453,20 @@ static cell AMX_NATIVE_CALL arrayset(AMX *amx, cell *params)
 	return 1;
 }
 
+// native bool:arraycompare(const any:what[], const any:with[], const size);
+static cell AMX_NATIVE_CALL arraycompare(AMX *amx, cell *params)
+{
+	cell *what = get_amxaddr(amx, params[1]);
+	cell *with = get_amxaddr(amx, params[2]);
+	int size = params[3];
+
+	while (size--)
+		if (*with++ != *what++)
+			return 0;
+
+	return 1;
+}
+
 static cell AMX_NATIVE_CALL CreateLangKey(AMX *amx, cell *params)
 {
 	int len;
@@ -4682,6 +4696,7 @@ AMX_NATIVE_INFO amxmodx_Natives[] =
 	{"admins_push",				admins_push},
 	{"amxclient_cmd",			amxclient_cmd},
 	{"arrayset",				arrayset},
+	{"arraycompare",			arraycompare},
 	{"get_addr_val",			get_addr_val},
 	{"get_var_addr",			get_var_addr},
 	{"set_addr_val",			set_addr_val},

--- a/plugins/include/amxmodx.inc
+++ b/plugins/include/amxmodx.inc
@@ -3310,6 +3310,17 @@ native DestroyForward(forward_handle);
 native arrayset(any:array[], any:value, size);
 
 /**
+ * Compares two arrays.
+ *
+ * @param what    First array 
+ * @param with    Second array
+ * @param size    Size of array
+ *
+ * @return Returns true if arrays are equaly, false otherwise.
+ */
+native bool:arraycompare(const any:what[], const any:with[], const size);
+
+/**
  * Returns the weapon id associated with a weapon name.
  *
  * @note The weapon name is case sensitive and has the weapon_* form.


### PR DESCRIPTION
```pawn
/**
 * Compares two arrays.
 *
 * @param what    First array 
 * @param with    Second array
 * @param size    Size of array
 *
 * @return Returns true if arrays are equaly, false otherwise.
 */
native bool:arraycompare(const any:what[], const any:with[], const size);
```

Example:
```pawn
new const Float:SOME_ARRAY[3] = {1.23, 1.11, 3.21};
new const Float:SOME_ARRAY2[3] = {1.23, 1.11, 78.3};

new Float:SomeArray[3];
SomeArray = SOME_ARRAY;

arraycompare(SOME_ARRAY, SomeArray, 3); // => true
arraycompare(SOME_ARRAY2, SomeArray, 3); // => false
arraycompare(SOME_ARRAY2, SomeArray, 2); // => true
```