### PR TITLE
nextmap.sma - Fix mp_chattime getting increased on quick map change

### DIFF
--- a/plugins/nextmap.sma
+++ b/plugins/nextmap.sma
@@ -22,6 +22,7 @@ new g_nextMap[32]
 new g_mapCycle[32]
 new g_pos
 new g_currentMap[32]
+new g_changeMapCalled;
 
 // pcvars
 new g_mp_friendlyfire, g_mp_chattime
@@ -94,10 +95,14 @@ public sayFFStatus()
 
 public delayedChange(param[])
 {
-	if (g_mp_chattime) {
+	engine_changelevel(param)
+}
+
+public plugin_end()
+{
+	if (g_mp_chattime && g_changeMapCalled) {
 		set_pcvar_float(g_mp_chattime, get_pcvar_float(g_mp_chattime) - 2.0)
 	}
-	engine_changelevel(param)
 }
 
 public changeMap()
@@ -107,6 +112,7 @@ public changeMap()
 	
 	if (g_mp_chattime) {
 		set_pcvar_float(g_mp_chattime, chattime + 2.0)		// make sure mp_chattime is long
+		g_changeMapCalled = true;
 	}
 	new len = getNextMapName(string, charsmax(string)) + 1
 	set_task(chattime, "delayedChange", 0, string, len)	// change with 1.5 sec. delay


### PR DESCRIPTION
Related issue: #855 

# Introduction

This should fix an ancient bug where the server takes too long to change the map after it's has finished (scoreboard screen is displayed).

The scoreboard screen will stay for too long, becoming annoying to the players to the point of even leaving the server.

# When this happens

Basically this happens when you change the map in the middle of the intermission screen. The cvar `mp_chattime` which controls how long the intermission screen stays, gets increased by 2 seconds. If you do this several times, the intermission screen time would start to get bigger, to the point of becoming noticeable to the players.

This most likely happens when the player doesn't like the next map and decides in the middle of the intermission screen to change it to a one he likes.

# Steps to reproduce it

1. Load some map.
2. Check out the value of `mp_chattime` first. Default value should be 10 seconds.
3. Wait the map to finish. You can speed up the process by setting `mp_timelimit` to `0.1` which means the map will finish in 10 seconds.
4. The scoreboard screen is being displayed. Change to another map with `amx_map` before the server changes it.
5. Check again `mp_chattime` value. This time you'll see that it has been increased by 2 seconds.
 
# How I fix it

The next-map plugin needs to override the next-map system from Half-Life to work. To achieve this, it will look first how long the intermission screen stays by reading the value of `mp_chattime`. After that, it will add two extra seconds to the `mp_chattime` to have enough time to change the map before the original next-map system does it.

Basically a task is being called when the intermission screen is on to return to the original value of `mp_chattime`. But the code doesn't take into account a player changing the map in the middle of the intermission screen. The `mp_chattime` original value never gets restored.

Instead of relying in that someone will not change the map before the task executes, this fix will restore the original value in `plugin_end()`, making it safe from the player's actions. This forward is called just before the map ends. I have tested this fix for a long time and I didn't find any issues so far.

# The End

Well, with everything said, I hope to see this get merged. Let me know if you need me to make a further explanation on something. Thanks for reading.