### PR TITLE
Fix typo on get_user_flags documentation

### DIFF
--- a/plugins/include/amxmodx.inc
+++ b/plugins/include/amxmodx.inc
@@ -1851,7 +1851,7 @@ native set_user_flags(index, flags = -1, id = 0);
  *       0 is actively used. You should not change the value of the second
  *       parameter from the default.
  *
- * @param index     Client index, 0 to set flags of server
+ * @param index     Client index, 0 to get flags of server
  * @param id        Flag set id, ranging from 0 to 31
  *
  * @return          Bitflag sum of client's admin flags


### PR DESCRIPTION
Hello,

I found that [amxmodx.inc](https://github.com/alliedmodders/amxmodx/blob/3eefe5562eaf709ce4a93cf1fd7d289b5b9e278a/plugins/include/amxmodx.inc#L1861) has a typo on `get_user_flags` documentation.
It's saying that passing index 0 will actually set server flags instead of returning it.