### PR TITLE
Fix sockets module socket_open when the connect fails, -1 is not set after closing sockfd

### DIFF
--- a/modules/sockets/sockets.cpp
+++ b/modules/sockets/sockets.cpp
@@ -142,7 +142,10 @@ static cell AMX_NATIVE_CALL socket_open(AMX *amx, cell *params)
 					if(nonblocking_socket && (errno == EINPROGRESS || errno == EWOULDBLOCK))
 						connect_inprogress = true;
 					else
+					{
 						close(sockfd);
+						sockfd = -1;
+					}
 				}
 				else
 				{


### PR DESCRIPTION
Fix sockets module socket_open when the connect fails, -1 is not set after closing sockfd