### PR TITLE
Add `ignorewarn` pragma to pawn compiler

### DIFF
--- a/compiler/libpc300/sc2.c
+++ b/compiler/libpc300/sc2.c
@@ -1158,6 +1158,12 @@ static int command(void)
           preproc_expr(&val,NULL);
           if (val>0)
             sc_tabsize=(int)val;
+
+        } else if (strcmp(str, "ignorewarn") == 0) {
+          cell val;
+          preproc_expr(&val, NULL);
+          pc_enablewarning(val, 0);
+
         } else if (strcmp(str,"align")==0) {
           sc_alignnext=TRUE;
         } else if (strcmp(str,"unused")==0) {


### PR DESCRIPTION
Usage:
```pawn
#pragma ignorewarn 217
// Will ignore all 217 (loose indentation) warnings
```