### PR TITLE
Add missing is_user_authorized() native to 1.9

### DIFF
--- a/plugins/include/amxmodx.inc
+++ b/plugins/include/amxmodx.inc
@@ -924,6 +924,19 @@ native is_user_bot(index);
 native is_user_hltv(index);
 
 /**
+ * Returns if the client is authorized.
+ *
+ * @note This does not throw an error if the provided index is out of the
+ *       1 to MaxClients range. That means you can safely use this native
+ *       without manually verifying that the index is a valid client index.
+ *
+ * @param index     Client index
+ *
+ * @return          1 if client is authorized, 0 otherwise
+ */
+native is_user_authorized(index);
+
+/**
  * Returns if the client is connected.
  *
  * @note This does not throw an error if the provided index is out of the


### PR DESCRIPTION
The same as #840, which was only pushed to the master branch. Function also exists in 1.9.