### PR TITLE
[Build] Implement CI for MacOS via appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -110,27 +110,6 @@ for:
 
         cd $APPVEYOR_BUILD_FOLDER
         
-        brew install robotsandpencils/made/xcodes
-
-        xcodes installed
-
-        echo -- sudo xcode-select -s /Applications/Xcode-10.3.app
-
-        echo -- clang --version
-
-        echo -- sudo xcodes select 9.4.1
-
-        echo -- sudo xcodes select /Applications/Xcode-9.4.1.app
-
-        echo -- sudo xcode-select --install
-
-        echo -- sudo xcode-select -switch /Library/Developer/CommandLineTools/
-
-        echo -- sudo xcode-select -s /Applications/Xcode-9.4.1.app
-        
-        echo -- clang --version
-
-        
     build_script:
     - >-
         echo $PATH

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -120,11 +120,11 @@ for:
 
         echo sudo xcodes select 9.4.1
 
-        echo sudo xcode-select -s /Applications/Xcode-9.4.1.app
+        sudo xcode-select -s /Applications/Xcode-9.4.1.app
 
-        echo sudo xcode-select --install
+        sudo xcode-select --install
 
-        echo clang --version
+        clang --version
 
         
     build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,11 @@ environment:
   matrix:
     - job_name: Windows
       appveyor_build_worker_image: Visual Studio 2015
+      job_group: Build
+    
     - job_name: MacOS
       appveyor_build_worker_image: macos
+      job_group: Build
 
 for:
   -

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -118,7 +118,9 @@ for:
 
         clang --version
 
-        sudo xcodes select 9.4.1
+        echo sudo xcodes select 9.4.1
+
+        sudo xcode-select -s /Applications/Xcode-9.4.1.app
 
         clang --version
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -114,17 +114,17 @@ for:
 
         xcodes installed
 
-        sudo xcode-select -s /Applications/Xcode-10.3.app
+        echo sudo xcode-select -s /Applications/Xcode-10.3.app
 
-        clang --version
+        echo clang --version
 
         echo sudo xcodes select 9.4.1
 
-        sudo xcode-select -s /Applications/Xcode-9.4.1.app
+        echo sudo xcode-select -s /Applications/Xcode-9.4.1.app
 
-        sudo xcode-select --install
+        echo sudo xcode-select --install
 
-        clang --version
+        echo clang --version
 
         
     build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -122,6 +122,8 @@ for:
 
         sudo xcode-select -s /Applications/Xcode-9.4.1.app
 
+        sudo xcode-select --install
+
         clang --version
 
         

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,6 +59,8 @@ for:
         
         c:\python38\python setup.py install
         
+        set PATH=C:\Python38;C:\Python38\Scripts;%PATH%
+        
         cd ..\amxmodx
         
 # cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,7 +64,7 @@ for:
 #   - c:\projects\mysql-5.5 -> appveyor.yml
     build_script:
     - cmd: >-
-        '"%VS140COMNTOOLS%\vsvars32.bat"'
+        "%VS140COMNTOOLS%\vsvars32.bat"
         
         mkdir build
         

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,13 +5,13 @@ environment:
   fast_finish: false
   allow_failures: true
   matrix:
-    - job_name: Windows
-      appveyor_build_worker_image: Visual Studio 2015
-      job_group: Build
-    
     - job_name: MacOS
       appveyor_build_worker_image: macos
       job_group: Build
+
+    - job_name: Windows
+      appveyor_build_worker_image: Visual Studio 2015
+      job_group: Build    
 
 for:
   -
@@ -87,7 +87,7 @@ for:
         ls -alh
 
         mkdir -p $APPVEYOR_BUILD_FOLDER/deps
-        
+
         ls -alh
         
         cd $APPVEYOR_BUILD_FOLDER/deps

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -114,7 +114,7 @@ for:
 
         xcodes installed
 
-        xcodes select 10.3
+        xcode-select /Applications/Xcode-10.3.app
 
         clang --version
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ install:
 - git clone https://github.com/alliedmodders/ambuild
 - git clone https://github.com/alliedmodders/metamod-hl1
 - git clone https://github.com/alliedmodders/hlsdk
-- ps: Start-FileDownload 'https://downloads.mysql.com/archives/get/p/19/file/mysql-connector-c-6.1.1-win32.zip'
+- curl -L -o "mysql-connector-c-6.1.1-win32.zip" https://downloads.mysql.com/archives/get/p/19/file/mysql-connector-c-6.1.1-win32.zip
 - 7z x mysql-connector-c-6.1.1-win32.zip -o"mysql"
 - cd mysql
 - dir
@@ -21,9 +21,9 @@ install:
 - cd ..\ambuild
 - c:\python27\python setup.py install
 - cd ..\amxmodx
-cache:
-  - c:\projects\*.zip -> appveyor.yml
-  - c:\projects\mysql-5.5 -> appveyor.yml
+# cache:
+#   - c:\projects\*.zip -> appveyor.yml
+#   - c:\projects\mysql-5.5 -> appveyor.yml
 build_script:
 - '"%VS140COMNTOOLS%\vsvars32.bat"'
 - mkdir build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -110,6 +110,11 @@ for:
 
         cd $APPVEYOR_BUILD_FOLDER
         
+        brew install robotsandpencils/made/xcodes
+
+        xcodes installed
+
+        
     build_script:
     - >-
         echo $PATH

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -118,9 +118,11 @@ for:
 
         echo clang --version
 
-        echo sudo xcodes select 9.4.1
+        sudo xcodes select 9.4.1
 
-        sudo xcode-select -s /Applications/Xcode-9.4.1.app
+        sudo xcodes select /Applications/Xcode-9.4.1.app
+
+        echo sudo xcode-select -s /Applications/Xcode-9.4.1.app
 
         sudo xcode-select --install
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,13 +55,13 @@ for:
         - job_name: MacOS
 
     install:
-    - bash: >-
+    - >-
         echo "CC=clang" >> $GITHUB_ENV
         echo "CXX=clang++" >> $GITHUB_ENV
         clang --version
         clang++ --version
     build_script:
-    - bash: >-
+    - >-
         mkdir build
         cd build
         python3 ../configure.py --enable-optimize --metamod=${{ env.DEPENDENCIES_ROOT }}/metamod-am --hlsdk=${{ env.DEPENDENCIES_ROOT }}/hlsdk --mysql=${{ env.DEPENDENCIES_ROOT }}/mysql-5.5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -74,6 +74,8 @@ for:
         
         c:\python38\python ../configure.py --enable-optimize --nasm="C:\nasm\nasm-2.13.03\nasm.exe"
         
+        echo $PATH
+        
         ambuild
 
   -

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
   allow_failures: true
   matrix:
     - job_name: MacOS
-      appveyor_build_worker_image: macos
+      appveyor_build_worker_image: macos-mojave
       job_group: Build
 
     - job_name: Windows
@@ -114,21 +114,21 @@ for:
 
         xcodes installed
 
-        echo sudo xcode-select -s /Applications/Xcode-10.3.app
+        echo -- sudo xcode-select -s /Applications/Xcode-10.3.app
 
-        echo clang --version
+        echo -- clang --version
 
         echo -- sudo xcodes select 9.4.1
 
         echo -- sudo xcodes select /Applications/Xcode-9.4.1.app
 
-        sudo xcode-select --install
+        echo -- sudo xcode-select --install
 
-        sudo xcode-select -switch /Library/Developer/CommandLineTools/
+        echo -- sudo xcode-select -switch /Library/Developer/CommandLineTools/
 
-        echo sudo xcode-select -s /Applications/Xcode-9.4.1.app
+        echo -- sudo xcode-select -s /Applications/Xcode-9.4.1.app
         
-        clang --version
+        echo -- clang --version
 
         
     build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,32 +1,68 @@
 version: 1.0.{build}
-clone_folder: c:\projects\amxmodx
-install:
-- git submodule update --init --recursive
-- 'c:'
-- mkdir c:\nasm
-- set PATH=c:\nasm\nasm-2.13.03;%PATH%
-- curl -L -o "c:\nasm\nasm.zip" https://www.nasm.us/pub/nasm/releasebuilds/2.13.03/win32/nasm-2.13.03-win32.zip
-- chdir c:\nasm
-- 7z x nasm.zip
-- chdir c:\projects
-- git clone https://github.com/alliedmodders/ambuild
-- git clone https://github.com/alliedmodders/metamod-hl1
-- git clone https://github.com/alliedmodders/hlsdk
-- curl -L -o "mysql-connector-c-6.1.1-win32.zip" https://downloads.mysql.com/archives/get/p/19/file/mysql-connector-c-6.1.1-win32.zip
-- 7z x mysql-connector-c-6.1.1-win32.zip -o"mysql"
-- cd mysql
-- dir
-- ren mysql-connector-c-6.1.1-win32 mysql-5.5
-- move /Y mysql-5.5 ..\
-- cd ..\ambuild
-- c:\python27\python setup.py install
-- cd ..\amxmodx
+
+
+environment:
+  fast_finish: false
+  allow_failures: true
+  matrix:
+    - job_name: Windows
+      appveyor_build_worker_image: Visual Studio 2015
+    - job_name: MacOS
+      appveyor_build_worker_image: macos
+
+for:
+  -
+    matrix:
+      only:
+        - job_name: Windows
+
+    clone_folder: c:\projects\amxmodx
+    install:
+    - cmd: >-
+        git submodule update --init --recursive
+        c:
+        mkdir c:\nasm
+        set PATH=c:\nasm\nasm-2.13.03;%PATH%
+        curl -L -o "c:\nasm\nasm.zip" https://www.nasm.us/pub/nasm/releasebuilds/2.13.03/win32/nasm-2.13.03-win32.zip
+        chdir c:\nasm
+        7z x nasm.zip
+        chdir c:\projects
+        git clone https://github.com/alliedmodders/ambuild
+        git clone https://github.com/alliedmodders/metamod-hl1
+        git clone https://github.com/alliedmodders/hlsdk
+        curl -L -o "mysql-connector-c-6.1.1-win32.zip" https://downloads.mysql.com/archives/get/p/19/file/mysql-connector-c-6.1.1-win32.zip
+        7z x mysql-connector-c-6.1.1-win32.zip -o"mysql"
+        cd mysql
+        dir
+        ren mysql-connector-c-6.1.1-win32 mysql-5.5
+        move /Y mysql-5.5 ..\
+        cd ..\ambuild
+        c:\python27\python setup.py install
+        cd ..\amxmodx
 # cache:
 #   - c:\projects\*.zip -> appveyor.yml
 #   - c:\projects\mysql-5.5 -> appveyor.yml
-build_script:
-- '"%VS140COMNTOOLS%\vsvars32.bat"'
-- mkdir build
-- cd build
-- c:\python27\python ../configure.py --enable-optimize --nasm="C:\nasm\nasm-2.13.03\nasm.exe"
-- ambuild
+    build_script:
+    - cmd: >-
+        '"%VS140COMNTOOLS%\vsvars32.bat"'
+        mkdir build
+        cd build
+        c:\python27\python ../configure.py --enable-optimize --nasm="C:\nasm\nasm-2.13.03\nasm.exe"
+        ambuild
+  -
+    matrix:
+      only:
+        - job_name: MacOS
+
+    install:
+    - bash: >-
+        echo "CC=clang" >> $GITHUB_ENV
+        echo "CXX=clang++" >> $GITHUB_ENV
+        clang --version
+        clang++ --version
+    build_script:
+    - bash: >-
+        mkdir build
+        cd build
+        python3 ../configure.py --enable-optimize --metamod=${{ env.DEPENDENCIES_ROOT }}/metamod-am --hlsdk=${{ env.DEPENDENCIES_ROOT }}/hlsdk --mysql=${{ env.DEPENDENCIES_ROOT }}/mysql-5.5
+        ambuild

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ for:
     - cmd: >-
         git submodule update --init --recursive
 
-        'c:'
+        c:
         
         mkdir c:\nasm
         

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -85,7 +85,7 @@ for:
     install:
     - >-
         git submodule update --init --recursive
-        
+
         mkdir -p $APPVEYOR_BUILD_FOLDER/deps
 
         ls -alh
@@ -112,6 +112,8 @@ for:
         
     build_script:
     - >-
+        echo $PATH
+        
         mkdir build
         
         cd build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -74,8 +74,8 @@ for:
         
         c:\python38\python ../configure.py --enable-optimize --nasm="C:\nasm\nasm-2.13.03\nasm.exe"
         
-        echo $PATH
-        
+        echo %PATH%
+
         ambuild
 
   -

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 version: 1.0.{build}
 
-
 environment:
   fast_finish: false
   allow_failures: true
@@ -11,7 +10,7 @@ environment:
 
     - job_name: Windows
       appveyor_build_worker_image: Visual Studio 2015
-      job_group: Build    
+      job_group: Build
 
 for:
   -
@@ -29,7 +28,7 @@ for:
         mkdir c:\nasm
         
         set PATH=c:\nasm\nasm-2.13.03;%PATH%
-        
+
         curl -L -o "c:\nasm\nasm.zip" https://www.nasm.us/pub/nasm/releasebuilds/2.13.03/win32/nasm-2.13.03-win32.zip
         
         chdir c:\nasm
@@ -58,7 +57,7 @@ for:
         
         cd ..\ambuild
         
-        c:\python27\python setup.py install
+        c:\python38\python setup.py install
         
         cd ..\amxmodx
         
@@ -73,10 +72,10 @@ for:
         
         cd build
         
-        c:\python27\python ../configure.py --enable-optimize --nasm="C:\nasm\nasm-2.13.03\nasm.exe"
+        c:\python38\python ../configure.py --enable-optimize --nasm="C:\nasm\nasm-2.13.03\nasm.exe"
         
         ambuild
-        
+
   -
     matrix:
       only:
@@ -121,4 +120,3 @@ for:
         python3 ../configure.py --enable-optimize --metamod=$APPVEYOR_BUILD_FOLDER/deps/metamod-am --hlsdk=$APPVEYOR_BUILD_FOLDER/deps/hlsdk --mysql=$APPVEYOR_BUILD_FOLDER/deps/mysql-5.5
         
         ambuild
-        

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -84,8 +84,6 @@ for:
 
     install:
     - >-
-        ls -alh
-
         mkdir -p $APPVEYOR_BUILD_FOLDER/deps
 
         ls -alh
@@ -103,6 +101,8 @@ for:
         clang --version
         
         clang++ --version
+
+        cd $APPVEYOR_BUILD_FOLDER
         
     build_script:
     - >-
@@ -110,7 +110,7 @@ for:
         
         cd build
         
-        python3 ../configure.py --enable-optimize --metamod=$APPVEYOR_BUILD_FOLDER/metamod-am --hlsdk=$APPVEYOR_BUILD_FOLDER/hlsdk --mysql=$APPVEYOR_BUILD_FOLDER/mysql-5.5
+        python3 ../configure.py --enable-optimize --metamod=$APPVEYOR_BUILD_FOLDER/deps/metamod-am --hlsdk=$APPVEYOR_BUILD_FOLDER/deps/hlsdk --mysql=$APPVEYOR_BUILD_FOLDER/deps/mysql-5.5
         
         ambuild
         

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -81,9 +81,9 @@ for:
 
     install:
     - >-
-        echo "CC=clang" >> $GITHUB_ENV
+        export CC=clang
         
-        echo "CXX=clang++" >> $GITHUB_ENV
+        export CXX=clang++
         
         clang --version
         

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -81,6 +81,14 @@ for:
 
     install:
     - >-
+        mkdir -p $APPVEYOR_BUILD_FOLDER/deps
+        
+        cd $APPVEYOR_BUILD_FOLDER/deps
+        
+        mkdir -p amxmodx
+
+        ../amxmodx/support/checkout-deps.sh
+
         export CC=clang
         
         export CXX=clang++
@@ -95,7 +103,7 @@ for:
         
         cd build
         
-        python3 ../configure.py --enable-optimize --metamod=${{ env.DEPENDENCIES_ROOT }}/metamod-am --hlsdk=${{ env.DEPENDENCIES_ROOT }}/hlsdk --mysql=${{ env.DEPENDENCIES_ROOT }}/mysql-5.5
+        python3 ../configure.py --enable-optimize --metamod=$APPVEYOR_BUILD_FOLDER/metamod-am --hlsdk=$APPVEYOR_BUILD_FOLDER/hlsdk --mysql=$APPVEYOR_BUILD_FOLDER/mysql-5.5
         
         ambuild
         

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -114,6 +114,11 @@ for:
 
         xcodes installed
 
+        xcodes select 10.3
+
+        clang --version
+
+
         
     build_script:
     - >-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -114,7 +114,7 @@ for:
 
         xcodes installed
 
-        xcode-select /Applications/Xcode-10.3.app
+        xcode-select -s /Applications/Xcode-10.3.app
 
         clang --version
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,35 +20,60 @@ for:
     install:
     - cmd: >-
         git submodule update --init --recursive
+
         'c:'
+        
         mkdir c:\nasm
+        
         set PATH=c:\nasm\nasm-2.13.03;%PATH%
+        
         curl -L -o "c:\nasm\nasm.zip" https://www.nasm.us/pub/nasm/releasebuilds/2.13.03/win32/nasm-2.13.03-win32.zip
+        
         chdir c:\nasm
+        
         7z x nasm.zip
+        
         chdir c:\projects
+        
         git clone https://github.com/alliedmodders/ambuild
+        
         git clone https://github.com/alliedmodders/metamod-hl1
+        
         git clone https://github.com/alliedmodders/hlsdk
+        
         curl -L -o "mysql-connector-c-6.1.1-win32.zip" https://downloads.mysql.com/archives/get/p/19/file/mysql-connector-c-6.1.1-win32.zip
+        
         7z x mysql-connector-c-6.1.1-win32.zip -o"mysql"
+        
         cd mysql
+        
         dir
+        
         ren mysql-connector-c-6.1.1-win32 mysql-5.5
+        
         move /Y mysql-5.5 ..\
+        
         cd ..\ambuild
+        
         c:\python27\python setup.py install
+        
         cd ..\amxmodx
+        
 # cache:
 #   - c:\projects\*.zip -> appveyor.yml
 #   - c:\projects\mysql-5.5 -> appveyor.yml
     build_script:
     - cmd: >-
         '"%VS140COMNTOOLS%\vsvars32.bat"'
+        
         mkdir build
+        
         cd build
+        
         c:\python27\python ../configure.py --enable-optimize --nasm="C:\nasm\nasm-2.13.03\nasm.exe"
+        
         ambuild
+        
   -
     matrix:
       only:
@@ -57,12 +82,20 @@ for:
     install:
     - >-
         echo "CC=clang" >> $GITHUB_ENV
+        
         echo "CXX=clang++" >> $GITHUB_ENV
+        
         clang --version
+        
         clang++ --version
+        
     build_script:
     - >-
         mkdir build
+        
         cd build
+        
         python3 ../configure.py --enable-optimize --metamod=${{ env.DEPENDENCIES_ROOT }}/metamod-am --hlsdk=${{ env.DEPENDENCIES_ROOT }}/hlsdk --mysql=${{ env.DEPENDENCIES_ROOT }}/mysql-5.5
+        
         ambuild
+        

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -118,6 +118,9 @@ for:
 
         clang --version
 
+        sudo xcodes select 9.4.1
+
+        clang --version
 
         
     build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -114,7 +114,7 @@ for:
 
         xcodes installed
 
-        xcode-select -s /Applications/Xcode-10.3.app
+        sudo xcode-select -s /Applications/Xcode-10.3.app
 
         clang --version
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ for:
     install:
     - cmd: >-
         git submodule update --init --recursive
-        c:
+        'c:'
         mkdir c:\nasm
         set PATH=c:\nasm\nasm-2.13.03;%PATH%
         curl -L -o "c:\nasm\nasm.zip" https://www.nasm.us/pub/nasm/releasebuilds/2.13.03/win32/nasm-2.13.03-win32.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -84,7 +84,11 @@ for:
 
     install:
     - >-
+        ls -alh
+
         mkdir -p $APPVEYOR_BUILD_FOLDER/deps
+        
+        ls -alh
         
         cd $APPVEYOR_BUILD_FOLDER/deps
         

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -94,6 +94,10 @@ for:
 
         ../support/checkout-deps.sh
 
+        brew install nasm
+
+        nasm -v
+
         export CC=clang
         
         export CXX=clang++

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -94,7 +94,7 @@ for:
         
         mkdir -p amxmodx
 
-        ../amxmodx/support/checkout-deps.sh
+        ../support/checkout-deps.sh
 
         export CC=clang
         

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -118,14 +118,16 @@ for:
 
         echo clang --version
 
-        sudo xcodes select 9.4.1
+        echo -- sudo xcodes select 9.4.1
 
-        sudo xcodes select /Applications/Xcode-9.4.1.app
-
-        echo sudo xcode-select -s /Applications/Xcode-9.4.1.app
+        echo -- sudo xcodes select /Applications/Xcode-9.4.1.app
 
         sudo xcode-select --install
 
+        sudo xcode-select -switch /Library/Developer/CommandLineTools/
+
+        echo sudo xcode-select -s /Applications/Xcode-9.4.1.app
+        
         clang --version
 
         

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -84,6 +84,8 @@ for:
 
     install:
     - >-
+        git submodule update --init --recursive
+        
         mkdir -p $APPVEYOR_BUILD_FOLDER/deps
 
         ls -alh


### PR DESCRIPTION
Since earlier CI (#1003), we missed out on MacOS builds, this PR implements MacOS builds via Appveyor.

### Appveyor vs Github Actions (MacOS)
Appveyor provides [3 OS Imags](https://www.appveyor.com/docs/macos-images-software/#operating-system) for MacOS, viz.,
```
macOS 11.5.2 "Big Sur"
macOS 10.15.7 "Catalina"
macOS 10.14.6 "Mojave"
```
and GitHub actions provides only [2 OS Images](https://github.com/actions/virtual-environments#available-environments), viz.,
```
macOS 11
macOS 10.15
```
and with given instructions on [wiki](https://wiki.alliedmods.net/Building_AMX_Mod_X#Mac_OS_X), i couldn't find a way to build Amxmodx on MacOS > 10.14. MacOS officially drops support for 32bit binaries from 10.15 onwards (even Developer Commandline tools dosent have i386 libs). Anyways if anyone can find a method to build amxmodx on MacOS > 10.14, i can try to convert it into Github Actions. 

With that being said, Present Build matrix is,

### MacOS Runners
MacOS Runners | Image | Compiler
--- | --- | ---
Appveyor MacOS job  | `macOS 10.14.6 "Mojave"` | `apple-clang version 11.0`
BuildBot MacOS Slave  | `macos-10.14` | `apple-clang version 11.0`

### Linux Runners
Linux Runners | Image | Compiler
--- | --- | ---
Github Actions | `linux-ubuntu-latest-gcc` (on this date) | - gcc (Ubuntu 9.3.0\-17ubuntu1\~20.04) 9.3.0<br/> - g++ (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0
Github Actions | `linux-ubuntu-latest-clang` (on this date) | clang version 10.0.0-4ubuntu1 
Github Actions | `linux-ubuntu-18.04-gcc-6` | - gcc-6 (Ubuntu 6.5.0\-2ubuntu1\~18.04) 6.5.0 20181026<br/>\- g++6 (Ubuntu 6.5.0-2ubuntu1~18.04) 6.5.0 20181026
Github Actions | `linux-ubuntu-18.04-clang-3.9` | clang version 3.9.1-19ubuntu1 (tags/RELEASE_391/rc2)
BuildBot Linux Slave  | - | clang version 3.8

### Windows Runners
Windows Runners | Image | Compiler
--- | --- | ---
Appveyor Windows job  | `Windows 2012` | msvc version _MSC_VER 1900 <br/> `msvc++v14.00 1900` `Visual Studio 2015v14.0`
Github Actions | `windows-windows-2016-msvc++14.16-vs2017-cl` | msvc version 1916 - Microsoft (R) C/C++ Optimizing Compiler Version 19.16.27045 for x86 `MSVC++14.16 (Visual Studio 2017v15.9)`
Github Actions | `windows-windows-latest-msvc` (on this date) | msvc version 1929 - Microsoft (R) C/C++ Optimizing Compiler Version 19.29.30133 for x86 `MSVC++14.29 (Visual Studio 2019v16.10+16.11)`
BuildBot Windows Slave  | - | msvc version _MSC_VER 1900 <br/> `MSVC++14.0 Visual Studio 2015v14.0`

Appveyor now builds for MacOS along with the earlier set `Windows Build` - `msvc++v14.00 1900` `Visual Studio 2015`.

### Changes Pertaining to Windows build job in Appveyor
- Updated py version from 27 to 38
- Removed Powershell `Start-FileDownload` dependency to download mysql pakage (using `curl` in `cmd` instead)
- Caching is disabled for now for donwloading dependencies, since we are using a script(windows cmd) to download deps, we need to implement more code to conditionally check if deps exist, if exists, dont download deps again, else build errors @ `move` L56 (folder mysql, restored from cache, already exists) (todo)