### PR TITLE
Fixed value check in json_object_set_value

### DIFF
--- a/modules/json/JsonNatives.cpp
+++ b/modules/json/JsonNatives.cpp
@@ -697,7 +697,7 @@ static cell AMX_NATIVE_CALL amxx_json_object_set_value(AMX *amx, cell *params)
 		return 0;
 	}
 
-	if (!JsonMngr->IsValidHandle(params[3], Handle_Object))
+	if (!JsonMngr->IsValidHandle(params[3]))
 	{
 		MF_LogError(amx, AMX_ERR_NATIVE, "Invalid JSON value! %d", params[3]);
 		return 0;


### PR DESCRIPTION
Same fix as #1015, but for 1.9 branch