### PR TITLE
Fix some misprints and mistakes in code, part 2

### DIFF
--- a/compiler/libpc300/sc6.c
+++ b/compiler/libpc300/sc6.c
@@ -70,7 +70,7 @@ static ucell hex2long(char *s,char **n)
     s++;
   } /* if */
 
-  assert((*s>='0' && *s<='9') || (*s>='a' && *s<='f') || (*s>='a' && *s<='f'));
+  assert((*s>='0' && *s<='9') || (*s>='a' && *s<='f') || (*s>='A' && *s<='F'));
   for ( ;; ) {
     if (*s>='0' && *s<='9')
       digit=*s-'0';

--- a/modules/dod/dodx/CMisc.cpp
+++ b/modules/dod/dodx/CMisc.cpp
@@ -434,7 +434,7 @@ void CPlayer::WeaponsCheck(int weapons)
 	int old;
 	int cur;
 
-	for(int i = 1; i < MAX_WEAPONS; ++i)
+	for(int i = 1; i < DODMAX_WEAPONS; ++i)
 	{
 		// Check to see we are not talking about a grenade and we have changed
 		if(i != 13 && i != 14 && i != 15 && i != 16 && i != 36)

--- a/modules/dod/dodx/NBase.cpp
+++ b/modules/dod/dodx/NBase.cpp
@@ -263,7 +263,7 @@ static cell AMX_NATIVE_CALL dod_weapon_type(AMX *amx, cell *params) /* 2 params 
 	{
 		int weaponsbit = pPlayer->pEdict->v.weapons & ~(1<<31); // don't count last element
 
-		for(int x = 1; x < MAX_WEAPONS; ++x)
+		for(int x = 1; x < DODMAX_WEAPONS; ++x)
 		{
 			if((weaponsbit&(1<<x)) > 0)
 			{

--- a/modules/dod/dodx/usermsg.cpp
+++ b/modules/dod/dodx/usermsg.cpp
@@ -222,7 +222,7 @@ void Client_AmmoX(void* mValue)
   case 1:
 	if (!mPlayer ) 
 		break;
-    for(int i = 1; i < MAX_WEAPONS ; ++i)
+    for(int i = 1; i < DODMAX_WEAPONS ; ++i)
 	{
       if (iAmmo == weaponData[i].ammoSlot)
         mPlayer->weapons[i].ammo = *(int*)mValue;
@@ -244,7 +244,7 @@ void Client_AmmoShort(void* mValue)
 	if(!mPlayer ) 
 		break;
 
-    for(int i = 1; i < MAX_WEAPONS ; ++i) 
+    for(int i = 1; i < DODMAX_WEAPONS ; ++i) 
 	{
       if (iAmmo == weaponData[i].ammoSlot)
 		  mPlayer->weapons[i].ammo = *(int*)mValue;

--- a/modules/fakemeta/fm_tr.cpp
+++ b/modules/fakemeta/fm_tr.cpp
@@ -34,31 +34,26 @@ static cell AMX_NATIVE_CALL set_tr(AMX *amx, cell *params)
 		{
 			gfm_tr->fAllSolid = *ptr;
 			return 1;
-			break;
 		}
 	case TR_StartSolid:
 		{
 			gfm_tr->fStartSolid = *ptr;
 			return 1;
-			break;
 		}
 	case TR_InOpen:
 		{
 			gfm_tr->fInOpen = *ptr;
 			return 1;
-			break;
 		}
 	case TR_InWater:
 		{
 			gfm_tr->fInWater = *ptr;
 			return 1;
-			break;
 		}
 	case TR_flFraction:
 		{
 			gfm_tr->flFraction = amx_ctof(*ptr);
 			return 1;
-			break;
 		}
 	case TR_vecEndPos:
 		{
@@ -66,13 +61,11 @@ static cell AMX_NATIVE_CALL set_tr(AMX *amx, cell *params)
 			gfm_tr->vecEndPos.y = amx_ctof(ptr[1]);
 			gfm_tr->vecEndPos.z = amx_ctof(ptr[2]);
 			return 1;
-			break;
 		}
 	case TR_flPlaneDist:
 		{
 			gfm_tr->flPlaneDist = amx_ctof(*ptr);
 			return 1;
-			break;
 		}
 	case TR_vecPlaneNormal:
 		{
@@ -80,7 +73,6 @@ static cell AMX_NATIVE_CALL set_tr(AMX *amx, cell *params)
 			gfm_tr->vecPlaneNormal.y = amx_ctof(ptr[1]);
 			gfm_tr->vecPlaneNormal.z = amx_ctof(ptr[2]);
 			return 1;
-			break;
 		}
 	case TR_pHit:
 		{
@@ -96,14 +88,12 @@ static cell AMX_NATIVE_CALL set_tr(AMX *amx, cell *params)
 		{
 			gfm_tr->iHitgroup = *ptr;
 			return 1;
-			break;
-		}
-	default:
-		{
-			MF_LogError(amx, AMX_ERR_NATIVE, "Unknown TraceResult member %d", params[2]);
-			return 0;
 		}
 	}
+	
+	MF_LogError(amx, AMX_ERR_NATIVE, "Unknown TraceResult member %d", params[2]);
+	
+	return 0;
 }
 
 static cell AMX_NATIVE_CALL get_tr(AMX *amx, cell *params)
@@ -116,29 +106,24 @@ static cell AMX_NATIVE_CALL get_tr(AMX *amx, cell *params)
 	case TR_AllSolid:
 		{
 			return gfm_tr->fAllSolid;
-			break;
 		}
 	case TR_StartSolid:
 		{
 			return gfm_tr->fStartSolid;
-			break;
 		}
 	case TR_InOpen:
 		{
 			return gfm_tr->fInOpen;
-			break;
 		}
 	case TR_InWater:
 		{
 			return gfm_tr->fInWater;
-			break;
 		}
 	case TR_flFraction:
 		{
 			ptr = MF_GetAmxAddr(amx, params[2]);
 			*ptr = amx_ftoc(gfm_tr->flFraction);
 			return 1;
-			break;
 		}
 	case TR_vecEndPos:
 		{
@@ -147,14 +132,12 @@ static cell AMX_NATIVE_CALL get_tr(AMX *amx, cell *params)
 			ptr[1] = amx_ftoc(gfm_tr->vecEndPos.y);
 			ptr[2] = amx_ftoc(gfm_tr->vecEndPos.z);
 			return 1;
-			break;
 		}
 	case TR_flPlaneDist:
 		{
 			ptr = MF_GetAmxAddr(amx, params[2]);
 			*ptr = amx_ftoc(gfm_tr->flPlaneDist);
 			return 1;
-			break;
 		}
 	case TR_vecPlaneNormal:
 		{
@@ -163,26 +146,21 @@ static cell AMX_NATIVE_CALL get_tr(AMX *amx, cell *params)
 			ptr[1] = amx_ftoc(gfm_tr->vecPlaneNormal.y);
 			ptr[2] = amx_ftoc(gfm_tr->vecPlaneNormal.z);
 			return 1;
-			break;
 		}
 	case TR_pHit:
 		{
 			if (FNullEnt(gfm_tr->pHit))
 				return -1;
 			return ENTINDEX(gfm_tr->pHit);
-			break;
 		}
 	case TR_iHitgroup:
 		{
 			return gfm_tr->iHitgroup;
-			break;
-		}
-	default:
-		{
-			MF_LogError(amx, AMX_ERR_NATIVE, "Unknown TraceResult member %d", params[2]);
-			return 0;
 		}
 	}
+	MF_LogError(amx, AMX_ERR_NATIVE, "Unknown TraceResult member %d", params[2]);
+	
+	return 0;
 }
 
 AMX_NATIVE_INFO tr_Natives[] = 

--- a/modules/fakemeta/fm_tr2.cpp
+++ b/modules/fakemeta/fm_tr2.cpp
@@ -48,31 +48,26 @@ static cell AMX_NATIVE_CALL set_tr2(AMX *amx, cell *params)
 		{
 			tr->fAllSolid = *ptr;
 			return 1;
-			break;
 		}
 	case TR_InOpen:
 		{
 			tr->fInOpen = *ptr;
 			return 1;
-			break;
 		}
 	case TR_StartSolid:
 		{
 			tr->fStartSolid = *ptr;
 			return 1;
-			break;
 		}
 	case TR_InWater:
 		{
 			tr->fInWater = *ptr;
 			return 1;
-			break;
 		}
 	case TR_flFraction:
 		{
 			tr->flFraction = amx_ctof(*ptr);
 			return 1;
-			break;
 		}
 	case TR_vecEndPos:
 		{
@@ -80,13 +75,11 @@ static cell AMX_NATIVE_CALL set_tr2(AMX *amx, cell *params)
 			tr->vecEndPos.y = amx_ctof(ptr[1]);
 			tr->vecEndPos.z = amx_ctof(ptr[2]);
 			return 1;
-			break;
 		}
 	case TR_flPlaneDist:
 		{
 			tr->flPlaneDist = amx_ctof(*ptr);
 			return 1;
-			break;
 		}
 	case TR_vecPlaneNormal:
 		{
@@ -94,7 +87,6 @@ static cell AMX_NATIVE_CALL set_tr2(AMX *amx, cell *params)
 			tr->vecPlaneNormal.y = amx_ctof(ptr[1]);
 			tr->vecPlaneNormal.z = amx_ctof(ptr[2]);
 			return 1;
-			break;
 		}
 	case TR_pHit:
 		{
@@ -110,15 +102,11 @@ static cell AMX_NATIVE_CALL set_tr2(AMX *amx, cell *params)
 		{
 			tr->iHitgroup = *ptr;
 			return 1;
-			break;
-		}
-	default:
-		{
-			MF_LogError(amx, AMX_ERR_NATIVE, "Unknown TraceResult member %d", params[2]);
-			return 0;
 		}
 	}
 
+	MF_LogError(amx, AMX_ERR_NATIVE, "Unknown TraceResult member %d", params[2]);
+	
 	return 0;
 }
 
@@ -137,29 +125,24 @@ static cell AMX_NATIVE_CALL get_tr2(AMX *amx, cell *params)
 	case TR_AllSolid:
 		{
 			return tr->fAllSolid;
-			break;
 		}
 	case TR_InOpen:
 		{
 			return tr->fInOpen;
-			break;
 		}
 	case TR_StartSolid:
 		{
 			return tr->fStartSolid;
-			break;
 		}
 	case TR_InWater:
 		{
 			return tr->fInWater;
-			break;
 		}
 	case TR_flFraction:
 		{
 			ptr = MF_GetAmxAddr(amx, params[3]);
 			*ptr = amx_ftoc(tr->flFraction);
 			return 1;
-			break;
 		}
 	case TR_vecEndPos:
 		{
@@ -168,14 +151,12 @@ static cell AMX_NATIVE_CALL get_tr2(AMX *amx, cell *params)
 			ptr[1] = amx_ftoc(tr->vecEndPos.y);
 			ptr[2] = amx_ftoc(tr->vecEndPos.z);
 			return 1;
-			break;
 		}
 	case TR_flPlaneDist:
 		{
 			ptr = MF_GetAmxAddr(amx, params[3]);
 			*ptr = amx_ftoc(tr->flPlaneDist);
 			return 1;
-			break;
 		}
 	case TR_vecPlaneNormal:
 		{
@@ -184,27 +165,21 @@ static cell AMX_NATIVE_CALL get_tr2(AMX *amx, cell *params)
 			ptr[1] = amx_ftoc(tr->vecPlaneNormal.y);
 			ptr[2] = amx_ftoc(tr->vecPlaneNormal.z);
 			return 1;
-			break;
 		}
 	case TR_pHit:
 		{
 			if (FNullEnt(tr->pHit))
 				return -1;
 			return ENTINDEX(tr->pHit);
-			break;
 		}
 	case TR_iHitgroup:
 		{
 			return tr->iHitgroup;
-			break;
-		}
-	default:
-		{
-			MF_LogError(amx, AMX_ERR_NATIVE, "Unknown TraceResult member %d", params[2]);
-			return 0;
 		}
 	}
 
+	MF_LogError(amx, AMX_ERR_NATIVE, "Unknown TraceResult member %d", params[2]);
+	
 	return 0;
 }
 
@@ -221,7 +196,6 @@ static cell AMX_NATIVE_CALL get_kvd(AMX *amx, cell *params)
 	case KV_fHandled:
 		{
 			return kvd->fHandled;
-			break;
 		}
 	case KV_ClassName:
 		{
@@ -232,7 +206,6 @@ static cell AMX_NATIVE_CALL get_kvd(AMX *amx, cell *params)
 			}
 			cell *ptr = MF_GetAmxAddr(amx, params[4]);
 			return MF_SetAmxString(amx, params[3], kvd->szClassName, (int)*ptr);
-			break;
 		}
 	case KV_KeyName:
 		{
@@ -243,7 +216,6 @@ static cell AMX_NATIVE_CALL get_kvd(AMX *amx, cell *params)
 			}
 			cell *ptr = MF_GetAmxAddr(amx, params[4]);
 			return MF_SetAmxString(amx, params[3], kvd->szKeyName, (int)*ptr);
-			break;
 		}
 	case KV_Value:
 		{
@@ -254,12 +226,11 @@ static cell AMX_NATIVE_CALL get_kvd(AMX *amx, cell *params)
 			}
 			cell *ptr = MF_GetAmxAddr(amx, params[4]);
 			return MF_SetAmxString(amx, params[3], kvd->szValue, (int)*ptr);
-			break;
 		}
 	}
 
 	MF_LogError(amx, AMX_ERR_NATIVE, "Invalid KeyValueData member: %d", params[2]);
-
+	
 	return 0;
 }
 
@@ -301,28 +272,24 @@ static cell AMX_NATIVE_CALL set_kvd(AMX *amx, cell *params)
 		{
 			kvd->fHandled = (int)*ptr;
 			return 1;
-			break;
 		}
 	case KV_ClassName:
 		{
 			kvdw->cls = MF_GetAmxString(amx, params[3], 0, &len);
 			kvd->szClassName = const_cast<char *>(kvdw->cls.chars());
 			return 1;
-			break;
 		}
 	case KV_KeyName:
 		{
 			kvdw->key = MF_GetAmxString(amx, params[3], 0, &len);
 			kvd->szKeyName = const_cast<char *>(kvdw->key.chars());
 			return 1;
-			break;
 		}
 	case KV_Value:
 		{
 			kvdw->val = MF_GetAmxString(amx, params[3], 0, &len);
 			kvd->szValue = const_cast<char *>(kvdw->val.chars());
 			return 1;
-			break;
 		}
 	}
 

--- a/modules/fakemeta/forward.cpp
+++ b/modules/fakemeta/forward.cpp
@@ -80,8 +80,7 @@ static cell AMX_NATIVE_CALL fm_return(AMX *amx, cell *params)
 		}
 	default:
 		{
-		return 0;
-		break;
+			return 0;
 		}
 	}
 

--- a/modules/mysqlx/basic_sql.cpp
+++ b/modules/mysqlx/basic_sql.cpp
@@ -277,7 +277,6 @@ static cell AMX_NATIVE_CALL SQL_ReadResult(AMX *amx, cell *params)
 		{
 			int num = row->GetInt(col);
 			return num;
-			break;
 		}
 	default:
 		{

--- a/modules/mysqlx/oldcompat_sql.cpp
+++ b/modules/mysqlx/oldcompat_sql.cpp
@@ -247,7 +247,6 @@ static cell AMX_NATIVE_CALL dbi_field(AMX *amx, cell *params)
 	case 2:
 		{
 			return atoi(data);
-			break;
 		}
 	case 3:
 		{
@@ -255,12 +254,10 @@ static cell AMX_NATIVE_CALL dbi_field(AMX *amx, cell *params)
 			REAL fdata = atof(data);
 			*destaddr = amx_ftoc(fdata);
 			return 1;
-			break;
 		}
 	case 4:
 		{
 			return MF_SetAmxString(amx, params[3], data, params[4]);
-			break;
 		}
 	}
 
@@ -315,7 +312,6 @@ static cell AMX_NATIVE_CALL dbi_result(AMX *amx, cell *params)
 	case 2:
 		{
 			return atoi(data);
-			break;
 		}
 	case 3:
 		{
@@ -323,12 +319,10 @@ static cell AMX_NATIVE_CALL dbi_result(AMX *amx, cell *params)
 			REAL fdata = atof(data);
 			*destaddr = amx_ftoc(fdata);
 			return 1;
-			break;
 		}
 	case 4:
 		{
 			return MF_SetAmxString(amx, params[3], data, params[4]);
-			break;
 		}
 	}
 

--- a/modules/nvault/amxxapi.cpp
+++ b/modules/nvault/amxxapi.cpp
@@ -115,20 +115,17 @@ static cell nvault_get(AMX *amx, cell *params)
 	case 2:
 		{
 			return atoi(val);
-			break;
 		}
 	case 3:
 		{
 			cell *fAddr = MF_GetAmxAddr(amx, params[3]);
 			*fAddr = amx_ftoc((REAL)atof(val));
 			return 1;
-			break;
 		}
 	case 4:
 		{
 			len = *(MF_GetAmxAddr(amx, params[4]));
 			return MF_SetAmxString(amx, params[3], val, len);
-			break;
 		}
 	}
 

--- a/modules/regex/CRegEx.cpp
+++ b/modules/regex/CRegEx.cpp
@@ -654,7 +654,7 @@ int RegEx::Replace(char *text, size_t textMaxLen, const char *replace, size_t re
 							 * $nn or ${nn}
 							 *   ^       ^
 							 */
-							if (*walk && *walk >= '0' && *walk <= '9')
+							if (*walk >= '0' && *walk <= '9')
 							{
 								backref = backref * 10 + *walk - '0';
 								++walk;

--- a/modules/sqlite/basic_sql.cpp
+++ b/modules/sqlite/basic_sql.cpp
@@ -273,7 +273,6 @@ static cell AMX_NATIVE_CALL SQL_ReadResult(AMX *amx, cell *params)
 		{
 			int num = row->GetInt(col);
 			return num;
-			break;
 		}
 	default:
 		{

--- a/modules/sqlite/oldcompat_sql.cpp
+++ b/modules/sqlite/oldcompat_sql.cpp
@@ -245,7 +245,6 @@ static cell AMX_NATIVE_CALL dbi_field(AMX *amx, cell *params)
 	case 2:
 		{
 			return atoi(data);
-			break;
 		}
 	case 3:
 		{
@@ -253,12 +252,10 @@ static cell AMX_NATIVE_CALL dbi_field(AMX *amx, cell *params)
 			REAL fdata = atof(data);
 			*destaddr = amx_ftoc(fdata);
 			return 1;
-			break;
 		}
 	case 4:
 		{
 			return MF_SetAmxString(amx, params[3], data, params[4]);
-			break;
 		}
 	}
 
@@ -309,7 +306,6 @@ static cell AMX_NATIVE_CALL dbi_result(AMX *amx, cell *params)
 	case 2:
 		{
 			return atoi(data);
-			break;
 		}
 	case 3:
 		{
@@ -317,12 +313,10 @@ static cell AMX_NATIVE_CALL dbi_result(AMX *amx, cell *params)
 			REAL fdata = atof(data);
 			*destaddr = amx_ftoc(fdata);
 			return 1;
-			break;
 		}
 	case 4:
 		{
 			return MF_SetAmxString(amx, params[3], data, params[4]);
-			break;
 		}
 	}
 

--- a/modules/tfcx/CMisc.h
+++ b/modules/tfcx/CMisc.h
@@ -161,10 +161,10 @@ struct CPlayer {
 		int	clip;
 	};
 
-	PlayerWeapon	weapons[MAX_WEAPONS];
+	PlayerWeapon	weapons[TFCMAX_WEAPONS];
 	PlayerWeapon	attackers[33];
 	PlayerWeapon	victims[33];
-	Stats			weaponsRnd[MAX_WEAPONS]; // DEC-Weapon (Round) stats
+	Stats			weaponsRnd[TFCMAX_WEAPONS]; // DEC-Weapon (Round) stats
 	Stats			life;
 
 	int teamId;

--- a/modules/tfcx/usermsg.cpp
+++ b/modules/tfcx/usermsg.cpp
@@ -46,7 +46,7 @@ void Client_WeaponList(void* mValue){
     break;
   case 7:
     int iId = *(int*)mValue;
-    if ( (iId < 0 || iId >= MAX_WEAPONS ) || ( wpnList & (1<<iId) ) )
+    if ( (iId < 0 || iId >= TFCMAX_WEAPONS ) || ( wpnList & (1<<iId) ) )
       break;
 
     wpnList |= (1<<iId);
@@ -340,7 +340,7 @@ void Client_AmmoX(void* mValue){
 	}
 	//
 
-    for(int i = 1; i < MAX_WEAPONS ; ++i) 
+    for(int i = 1; i < TFCMAX_WEAPONS ; ++i) 
       if (iAmmo == weaponData[i].ammoSlot)
         mPlayer->weapons[i].ammo = *(int*)mValue;
   }
@@ -355,7 +355,7 @@ void Client_AmmoPickup(void* mValue){
     break;
   case 1:
 	if (!mPlayer ) break;
-    for(int i = 1; i < MAX_WEAPONS ; ++i)
+    for(int i = 1; i < TFCMAX_WEAPONS ; ++i)
       if (weaponData[i].ammoSlot == iSlot)
         mPlayer->weapons[i].ammo += *(int*)mValue;
   }


### PR DESCRIPTION
Fix many useless break\s in code. Fix buffer overflow in non cstrike mods (MAX_WEAPONS misprints) and small other fixes.