### PR TITLE
Fix CFrameActionMngr (RequestFrame) not being cleared

### DIFF
--- a/amxmodx/CFrameAction.h
+++ b/amxmodx/CFrameAction.h
@@ -53,6 +53,15 @@ public:
 		}
 	}
 
+	void clear()
+	{
+		int count = m_requestedFrames.length();
+		while (count--)
+		{
+			m_requestedFrames.popFront();
+		}
+	}
+
 private:
 	ke::Deque<ke::AutoPtr<CFrameAction>> m_requestedFrames;
 

--- a/amxmodx/meta_api.cpp
+++ b/amxmodx/meta_api.cpp
@@ -393,6 +393,7 @@ int	C_Spawn(edict_t *pent)
 
 	}
 
+	g_frameActionMngr.clear();
 	g_forwards.clear();
 
 	g_log.MapChange();
@@ -771,6 +772,7 @@ void C_ServerDeactivate_Post()
 	g_forcegeneric.clear();
 	g_grenades.clear();
 	g_tasksMngr.clear();
+	g_frameActionMngr.clear();
 	g_forwards.clear();
 	g_logevents.clearLogEvents();
 	g_events.clearEvents();
@@ -1731,6 +1733,7 @@ C_DLLEXPORT	int	Meta_Detach(PLUG_LOADTIME now, PL_UNLOAD_REASON	reason)
 	modules_callPluginsUnloading();
 
 	g_auth.clear();
+	g_frameActionMngr.clear();
 	g_forwards.clear();
 	g_commands.clear();
 	g_forcemodels.clear();


### PR DESCRIPTION
The fix looks like a workaround because there is no clear method in [amtl/am-deque.h](https://github.com/alliedmodders/amtl/blob/ad9d5c33534dcfd902e2aeb0744df1a227b1c6d3/amtl/am-deque.h) and i don't know if i can or how to call it directly

if i were better at C stuff i could make a pr to add a clear method on am-deque first

Fixes #1039, also don't forget to apply it to 1.9-dev too
