### PR TITLE
Update CMisc.h

### DIFF
--- a/modules/tfcx/CMisc.h
+++ b/modules/tfcx/CMisc.h
@@ -23,7 +23,7 @@
 	#define PLAYER_LINUXOFFSET  0
 	#define CLIP_LINUXOFFSET    0
 #else
-	#define LINUXOFFSET         4
+	#define LINUXOFFSET         3
 	#define PLAYER_LINUXOFFSET  5
 	#define CLIP_LINUXOFFSET    4
 #endif


### PR DESCRIPTION
LINUXOFFSET is back at 3 since HLDS Linux build 8308 (dated July 24, 2019).