### PR TITLE
amxmodx: do not try to parse a signature starting with @ as hex

### DIFF
--- a/amxmodx/CGameConfigs.cpp
+++ b/amxmodx/CGameConfigs.cpp
@@ -584,8 +584,7 @@ SMCResult CGameConfig::ReadSMC_LeavingSection(const SMCStates *states)
 					}
 #endif
 				}
-
-				if (!finalAddress)
+				else
 				{
 					finalAddress = g_MemUtils.DecodeAndFindPattern(addressInBase, TempSig.signature);
 				}


### PR DESCRIPTION
Imagine a situation where `MemoryUtils::ResolveSymbol` for some reason fails.

Then the signature gets parsed as a HEX value. The way the `MemoryUtils::DecodeHexString` (called by `MemoryUtils::DecodeAndFindPattern`) works is that it takes any symbols, checks if it's backslash and tries to parse it, otherwise it just silently puts into the buffer.

The problem of this is that the `MemoryUtils::FindPattern` will look for any pattern match, despite it's not a pattern but a symbol name in an ASCII. This might lead to unwanted consequences, and to me, it's better fail here than crash.