### PR TITLE
(CRITICAL) Restore trace_flags value inside Fun's TraceLine hook

### DIFF
--- a/modules/fun/fun.cpp
+++ b/modules/fun/fun.cpp
@@ -484,7 +484,9 @@ int ClientConnect(edict_t *pPlayer, const char *pszName, const char *pszAddress,
 
 void TraceLine(const float *v1, const float *v2, int fNoMonsters, edict_t *shooter, TraceResult *ptr)
 {
+	const auto traceflags = gpGlobals->trace_flags;
 	TRACE_LINE(v1, v2, fNoMonsters, shooter, ptr);
+	gpGlobals->trace_flags = traceflags;
 
 	if (ptr->pHit && (ptr->pHit->v.flags & (FL_CLIENT | FL_FAKECLIENT))
 	    && shooter &&  (shooter->v.flags & (FL_CLIENT | FL_FAKECLIENT)) )


### PR DESCRIPTION
The engine resets the `trace_flags `value at the end of `PF_traceline_DLL`. This causes any assigned trace_flags to be overwritten when an additional TraceLine call is made inside the `pfnTraceLine `hook. If the Fun module is loaded before Fakemeta, plugins cannot catch the `gpGlobals->trace_flags` value, which now has an important use with ReGameDLL_CS. This behavior directly exposes an old, previously undiscovered bug.

NOTE: The Fun module’s TraceLine misbehavior has been documented for a long time in #554 . It is recommended to skip this module due to its double-call behavior.