### PR TITLE
Update CMisc.h to stop real players showing as 127.0.0.1(That IP has full admin on listenserver.cfg) AND appveyor so the MacOS build goes through.

### DIFF
--- a/amxmodx/CMisc.h
+++ b/amxmodx/CMisc.h
@@ -83,18 +83,8 @@ public:
 
 	inline bool IsBot()
 	{
-		if ((pEdict->v.flags & FL_FAKECLIENT) == FL_FAKECLIENT)
-		{
-			return true;
-		}
-		
-		const char *auth = GETPLAYERAUTHID(pEdict); 	 
-		if (auth && (strcmp(auth, "BOT") == 0)) 	 
-		{
-			return true;
-		}
-		
-		return false;
+		const char *auth = GETPLAYERAUTHID(pEdict);
+		return auth && !strcmp(auth, "BOT");
 	}
 
 	inline bool IsAlive()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -101,7 +101,7 @@ for:
 
         brew install ca-certificates
 
-        nasm install nasm
+        brew install nasm
 
         nasm -v
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -99,7 +99,7 @@ for:
 
         ../support/checkout-deps.sh
 
-        brew install nasm
+        brew install ca-certificates nasm
 
         nasm -v
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -99,7 +99,9 @@ for:
 
         ../support/checkout-deps.sh
 
-        brew install ca-certificates nasm
+        brew install ca-certificates
+
+        nasm install nasm
 
         nasm -v
 


### PR DESCRIPTION
Resolve real players being mistaken for bots.