### PR TITLE
Fix OnConfigsExecuted issue. (restmenu.sma and adminhelp.sma is broken)

### DIFF
--- a/amxmodx/CoreConfig.cpp
+++ b/amxmodx/CoreConfig.cpp
@@ -316,14 +316,10 @@ void CoreConfig::CheckLegacyBufferedCommand(char *command)
 		return;
 	}
 
-	if (!m_LegacyMainConfigExecuted && strstr(command, MainConfigFile))
+	if (!m_LegacyMainConfigExecuted && (strstr(command, MainConfigFile) ||  strstr(command, MapConfigDir)))
 	{
 		m_LegacyMainConfigExecuted = true;
-	}
-
-	if (!m_LegacyMapConfigsExecuted && strstr(command, MapConfigDir))
-	{
-		m_LegacyMapConfigsExecuted = true;
+		m_PendingForwardPush = true;
 	}
 }
 


### PR DESCRIPTION
OnConfigsExecuted not executed and broke all plugins where used this forward. Even default like **restmenu.sma** and **adminhelp.sma**!