### PR TITLE
Revert "Update CMisc.h (#984)"

### DIFF
--- a/modules/tfcx/CMisc.h
+++ b/modules/tfcx/CMisc.h
@@ -23,7 +23,7 @@
 	#define PLAYER_LINUXOFFSET  0
 	#define CLIP_LINUXOFFSET    0
 #else
-	#define LINUXOFFSET         3
+	#define LINUXOFFSET         4
 	#define PLAYER_LINUXOFFSET  5
 	#define CLIP_LINUXOFFSET    4
 #endif


### PR DESCRIPTION
Turned out both test servers still had an old "tfc_i386.so" file which took precedence over the newer "tfc.so" library, so both servers were misconfigured and that's why the offsets didn't work.