### PR TITLE
Fix signatures and globalvars for both legacy and hl25 server branches

### DIFF
--- a/gamedata/common.games/functions.engine.txt
+++ b/gamedata/common.games/functions.engine.txt
@@ -11,23 +11,49 @@
 
 "Games"
 {
-	"#default"
+	"#default" // Build 10210
 	{
 		"Signatures"
 		{
 			"SV_DropClient" // void SV_DropClient(client_t *cl, qboolean crash, const char *fmt, ...);
 			{
 				"library"   "engine"
-				"windows"   "\x55\x8B\x2A\x81\x2A\x2A\x2A\x2A\x2A\x8B\x2A\x2A\x53\x56\x8D"
+				"windows"   "\x55\x8B\xEC\x81\xEC\x2A\x2A\x2A\x2A\xA1\x2A\x2A\x2A\x2A\x33\xC5\x89\x45\x2A\x56\x57\x8B\x7D\x2A\x8D\x45\x2A\x50\x33\xF6"
 				"linux"     "@SV_DropClient"
 				"mac"       "@SV_DropClient"
 			}
 			"Cvar_DirectSet" // void Cvar_DirectSet(struct cvar_s *var, char *value);
 			{
 				"library"   "engine"
-				"windows"   "\x55\x8B\x2A\x81\x2A\x2A\x2A\x2A\x2A\x56\x8B\x2A\x2A\x57\x8B\x2A\x2A\x85"
+				"windows"   "\x55\x8B\xEC\x81\xEC\x2A\x2A\x2A\x2A\xA1\x2A\x2A\x2A\x2A\x33\xC5\x89\x45\x2A\x56\x8B\x75\x2A\x57\x8B\x7D\x2A\x85\xFF"
 				"linux"     "@Cvar_DirectSet"
 				"mac"       "@Cvar_DirectSet"
+			}
+		}
+	}
+
+	"*" // Build 8684 - Windows
+	{
+		"CRC"
+		{
+			"engine"
+			{
+				"windows" "F7DCFFD9" // hw.dll
+				"windows" "2C9EDE6B" // swds.dll
+			}
+		}
+
+		"Signatures"
+		{
+			"SV_DropClient"
+			{
+				"library"   "engine"
+				"windows"   "\x55\x8B\x2A\x81\x2A\x2A\x2A\x2A\x2A\x8B\x2A\x2A\x53\x56\x8D"
+			}
+			"Cvar_DirectSet"
+			{
+				"library"   "engine"
+				"windows"   "\x55\x8B\x2A\x81\x2A\x2A\x2A\x2A\x2A\x56\x8B\x2A\x2A\x57\x8B\x2A\x2A\x85"
 			}
 		}
 	}

--- a/gamedata/common.games/globalvars.engine.txt
+++ b/gamedata/common.games/globalvars.engine.txt
@@ -11,33 +11,33 @@
 
 "Games"
 {
-	"#default"
+	"#default" // Build 10210
 	{
 		"Offsets"
 		{
 			"svs"    // Used with pfnGetCurrentPlayer base address
 			{
-				"windows"   "8"
+				"windows"   "13"
 			}
 		}
 
 		"Addresses"
 		{
-			"realtime"
-			{
-				"windows"
-				{
-					"signature"  "realtime"
-					"read"       "2"
-				}
-			}
-
 			"sv"
 			{
 				"windows"
 				{
 					"signature"  "sv"
-					"read"       "2"
+					"read"       "8"
+				}
+			}
+
+			"realtime"
+			{
+				"windows"
+				{
+					"signature"  "realtime"
+					"read"       "4"
 				}
 			}
 
@@ -47,7 +47,7 @@
 				
 				"windows"
 				{
-					"read"       "2"
+					"read"       "12"
 				}
 				
 				"read"  "0"
@@ -66,7 +66,7 @@
 			"sv"    // server_t sv
 			{
 				"library"   "engine"
-				"windows"   "\x8B\x2A\x2A\x2A\x2A\x2A\x8D\x2A\x2A\x2A\x2A\x2A\x53\x33\x2A\x89"  // SVC_PlayerInfo()
+				"windows"   "\x55\x8B\xEC\x83\xEC\x2A\x83\x3D\x2A\x2A\x2A\x2A\x2A\x53\x56\x57\x0F\x84\x2A\x2A\x2A\x2A\xE8" // Host_ShutdownServer() uses "Server shutting down"
 				"linux"     "@sv"
 				"mac"       "@sv"
 			}
@@ -74,7 +74,7 @@
 			"realtime"    // double realtime
 			{
 				"library"   "engine"
-				"windows"   "\xDC\x2A\x2A\x2A\x2A\x2A\xA1\x2A\x2A\x2A\x2A\x56" // SV_CheckTimeouts()
+				"windows"   "\xF2\x0F\x10\x0D\x2A\x2A\x2A\x2A\xA1" // SV_Frame() before "%s timed out\n"
 				"linux"     "@realtime"
 				"mac"       "@realtime"
 			}
@@ -82,9 +82,85 @@
 			"g_pGameRules" // CGameRules *g_pGameRules
 			{
 				"library"   "server"
-				"windows"   "\x8B\x2A\x2A\x2A\x2A\x2A\x85\x2A\x74\x2A\x8B\x2A\xFF\x2A\x2A\xA1" // StartFrame()
+				"windows"   "\x68\x2A\x2A\x2A\x2A\xFF\x15\x2A\x2A\x2A\x2A\xA1\x2A\x2A\x2A\x2A\x83\xC4\x2A\x85\xC0" // CWorld::Precache() on "room_type"
 				"linux"     "@g_pGameRules"
 				"mac"       "@g_pGameRules"
+			}
+		}
+	}
+
+	"*" // Build 8684 - Windows
+	{
+		"CRC"
+		{
+			"engine"
+			{
+				"windows" "F7DCFFD9" // hw.dll
+				"windows" "2C9EDE6B" // swds.dll
+			}
+		}
+
+		"Offsets"
+		{
+			"svs"    // Used with pfnGetCurrentPlayer base address
+			{
+				"windows"   "8"
+			}
+		}
+
+		"Addresses"
+		{
+			"sv"
+			{
+				"windows"
+				{
+					"signature"  "sv"
+					"read"       "2"
+				}
+			}
+
+			"realtime"
+			{
+				"windows"
+				{
+					"signature"  "realtime"
+					"read"       "2"
+				}
+			}
+
+			"g_pGameRules"
+			{
+				"windows"
+				{
+					"signature"  "g_pGameRules"
+					"read"       "2"
+				}
+			}
+		}
+
+		"Signatures"
+		{
+			"svs"    // server_static_t svs
+			{
+				"library"   "engine"
+			}
+
+			"sv"    // server_t sv
+			{
+				"library"   "engine"
+				"windows"   "\x8B\x2A\x2A\x2A\x2A\x2A\x8D\x2A\x2A\x2A\x2A\x2A\x53\x33\x2A\x89"  // SVC_PlayerInfo()
+			}
+
+			"realtime"    // double realtime
+			{
+				"library"   "engine"
+				"windows"   "\xDC\x2A\x2A\x2A\x2A\x2A\xA1\x2A\x2A\x2A\x2A\x56" // SV_CheckTimeouts()
+			}
+
+			"g_pGameRules" // CGameRules *g_pGameRules
+			{
+				"library"   "server"
+				"windows"   "\x8B\x2A\x2A\x2A\x2A\x2A\x85\x2A\x74\x2A\x8B\x2A\xFF\x2A\x2A\xA1" // StartFrame()
 			}
 		}
 	}

--- a/gamedata/common.games/virtual.games/valve/offsets-common.txt
+++ b/gamedata/common.games/virtual.games/valve/offsets-common.txt
@@ -11,8 +11,1096 @@
 
 "Games"
 {
-    "#default"
+    "#default" // Build 10210
     {
+        "Offsets"
+        {
+            "pev"
+            {
+                "windows"  "4"
+                "linux"    "4"
+                "mac"      "4"
+            }
+
+            "base"
+            {
+                "windows"  "0x0"
+                "linux"    "0x0"
+                "mac"      "0x0"
+            }
+
+            "spawn"
+            {
+                "windows"  "0"
+                "linux"    "0"
+                "mac"      "0"
+            }
+
+            "precache"
+            {
+                "windows"  "1"
+                "linux"    "1"
+                "mac"      "1"
+            }
+
+            "keyvalue"
+            {
+                "windows"  "2"
+                "linux"    "2"
+                "mac"      "2"
+            }
+
+            "objectcaps"
+            {
+                "windows"  "5"
+                "linux"    "5"
+                "mac"      "5"
+            }
+
+            "activate"
+            {
+                "windows"  "6"
+                "linux"    "6"
+                "mac"      "6"
+            }
+
+            "setobjectcollisionbox"
+            {
+                "windows"  "7"
+                "linux"    "7"
+                "mac"      "7"
+            }
+
+            "classify"
+            {
+                "windows"  "8"
+                "linux"    "8"
+                "mac"      "8"
+            }
+
+            "deathnotice"
+            {
+                "windows"  "9"
+                "linux"    "9"
+                "mac"      "9"
+            }
+
+            "traceattack"
+            {
+                "windows"  "10"
+                "linux"    "10"
+                "mac"      "10"
+            }
+
+            "takedamage"
+            {
+                "windows"  "11"
+                "linux"    "11"
+                "mac"      "11"
+            }
+
+            "takehealth"
+            {
+                "windows"  "12"
+                "linux"    "12"
+                "mac"      "12"
+            }
+
+            "killed"
+            {
+                "windows"  "13"
+                "linux"    "13"
+                "mac"      "13"
+            }
+
+            "bloodcolor"
+            {
+                "windows"  "14"
+                "linux"    "14"
+                "mac"      "14"
+            }
+
+            "tracebleed"
+            {
+                "windows"  "15"
+                "linux"    "15"
+                "mac"      "15"
+            }
+
+            "istriggered"
+            {
+                "windows"  "16"
+                "linux"    "16"
+                "mac"      "16"
+            }
+
+            "mymonsterpointer"
+            {
+                "windows"  "18"
+                "linux"    "18"
+                "mac"      "18"
+            }
+
+            "mysquadmonsterpointer"
+            {
+                "windows"  "19"
+                "linux"    "19"
+                "mac"      "19"
+            }
+
+            "gettogglestate"
+            {
+                "windows"  "20"
+                "linux"    "20"
+                "mac"      "20"
+            }
+
+            "addpoints"
+            {
+                "windows"  "21"
+                "linux"    "21"
+                "mac"      "21"
+            }
+
+            "addpointstoteam"
+            {
+                "windows"  "22"
+                "linux"    "22"
+                "mac"      "22"
+            }
+
+            "addplayeritem"
+            {
+                "windows"  "23"
+                "linux"    "23"
+                "mac"      "23"
+            }
+
+            "removeplayeritem"
+            {
+                "windows"  "24"
+                "linux"    "24"
+                "mac"      "24"
+            }
+
+            "giveammo"
+            {
+                "windows"  "25"
+                "linux"    "25"
+                "mac"      "25"
+            }
+
+            "getdelay"
+            {
+                "windows"  "26"
+                "linux"    "26"
+                "mac"      "26"
+            }
+
+            "ismoving"
+            {
+                "windows"  "27"
+                "linux"    "27"
+                "mac"      "27"
+            }
+
+            "overridereset"
+            {
+                "windows"  "28"
+                "linux"    "28"
+                "mac"      "28"
+            }
+
+            "damagedecal"
+            {
+                "windows"  "29"
+                "linux"    "29"
+                "mac"      "29"
+            }
+
+            "settogglestate"
+            {
+                "windows"  "30"
+                "linux"    "30"
+                "mac"      "30"
+            }
+
+            "startsneaking"
+            {
+                "windows"  "31"
+                "linux"    "31"
+                "mac"      "31"
+            }
+
+            "stopsneaking"
+            {
+                "windows"  "32"
+                "linux"    "32"
+                "mac"      "32"
+            }
+
+            "oncontrols"
+            {
+                "windows"  "33"
+                "linux"    "33"
+                "mac"      "33"
+            }
+
+            "issneaking"
+            {
+                "windows"  "34"
+                "linux"    "34"
+                "mac"      "34"
+            }
+
+            "isalive"
+            {
+                "windows"  "35"
+                "linux"    "35"
+                "mac"      "35"
+            }
+
+            "isbspmodel"
+            {
+                "windows"  "36"
+                "linux"    "36"
+                "mac"      "36"
+            }
+
+            "reflectgauss"
+            {
+                "windows"  "37"
+                "linux"    "37"
+                "mac"      "37"
+            }
+
+            "hastarget"
+            {
+                "windows"  "38"
+                "linux"    "38"
+                "mac"      "38"
+            }
+
+            "isinworld"
+            {
+                "windows"  "39"
+                "linux"    "39"
+                "mac"      "39"
+            }
+
+            "isplayer"
+            {
+                "windows"  "40"
+                "linux"    "40"
+                "mac"      "40"
+            }
+
+            "isnetclient"
+            {
+                "windows"  "41"
+                "linux"    "41"
+                "mac"      "41"
+            }
+
+            "teamid"
+            {
+                "windows"  "42"
+                "linux"    "42"
+                "mac"      "42"
+            }
+
+            "getnexttarget"
+            {
+                "windows"  "43"
+                "linux"    "43"
+                "mac"      "43"
+            }
+
+            "think"
+            {
+                "windows"  "44"
+                "linux"    "44"
+                "mac"      "44"
+            }
+
+            "touch"
+            {
+                "windows"  "45"
+                "linux"    "45"
+                "mac"      "45"
+            }
+
+            "use"
+            {
+                "windows"  "46"
+                "linux"    "46"
+                "mac"      "46"
+            }
+
+            "blocked"
+            {
+                "windows"  "47"
+                "linux"    "47"
+                "mac"      "47"
+            }
+
+            "respawn"
+            {
+                "windows"  "48"
+                "linux"    "48"
+                "mac"      "48"
+            }
+
+            "updateowner"
+            {
+                "windows"  "49"
+                "linux"    "49"
+                "mac"      "49"
+            }
+
+            "fbecomeprone"
+            {
+                "windows"  "50"
+                "linux"    "50"
+                "mac"      "50"
+            }
+
+            "center"
+            {
+                "windows"  "51"
+                "linux"    "51"
+                "mac"      "51"
+            }
+
+            "eyeposition"
+            {
+                "windows"  "52"
+                "linux"    "52"
+                "mac"      "52"
+            }
+
+            "earposition"
+            {
+                "windows"  "53"
+                "linux"    "53"
+                "mac"      "53"
+            }
+
+            "bodytarget"
+            {
+                "windows"  "54"
+                "linux"    "54"
+                "mac"      "54"
+            }
+
+            "illumination"
+            {
+                "windows"  "55"
+                "linux"    "55"
+                "mac"      "55"
+            }
+
+            "fvisible"
+            {
+                "windows"  "57"
+                "linux"    "56"
+                "mac"      "56"
+            }
+
+            "fvecvisible"
+            {
+                "windows"  "56"
+                "linux"    "57"
+                "mac"      "57"
+            }
+
+            "playsentence"
+            {
+                "windows"  "59"
+                "linux"    "59"
+                "mac"      "59"
+            }
+
+            "item_addtoplayer"
+            {
+                "windows"  "59"
+                "linux"    "59"
+                "mac"      "59"
+            }
+
+            "playscriptedsentence"
+            {
+                "windows"  "60"
+                "linux"    "60"
+                "mac"      "60"
+            }
+
+            "item_addduplicate"
+            {
+                "windows"  "60"
+                "linux"    "60"
+                "mac"      "60"
+            }
+
+            "sentencestop"
+            {
+                "windows"  "61"
+                "linux"    "61"
+                "mac"      "61"
+            }
+
+            "item_getiteminfo"
+            {
+                "windows"  "61"
+                "linux"    "61"
+                "mac"      "61"
+            }
+
+            "item_candeploy"
+            {
+                "windows"  "62"
+                "linux"    "62"
+                "mac"      "62"
+            }
+
+            "look"
+            {
+                "windows"  "63"
+                "linux"    "63"
+                "mac"      "63"
+            }
+
+            "item_deploy"
+            {
+                "windows"  "63"
+                "linux"    "63"
+                "mac"      "63"
+            }
+
+            "runai"
+            {
+                "windows"  "64"
+                "linux"    "64"
+                "mac"      "64"
+            }
+
+            "item_canholster"
+            {
+                "windows"  "64"
+                "linux"    "64"
+                "mac"      "64"
+            }
+
+            "player_shouldfadeondeath"
+            {
+                "windows"  "65"
+                "linux"    "65"
+                "mac"      "65"
+            }
+
+            "item_holster"
+            {
+                "windows"  "65"
+                "linux"    "65"
+                "mac"      "65"
+            }
+
+            "changeyaw"
+            {
+                "windows"  "66"
+                "linux"    "66"
+                "mac"      "66"
+            }
+
+            "item_updateiteminfo"
+            {
+                "windows"  "66"
+                "linux"    "66"
+                "mac"      "66"
+            }
+
+            "monsterthink"
+            {
+                "windows"  "67"
+                "linux"    "67"
+                "mac"      "67"
+            }
+
+            "item_preframe"
+            {
+                "windows"  "67"
+                "linux"    "67"
+                "mac"      "67"
+            }
+
+            "irelationship"
+            {
+                "windows"  "68"
+                "linux"    "68"
+                "mac"      "68"
+            }
+
+            "item_postframe"
+            {
+                "windows"  "68"
+                "linux"    "68"
+                "mac"      "68"
+            }
+
+            "monsterinit"
+            {
+                "windows"  "69"
+                "linux"    "69"
+                "mac"      "69"
+            }
+
+            "item_drop"
+            {
+                "windows"  "69"
+                "linux"    "69"
+                "mac"      "69"
+            }
+
+            "monsterinitdead"
+            {
+                "windows"  "70"
+                "linux"    "70"
+                "mac"      "70"
+            }
+
+            "item_kill"
+            {
+                "windows"  "70"
+                "linux"    "70"
+                "mac"      "70"
+            }
+
+            "becomedead"
+            {
+                "windows"  "71"
+                "linux"    "71"
+                "mac"      "71"
+            }
+
+            "item_attachtoplayer"
+            {
+                "windows"  "71"
+                "linux"    "71"
+                "mac"      "71"
+            }
+
+            "item_primaryammoindex"
+            {
+                "windows"  "72"
+                "linux"    "72"
+                "mac"      "72"
+            }
+
+            "bestvisibleenemy"
+            {
+                "windows"  "73"
+                "linux"    "73"
+                "mac"      "73"
+            }
+
+            "item_secondaryammoindex"
+            {
+                "windows"  "73"
+                "linux"    "73"
+                "mac"      "73"
+            }
+
+            "finviewcone"
+            {
+                "windows"  "75"
+                "linux"    "74"
+                "mac"      "74"
+            }
+
+            "item_updateclientdata"
+            {
+                "windows"  "74"
+                "linux"    "74"
+                "mac"      "74"
+            }
+
+            "fvecinviewcone"
+            {
+                "windows"  "74"
+                "linux"    "75"
+                "mac"      "75"
+            }
+
+            "item_getweaponptr"
+            {
+                "windows"  "75"
+                "linux"    "75"
+                "mac"      "75"
+            }
+
+            "checklocalmove"
+            {
+                "windows"  "76"
+                "linux"    "76"
+                "mac"      "76"
+            }
+
+            "item_itemslot"
+            {
+                "windows"  "76"
+                "linux"    "76"
+                "mac"      "76"
+            }
+
+            "move"
+            {
+                "windows"  "77"
+                "linux"    "77"
+                "mac"      "77"
+            }
+
+            "weapon_extractammo"
+            {
+                "windows"  "77"
+                "linux"    "77"
+                "mac"      "77"
+            }
+
+            "moveexecute"
+            {
+                "windows"  "78"
+                "linux"    "78"
+                "mac"      "78"
+            }
+
+            "weapon_extractclipammo"
+            {
+                "windows"  "78"
+                "linux"    "78"
+                "mac"      "78"
+            }
+
+            "shouldadvanceroute"
+            {
+                "windows"  "79"
+                "linux"    "79"
+                "mac"      "79"
+            }
+
+            "weapon_addweapon"
+            {
+                "windows"  "79"
+                "linux"    "79"
+                "mac"      "79"
+            }
+
+            "getstoppedactivity"
+            {
+                "windows"  "80"
+                "linux"    "80"
+                "mac"      "80"
+            }
+
+            "weapon_playemptysound"
+            {
+                "windows"  "80"
+                "linux"    "80"
+                "mac"      "80"
+            }
+
+            "stop"
+            {
+                "windows"  "81"
+                "linux"    "81"
+                "mac"      "81"
+            }
+
+            "weapon_resetemptysound"
+            {
+                "windows"  "81"
+                "linux"    "81"
+                "mac"      "81"
+            }
+
+            "checkrangeattack1"
+            {
+                "windows"  "82"
+                "linux"    "82"
+                "mac"      "82"
+            }
+
+            "weapon_sendweaponanim"
+            {
+                "windows"  "82"
+                "linux"    "82"
+                "mac"      "82"
+            }
+
+            "checkrangeattack2"
+            {
+                "windows"  "83"
+                "linux"    "83"
+                "mac"      "83"
+            }
+
+            "weapon_isusable"
+            {
+                "windows"  "83"
+                "linux"    "83"
+                "mac"      "83"
+            }
+
+            "checkmeleeattack1"
+            {
+                "windows"  "84"
+                "linux"    "84"
+                "mac"      "84"
+            }
+
+            "weapon_primaryattack"
+            {
+                "windows"  "84"
+                "linux"    "84"
+                "mac"      "84"
+            }
+
+            "checkmeleeattack2"
+            {
+                "windows"  "85"
+                "linux"    "85"
+                "mac"      "85"
+            }
+
+            "weapon_secondaryattack"
+            {
+                "windows"  "85"
+                "linux"    "85"
+                "mac"      "85"
+            }
+
+            "weapon_reload"
+            {
+                "windows"  "86"
+                "linux"    "86"
+                "mac"      "86"
+            }
+
+            "weapon_weaponidle"
+            {
+                "windows"  "87"
+                "linux"    "87"
+                "mac"      "87"
+            }
+
+            "weapon_retireweapon"
+            {
+                "windows"  "88"
+                "linux"    "88"
+                "mac"      "88"
+            }
+
+            "weapon_shouldweaponidle"
+            {
+                "windows"  "89"
+                "linux"    "89"
+                "mac"      "89"
+            }
+
+            "weapon_usedecrement"
+            {
+                "windows"  "90"
+                "linux"    "90"
+                "mac"      "90"
+            }
+
+            "schedulechange"
+            {
+                "windows"  "91"
+                "linux"    "91"
+                "mac"      "91"
+            }
+
+            "canplaysequence"
+            {
+                "windows"  "92"
+                "linux"    "92"
+                "mac"      "92"
+            }
+
+            "canplaysentence2"
+            {
+                "windows"  "93"
+                "linux"    "93"
+                "mac"      "93"
+            }
+
+            "getidealstate"
+            {
+                "windows"  "94"
+                "linux"    "94"
+                "mac"      "94"
+            }
+
+            "setactivity"
+            {
+                "windows"  "95"
+                "linux"    "95"
+                "mac"      "95"
+            }
+
+            "reportaistate"
+            {
+                "windows"  "96"
+                "linux"    "96"
+                "mac"      "96"
+            }
+
+            "checkenemy"
+            {
+                "windows"  "97"
+                "linux"    "97"
+                "mac"      "97"
+            }
+
+            "ftriangulate"
+            {
+                "windows"  "98"
+                "linux"    "98"
+                "mac"      "98"
+            }
+
+            "setyawspeed"
+            {
+                "windows"  "99"
+                "linux"    "99"
+                "mac"      "99"
+            }
+
+            "buildnearestroute"
+            {
+                "windows"  "100"
+                "linux"    "100"
+                "mac"      "100"
+            }
+
+            "findcover"
+            {
+                "windows"  "101"
+                "linux"    "101"
+                "mac"      "101"
+            }
+
+            "coverradius"
+            {
+                "windows"  "103"
+                "linux"    "103"
+                "mac"      "103"
+            }
+
+            "fcancheckattacks"
+            {
+                "windows"  "104"
+                "linux"    "104"
+                "mac"      "104"
+            }
+
+            "checkammo"
+            {
+                "windows"  "105"
+                "linux"    "105"
+                "mac"      "105"
+            }
+
+            "ignoreconditions"
+            {
+                "windows"  "106"
+                "linux"    "106"
+                "mac"      "106"
+            }
+
+            "fvalidatehinttype"
+            {
+                "windows"  "107"
+                "linux"    "107"
+                "mac"      "107"
+            }
+
+            "fcanactiveidle"
+            {
+                "windows"  "108"
+                "linux"    "108"
+                "mac"      "108"
+            }
+
+            "isoundmask"
+            {
+                "windows"  "109"
+                "linux"    "109"
+                "mac"      "109"
+            }
+
+            "hearingsensitivity"
+            {
+                "windows"  "112"
+                "linux"    "112"
+                "mac"      "112"
+            }
+
+            "barnaclevictimbitten"
+            {
+                "windows"  "113"
+                "linux"    "113"
+                "mac"      "113"
+            }
+
+            "barnaclevictimreleased"
+            {
+                "windows"  "114"
+                "linux"    "114"
+                "mac"      "114"
+            }
+
+            "preschedulethink"
+            {
+                "windows"  "115"
+                "linux"    "115"
+                "mac"      "115"
+            }
+
+            "getdeathactivity"
+            {
+                "windows"  "116"
+                "linux"    "116"
+                "mac"      "116"
+            }
+
+            "gibmonster"
+            {
+                "windows"  "117"
+                "linux"    "117"
+                "mac"      "117"
+            }
+
+            "hashumangibs"
+            {
+                "windows"  "118"
+                "linux"    "118"
+                "mac"      "118"
+            }
+
+            "hasaliengibs"
+            {
+                "windows"  "119"
+                "linux"    "119"
+                "mac"      "119"
+            }
+
+            "fademonster"
+            {
+                "windows"  "120"
+                "linux"    "120"
+                "mac"      "120"
+            }
+
+            "player_getgunposition"
+            {
+                "windows"  "121"
+                "linux"    "121"
+                "mac"      "121"
+            }
+
+            "deathsound"
+            {
+                "windows"  "122"
+                "linux"    "122"
+                "mac"      "122"
+            }
+
+            "alertsound"
+            {
+                "windows"  "123"
+                "linux"    "123"
+                "mac"      "123"
+            }
+
+            "idlesound"
+            {
+                "windows"  "124"
+                "linux"    "124"
+                "mac"      "124"
+            }
+
+            "painsound"
+            {
+                "windows"  "125"
+                "linux"    "125"
+                "mac"      "125"
+            }
+
+            "stopfollowing"
+            {
+                "windows"  "126"
+                "linux"    "126"
+                "mac"      "126"
+            }
+
+            "player_jump"
+            {
+                "windows"  "127"
+                "linux"    "127"
+                "mac"      "127"
+            }
+
+            "player_duck"
+            {
+                "windows"  "128"
+                "linux"    "128"
+                "mac"      "128"
+            }
+
+            "player_prethink"
+            {
+                "windows"  "129"
+                "linux"    "129"
+                "mac"      "129"
+            }
+
+            "player_postthink"
+            {
+                "windows"  "130"
+                "linux"    "130"
+                "mac"      "130"
+            }
+
+            "player_updateclientdata"
+            {
+                "windows"  "131"
+                "linux"    "131"
+                "mac"      "131"
+            }
+
+            "player_impulsecommands"
+            {
+                "windows"  "132"
+                "linux"    "132"
+                "mac"      "132"
+            }
+        }
+    }
+
+    "*" // Build 8684
+    {
+        "CRC"
+        {
+            "server"
+            {
+                "windows" "63458B85" // valve/dlls/hl.dll
+                "windows" "24124B9D" // dmc/dlls/dmc.dll
+                "linux" "E9A2A805" // valve/dlls/hl.so
+                "linux" "A9EF40F9" // dmc/dlls/dmc.so
+            }
+        }
+
         "Offsets"
         {
             "pev"
@@ -402,14 +1490,14 @@
 
             "fvisible"
             {
-                "windows"  "55"
+                "windows"  "56"
                 "linux"    "55"
                 "mac"      "55"
             }
 
             "fvecvisible"
             {
-                "windows"  "56"
+                "windows"  "55"
                 "linux"    "56"
                 "mac"      "56"
             }
@@ -421,11 +1509,67 @@
                 "mac"      "58"
             }
 
+            "item_addtoplayer"
+            {
+                "windows"  "58"
+                "linux"    "58"
+                "mac"      "58"
+            }
+
+            "runai"
+            {
+                "windows"  "59"
+                "linux"    "59"
+                "mac"      "59"
+            }
+
+            "item_addduplicate"
+            {
+                "windows"  "59"
+                "linux"    "59"
+                "mac"      "59"
+            }
+
+            "player_shouldfadeondeath"
+            {
+                "windows"  "60"
+                "linux"    "60"
+                "mac"      "60"
+            }
+
+            "item_getiteminfo"
+            {
+                "windows"  "60"
+                "linux"    "60"
+                "mac"      "60"
+            }
+
             "changeyaw"
             {
                 "windows"  "61"
                 "linux"    "61"
                 "mac"      "61"
+            }
+
+            "item_candeploy"
+            {
+                "windows"  "61"
+                "linux"    "61"
+                "mac"      "61"
+            }
+
+            "monsterthink"
+            {
+                "windows"  "62"
+                "linux"    "62"
+                "mac"      "62"
+            }
+
+            "item_deploy"
+            {
+                "windows"  "62"
+                "linux"    "62"
+                "mac"      "62"
             }
 
             "irelationship"
@@ -435,7 +1579,35 @@
                 "mac"      "63"
             }
 
+            "item_canholster"
+            {
+                "windows"  "63"
+                "linux"    "63"
+                "mac"      "63"
+            }
+
+            "monsterinit"
+            {
+                "windows"  "64"
+                "linux"    "64"
+                "mac"      "64"
+            }
+
+            "item_holster"
+            {
+                "windows"  "64"
+                "linux"    "64"
+                "mac"      "64"
+            }
+
             "monsterinitdead"
+            {
+                "windows"  "65"
+                "linux"    "65"
+                "mac"      "65"
+            }
+
+            "item_updateiteminfo"
             {
                 "windows"  "65"
                 "linux"    "65"
@@ -449,7 +1621,28 @@
                 "mac"      "66"
             }
 
+            "item_preframe"
+            {
+                "windows"  "66"
+                "linux"    "66"
+                "mac"      "66"
+            }
+
+            "item_postframe"
+            {
+                "windows"  "67"
+                "linux"    "67"
+                "mac"      "67"
+            }
+
             "bestvisibleenemy"
+            {
+                "windows"  "68"
+                "linux"    "68"
+                "mac"      "68"
+            }
+
+            "item_drop"
             {
                 "windows"  "68"
                 "linux"    "68"
@@ -458,6 +1651,13 @@
 
             "finviewcone"
             {
+                "windows"  "70"
+                "linux"    "69"
+                "mac"      "69"
+            }
+
+            "item_kill"
+            {
                 "windows"  "69"
                 "linux"    "69"
                 "mac"      "69"
@@ -465,33 +1665,26 @@
 
             "fvecinviewcone"
             {
+                "windows"  "69"
+                "linux"    "70"
+                "mac"      "70"
+            }
+
+            "item_attachtoplayer"
+            {
                 "windows"  "70"
                 "linux"    "70"
                 "mac"      "70"
             }
 
-            "runai"
-            {
-                "windows"  "59"
-                "linux"    "59"
-                "mac"      "59"
-            }
-
-            "monsterthink"
-            {
-                "windows"  "62"
-                "linux"    "62"
-                "mac"      "62"
-            }
-
-            "monsterinit"
-            {
-                "windows"  "64"
-                "linux"    "64"
-                "mac"      "64"
-            }
-
             "checklocalmove"
+            {
+                "windows"  "71"
+                "linux"    "71"
+                "mac"      "71"
+            }
+
+            "item_primaryammoindex"
             {
                 "windows"  "71"
                 "linux"    "71"
@@ -505,7 +1698,21 @@
                 "mac"      "72"
             }
 
+            "item_secondaryammoindex"
+            {
+                "windows"  "72"
+                "linux"    "72"
+                "mac"      "72"
+            }
+
             "moveexecute"
+            {
+                "windows"  "73"
+                "linux"    "73"
+                "mac"      "73"
+            }
+
+            "item_updateclientdata"
             {
                 "windows"  "73"
                 "linux"    "73"
@@ -519,7 +1726,21 @@
                 "mac"      "74"
             }
 
+            "item_getweaponptr"
+            {
+                "windows"  "74"
+                "linux"    "74"
+                "mac"      "74"
+            }
+
             "getstoppedactivity"
+            {
+                "windows"  "75"
+                "linux"    "75"
+                "mac"      "75"
+            }
+
+            "item_itemslot"
             {
                 "windows"  "75"
                 "linux"    "75"
@@ -533,7 +1754,21 @@
                 "mac"      "76"
             }
 
+            "weapon_extractammo"
+            {
+                "windows"  "76"
+                "linux"    "76"
+                "mac"      "76"
+            }
+
             "checkrangeattack1"
+            {
+                "windows"  "77"
+                "linux"    "77"
+                "mac"      "77"
+            }
+
+            "weapon_extractclipammo"
             {
                 "windows"  "77"
                 "linux"    "77"
@@ -547,7 +1782,21 @@
                 "mac"      "78"
             }
 
+            "weapon_addweapon"
+            {
+                "windows"  "78"
+                "linux"    "78"
+                "mac"      "78"
+            }
+
             "checkmeleeattack1"
+            {
+                "windows"  "79"
+                "linux"    "79"
+                "mac"      "79"
+            }
+
+            "weapon_playemptysound"
             {
                 "windows"  "79"
                 "linux"    "79"
@@ -561,7 +1810,56 @@
                 "mac"      "80"
             }
 
+            "weapon_resetemptysound"
+            {
+                "windows"  "80"
+                "linux"    "80"
+                "mac"      "80"
+            }
+
+            "weapon_sendweaponanim"
+            {
+                "windows"  "81"
+                "linux"    "81"
+                "mac"      "81"
+            }
+
+            "weapon_isusable"
+            {
+                "windows"  "82"
+                "linux"    "82"
+                "mac"      "82"
+            }
+
+            "weapon_primaryattack"
+            {
+                "windows"  "83"
+                "linux"    "83"
+                "mac"      "83"
+            }
+
+            "weapon_secondaryattack"
+            {
+                "windows"  "84"
+                "linux"    "84"
+                "mac"      "84"
+            }
+
+            "weapon_reload"
+            {
+                "windows"  "85"
+                "linux"    "85"
+                "mac"      "85"
+            }
+
             "schedulechange"
+            {
+                "windows"  "86"
+                "linux"    "86"
+                "mac"      "86"
+            }
+
+            "weapon_weaponidle"
             {
                 "windows"  "86"
                 "linux"    "86"
@@ -575,7 +1873,21 @@
                 "mac"      "87"
             }
 
-            "canplaysentence"
+            "weapon_retireweapon"
+            {
+                "windows"  "87"
+                "linux"    "87"
+                "mac"      "87"
+            }
+
+            "canplaysentence2"
+            {
+                "windows"  "88"
+                "linux"    "88"
+                "mac"      "88"
+            }
+
+            "weapon_shouldweaponidle"
             {
                 "windows"  "88"
                 "linux"    "88"
@@ -583,6 +1895,13 @@
             }
 
             "playsentence"
+            {
+                "windows"  "89"
+                "linux"    "89"
+                "mac"      "89"
+            }
+
+            "weapon_usedecrement"
             {
                 "windows"  "89"
                 "linux"    "89"
@@ -771,6 +2090,13 @@
                 "mac"      "118"
             }
 
+            "player_getgunposition"
+            {
+                "windows"  "119"
+                "linux"    "119"
+                "mac"      "119"
+            }
+
             "deathsound"
             {
                 "windows"  "120"
@@ -834,18 +2160,11 @@
                 "mac"      "128"
             }
 
-            "player_getgunposition"
+            "player_updateclientdata"
             {
-                "windows"  "119"
-                "linux"    "119"
-                "mac"      "119"
-            }
-
-            "player_shouldfadeondeath"
-            {
-                "windows"  "60"
-                "linux"    "60"
-                "mac"      "60"
+                "windows"  "129"
+                "linux"    "129"
+                "mac"      "129"
             }
 
             "player_impulsecommands"
@@ -854,238 +2173,6 @@
                 "linux"    "130"
                 "mac"      "130"
             }
-
-            "player_updateclientdata"
-            {
-                "windows"  "129"
-                "linux"    "129"
-                "mac"      "129"
-            }
-
-            "item_addtoplayer"
-            {
-                "windows"  "58"
-                "linux"    "58"
-                "mac"      "58"
-            }
-
-            "item_addduplicate"
-            {
-                "windows"  "59"
-                "linux"    "59"
-                "mac"      "59"
-            }
-
-            "item_getiteminfo"
-            {
-                "windows"  "60"
-                "linux"    "60"
-                "mac"      "60"
-            }
-
-            "item_candeploy"
-            {
-                "windows"  "61"
-                "linux"    "61"
-                "mac"      "61"
-            }
-
-            "item_deploy"
-            {
-                "windows"  "62"
-                "linux"    "62"
-                "mac"      "62"
-            }
-
-            "item_canholster"
-            {
-                "windows"  "63"
-                "linux"    "63"
-                "mac"      "63"
-            }
-
-            "item_holster"
-            {
-                "windows"  "64"
-                "linux"    "64"
-                "mac"      "64"
-            }
-
-            "item_updateiteminfo"
-            {
-                "windows"  "65"
-                "linux"    "65"
-                "mac"      "65"
-            }
-
-            "item_preframe"
-            {
-                "windows"  "66"
-                "linux"    "66"
-                "mac"      "66"
-            }
-
-            "item_postframe"
-            {
-                "windows"  "67"
-                "linux"    "67"
-                "mac"      "67"
-            }
-
-            "item_drop"
-            {
-                "windows"  "68"
-                "linux"    "68"
-                "mac"      "68"
-            }
-
-            "item_kill"
-            {
-                "windows"  "69"
-                "linux"    "69"
-                "mac"      "69"
-            }
-
-            "item_attachtoplayer"
-            {
-                "windows"  "70"
-                "linux"    "70"
-                "mac"      "70"
-            }
-
-            "item_primaryammoindex"
-            {
-                "windows"  "71"
-                "linux"    "71"
-                "mac"      "71"
-            }
-
-            "item_secondaryammoindex"
-            {
-                "windows"  "72"
-                "linux"    "72"
-                "mac"      "72"
-            }
-
-            "item_updateclientdata"
-            {
-                "windows"  "73"
-                "linux"    "73"
-                "mac"      "73"
-            }
-
-            "item_getweaponptr"
-            {
-                "windows"  "74"
-                "linux"    "74"
-                "mac"      "74"
-            }
-
-            "item_itemslot"
-            {
-                "windows"  "75"
-                "linux"    "75"
-                "mac"      "75"
-            }
-
-            "weapon_extractammo"
-            {
-                "windows"  "76"
-                "linux"    "76"
-                "mac"      "76"
-            }
-
-            "weapon_extractclipammo"
-            {
-                "windows"  "77"
-                "linux"    "77"
-                "mac"      "77"
-            }
-
-            "weapon_addweapon"
-            {
-                "windows"  "78"
-                "linux"    "78"
-                "mac"      "78"
-            }
-
-            "weapon_playemptysound"
-            {
-                "windows"  "79"
-                "linux"    "79"
-                "mac"      "79"
-            }
-
-            "weapon_resetemptysound"
-            {
-                "windows"  "80"
-                "linux"    "80"
-                "mac"      "80"
-            }
-
-            "weapon_sendweaponanim"
-            {
-                "windows"  "81"
-                "linux"    "81"
-                "mac"      "81"
-            }
-
-            "weapon_isusable"
-            {
-                "windows"  "82"
-                "linux"    "82"
-                "mac"      "82"
-            }
-
-            "weapon_primaryattack"
-            {
-                "windows"  "83"
-                "linux"    "83"
-                "mac"      "83"
-            }
-
-            "weapon_secondaryattack"
-            {
-                "windows"  "84"
-                "linux"    "84"
-                "mac"      "84"
-            }
-
-            "weapon_reload"
-            {
-                "windows"  "85"
-                "linux"    "85"
-                "mac"      "85"
-            }
-
-            "weapon_weaponidle"
-            {
-                "windows"  "86"
-                "linux"    "86"
-                "mac"      "86"
-            }
-
-            "weapon_retireweapon"
-            {
-                "windows"  "87"
-                "linux"    "87"
-                "mac"      "87"
-            }
-
-            "weapon_shouldweaponidle"
-            {
-                "windows"  "88"
-                "linux"    "88"
-                "mac"      "88"
-            }
-
-            "weapon_usedecrement"
-            {
-                "windows"  "89"
-                "linux"    "89"
-                "mac"      "89"
-            }
-
         }
     }
 }

--- a/gamedata/modules.games/game.cstrike.txt
+++ b/gamedata/modules.games/game.cstrike.txt
@@ -11,14 +11,14 @@
 
 "Games"
 {
-	"#default"
+	"#default" // Build 10210
 	{
 		"Signatures"
 		{
 			"CanPlayerBuy"  // bool CBasePlayer::CanPlayerBuy(bool display)
 			{
 				"library"   "server"
-				"windows"   "\x51\x53\x55\x56\x57\x8B\x2A\x8B\x2A\x2A\x2A\x2A\x2A\x8B\x2A\xFF"
+				"windows"   "\x55\x8B\xEC\x51\x56\x8B\xF1\x8B\x0D\x2A\x2A\x2A\x2A\x8B\x01"
 				"linux"     "@_ZN11CBasePlayer12CanPlayerBuyEb"
 				"mac"       "@_ZN11CBasePlayer12CanPlayerBuyEb"
 			}
@@ -26,7 +26,7 @@
 			"CanBuyThis"  // bool CanBuyThis(CBasePlayer *pPlayer, int weaponId)
 			{
 				"library"   "server"
-				"windows"   "\x53\x8B\x2A\x2A\x2A\x2A\x2A\x56\x8B\x2A\x2A\x2A\x57\x8B"
+				"windows"   "\x55\x8B\xEC\x53\x8B\x1D\x2A\x2A\x2A\x2A\x56\x8B\x75"
 				"linux"     "@_Z10CanBuyThisP11CBasePlayeri"
 				"mac"       "@_Z10CanBuyThisP11CBasePlayeri"
 			}
@@ -34,7 +34,7 @@
 			"AddAccount"    // void CBasePlayer::AddAccount(int amount, bool bTrackChange)
 			{
 				"library"   "server"
-				"windows"   "\x8B\x2A\x2A\x2A\x56\x8B\x2A\x8B\x2A\x2A\x2A\x2A\x2A\x03"
+				"windows"   "\x55\x8B\xEC\x8B\x45\x2A\x56\x8B\xF1\x01\x86"
 				"linux"     "@_ZN11CBasePlayer10AddAccountEib"
 				"mac"       "@_ZN11CBasePlayer10AddAccountEib"
 			}
@@ -42,7 +42,7 @@
 			"GiveNamedItem" // void CBasePlayer::GiveNamedItem(const char *pszName)
 			{
 				"library"   "server"
-				"windows"   "\x8B\x2A\x2A\x2A\x56\x57\x8B\x2A\x8B\x2A\x2A\x2A\x2A\x2A\x2B"
+				"windows"   "\x55\x8B\xEC\xA1\x2A\x2A\x2A\x2A\x8B\x55\x2A\x56"
 				"linux"     "@_ZN11CBasePlayer13GiveNamedItemEPKc"
 				"mac"       "@_ZN11CBasePlayer13GiveNamedItemEPKc"
 			}
@@ -50,7 +50,7 @@
 			"GiveDefaultItems" // void CBasePlayer::GiveDefaultItems(void)
 			{
 				"library"   "server"
-				"windows"   "\x56\x57\x6A\x2A\x8B\x2A\xE8\x2A\x2A\x2A\x2A\x8B\x2A\x2A\x2A\x2A\x2A\xC6"
+				"windows"   "\x56\x6A\x2A\x8B\xF1\xE8\x2A\x2A\x2A\x2A\x8B\x86"
 				"linux"     "@_ZN11CBasePlayer16GiveDefaultItemsEv"
 				"mac"       "@_ZN11CBasePlayer16GiveDefaultItemsEv"
 			}
@@ -58,7 +58,7 @@
 			"GiveShield"    // void CBasePlayer::GiveShield(bool bRetire)
 			{
 				"library"   "server"
-				"windows"   "\x56\x8B\x2A\x57\x33\x2A\x8B\x2A\x2A\x2A\x2A\x2A\xB0"
+				"windows"   "\x55\x8B\xEC\x56\x8B\xF1\x8B\x8E\x2A\x2A\x2A\x2A\xC6\x86"
 				"linux"     "@_ZN11CBasePlayer10GiveShieldEb"
 				"mac"       "@_ZN11CBasePlayer10GiveShieldEb"
 			}
@@ -66,7 +66,7 @@
 			"CreateNamedEntity" // edict_t* CREATE_NAMED_ENTITY(int classname)
 			{
 				"library"   "server"
-				"windows"   "\x56\x57\x8B\x2A\x2A\x2A\x57\xFF\x2A\x2A\x2A\x2A\x2A\x8B"
+				"windows"   "\x55\x8B\xEC\x56\xFF\x75\x2A\xFF\x15"
 				"linux"     "@_Z19CREATE_NAMED_ENTITYj"
 				"mac"       "@_Z19CREATE_NAMED_ENTITYj"
 			}
@@ -74,7 +74,7 @@
 			"FindEntityByString" // CBaseEntity *UTIL_FindEntityByString(CBaseEntity *pStartEntity, const char *szKeyword, const char *szValue)
 			{
 				"library"   "server"
-				"windows"   "\x51\x8B\x2A\x2A\x2A\x53\x55\x56\x85\x2A\x57"
+				"windows"   "\x55\x8B\xEC\x51\x8B\x45\x2A\x53\x56"
 				"linux"     "@_Z23UTIL_FindEntityByStringP11CBaseEntityPKcS2_"
 				"mac"       "@_Z23UTIL_FindEntityByStringP11CBaseEntityPKcS2_"
 			}
@@ -82,7 +82,7 @@
 			"AddEntityHashValue" // void AddEntityHashValue(struct entvars_s *pev, const char *value, hash_types_e fieldType)
 			{
 				"library"   "server"
-				"windows"   "\x8B\x2A\x2A\x2A\x83\x2A\x2A\x85\x2A\x53\x55\x56\x57\x0F"
+				"windows"   "\x55\x8B\xEC\x51\x83\x7D"
 				"linux"     "@_Z18AddEntityHashValueP9entvars_sPKc12hash_types_e"
 				"mac"       "@_Z18AddEntityHashValueP9entvars_sPKc12hash_types_e"
 			}
@@ -90,7 +90,7 @@
 			"RemoveEntityHashValue" // void RemoveEntityHashValue(struct entvars_s *pev, const char *value, hash_types_e fieldType)
 			{
 				"library"   "server"
-				"windows"   "\x8B\x2A\x2A\x2A\x53\x8B\x2A\x55\x8A\x2A\x33"
+				"windows"   "\x55\x8B\xEC\x8B\x4D\x2A\x33\xD2\x56\x57"
 				"linux"     "@_Z21RemoveEntityHashValueP9entvars_sPKc12hash_types_e"
 				"mac"       "@_Z21RemoveEntityHashValueP9entvars_sPKc12hash_types_e"
 			}
@@ -98,7 +98,7 @@
 			"GetWeaponInfo" // WeaponInfoStruct *GetWeaponInfo(int id);
 			{
 				"library"   "server"
-				"windows"   "\x8B\x2A\x2A\x2A\x2A\x2A\x33\x2A\x85\x2A\x56\x74\x2A\x8B"
+				"windows"   "\x55\x8B\xEC\xA1\x2A\x2A\x2A\x2A\x33\xC9\x85\x2A\x74" // Found following weaponInfo array
 				"linux"     "@_Z13GetWeaponInfoi"
 				"mac"       "@_Z13GetWeaponInfoi"
 			}
@@ -106,7 +106,7 @@
 			"GetAmmoIndex" // int CBasePlayer::GetAmmoIndex(const char *psz)
 			{
 				"library"   "server"
-				"windows"   "\x56\x57\x8B\x2A\x2A\x2A\x85\x2A\x74\x2A\xBE"
+				"windows"   "\x55\x8B\xEC\x53\x56\x57\x8B\x7D\x2A\x85\xFF\x74\x2A\x8B\x1D"
 				"linux"     "@_ZN11CBasePlayer12GetAmmoIndexEPKc"
 				"mac"       "@_ZN11CBasePlayer12GetAmmoIndexEPKc"
 			}
@@ -114,21 +114,14 @@
 			"BuyGunAmmo" // bool BuyGunAmmo(CBasePlayer *player, CBasePlayerItem *weapon, bool bBlinkMoney)
 			{
 				"library"   "server"
-				"windows"   "\x56\x57\x8B\x2A\x2A\x2A\x6A\x2A\x8B\x2A\xE8\x2A\x2A\x2A\x2A\x84\x2A\x0F"
+				"windows"   "\x55\x8B\xEC\x56\x57\x8B\x7D\x2A\x8B\xCF\x6A"
 				"linux"     "@_Z10BuyGunAmmoR11CBasePlayerR15CBasePlayerItemb"
 				"mac"       "@_Z10BuyGunAmmoR11CBasePlayerR15CBasePlayerItemb"
 			}
-		}
-	}
 
-	"#default"
-	{
-		"Signatures"
-		{
 			"UseBotArgs"    // bool UseBotArgs
 			{
 				"library"   "server"
-				"windows"   "\x8B\x2A\x2A\x2A\x56\x8B\x2A\x8B\x2A\x2A\x2A\x2A\x2A\x03"
 				"linux"     "@UseBotArgs"
 				"mac"       "@UseBotArgs"
 			}
@@ -136,7 +129,6 @@
 			"BotArgs"       // const char *BotArgs[4]
 			{
 				"library"   "server"
-				"windows"   "\x8B\x2A\x2A\x2A\x56\x8B\x2A\x8B\x2A\x2A\x2A\x2A\x2A\x03"
 				"linux"     "@BotArgs"
 				"mac"       "@BotArgs"
 			}
@@ -146,12 +138,12 @@
 		{
 			"UseBotArgs"    // bool UseBotArgs
 			{
-				"windows"   "2"
+				"windows"   "21" // Used with pfnClientCommand base address
 			}
 
 			"BotArgs"       // const char *BotArgs[4]
 			{
-				"windows"   "22"
+				"windows"   "42"
 			}
 		}
 	}
@@ -371,6 +363,99 @@
 					"itemid"    "37"  // CSI_SECAMMO
 					"altname"   "buyammo2"
 				}
+			}
+		}
+	}
+
+	"*" // Build 8684 - Windows
+	{
+		"CRC"
+		{
+			"server"
+			{
+				"windows" "6BF63A24" // cstrike/dlls/mp.dll
+				"windows" "BD938A62" // czero/dlls/mp.dll
+			}
+		}
+
+		"Signatures"
+		{
+			"CanPlayerBuy"
+			{
+				"windows"   "\x51\x53\x55\x56\x57\x8B\x2A\x8B\x2A\x2A\x2A\x2A\x2A\x8B\x2A\xFF"
+			}
+
+			"CanBuyThis"
+			{
+				"windows"   "\x53\x8B\x2A\x2A\x2A\x2A\x2A\x56\x8B\x2A\x2A\x2A\x57\x8B"
+			}
+
+			"AddAccount"
+			{
+				"windows"   "\x8B\x2A\x2A\x2A\x56\x8B\x2A\x8B\x2A\x2A\x2A\x2A\x2A\x03"
+			}
+
+			"GiveNamedItem"
+			{
+				"windows"   "\x8B\x2A\x2A\x2A\x56\x57\x8B\x2A\x8B\x2A\x2A\x2A\x2A\x2A\x2B"
+			}
+
+			"GiveDefaultItems"
+			{
+				"windows"   "\x56\x57\x6A\x2A\x8B\x2A\xE8\x2A\x2A\x2A\x2A\x8B\x2A\x2A\x2A\x2A\x2A\xC6"
+			}
+
+			"GiveShield"
+			{
+				"windows"   "\x56\x8B\x2A\x57\x33\x2A\x8B\x2A\x2A\x2A\x2A\x2A\xB0"
+			}
+
+			"CreateNamedEntity"
+			{
+				"windows"   "\x56\x57\x8B\x2A\x2A\x2A\x57\xFF\x2A\x2A\x2A\x2A\x2A\x8B"
+			}
+
+			"FindEntityByString"
+			{
+				"windows"   "\x51\x8B\x2A\x2A\x2A\x53\x55\x56\x85\x2A\x57"
+			}
+
+			"AddEntityHashValue"
+			{
+				"windows"   "\x8B\x2A\x2A\x2A\x83\x2A\x2A\x85\x2A\x53\x55\x56\x57\x0F"
+			}
+
+			"RemoveEntityHashValue"
+			{
+				"windows"   "\x8B\x2A\x2A\x2A\x53\x8B\x2A\x55\x8A\x2A\x33"
+			}
+
+			"GetWeaponInfo"
+			{
+				"windows"   "\x8B\x2A\x2A\x2A\x2A\x2A\x33\x2A\x85\x2A\x56\x74\x2A\x8B"
+			}
+
+			"GetAmmoIndex"
+			{
+				"windows"   "\x56\x57\x8B\x2A\x2A\x2A\x85\x2A\x74\x2A\xBE"
+			}
+
+			"BuyGunAmmo"
+			{
+				"windows"   "\x56\x57\x8B\x2A\x2A\x2A\x6A\x2A\x8B\x2A\xE8\x2A\x2A\x2A\x2A\x84\x2A\x0F"
+			}
+		}
+
+		"Offsets"
+		{
+			"UseBotArgs"
+			{
+				"windows"   "2" // Used with pfnClientCommand base address
+			}
+
+			"BotArgs"
+			{
+				"windows"   "22"
 			}
 		}
 	}


### PR DESCRIPTION
amxx should now run without issues on servers running both hl25 or legacy binaries by checking for legacy's files with #1131
includes updated signatures for cstrike and updated offsets-common.txt for valve also using crc checks

closes #1086 , closes #1093 and fixes #1118
also, a small mention to #1108