### PR TITLE
Implement new meta natives for module development: MF_GetScriptInfo, MF_GetAmxVersion, MF_SetFailState

### DIFF
--- a/amxmodx/modules.cpp
+++ b/amxmodx/modules.cpp
@@ -1137,6 +1137,43 @@ const char *MNF_GetAmxScriptName(int id)
 	return nullptr;
 }
 
+bool MNF_GetAmxScriptInfo(const AMX* amx, const char** pszTitle = nullptr, const char** pszAuthor = nullptr, const char** pszVersion = nullptr)
+{
+	CPluginMngr::CPlugin* pl = g_plugins.findPluginFast(const_cast<AMX*>(amx));
+
+	if (pl->getId() != -1)
+	{
+		if (pszTitle != nullptr)
+		{
+			*pszTitle = pl->getTitle();
+		}
+
+		if (pszAuthor != nullptr)
+		{
+			*pszAuthor = pl->getAuthor();
+		}
+
+		if (pszVersion != nullptr)
+		{
+			*pszVersion = pl->getVersion();
+		}
+
+		return pl->isValid();
+	}
+
+	return false;
+}
+
+void MNF_SetAmxFailState(const AMX* amx, const char* str)
+{
+	g_langMngr.SetDefLang(LANG_SERVER);	// Default language = server
+
+	CPluginMngr::CPlugin* pPlugin = g_plugins.findPluginFast(const_cast<AMX*>(amx));
+
+	pPlugin->setStatus(ps_error);
+	pPlugin->setError(str);
+}
+
 int MNF_FindAmxScriptByName(const char *name)
 {
 	bool found = false;
@@ -1687,6 +1724,11 @@ void MNF_MessageBlock(int mode, int msg, int *opt)
 	}
 }
 
+const char* MNF_GetAmxVersion()
+{
+	return Plugin_info.version;
+}
+
 void *MNF_PlayerPropAddr(int id, int prop)
 {
 	if (id < 1 || id > gpGlobals->maxClients)
@@ -1847,6 +1889,9 @@ void Module_CacheFunctions()
 	REGISTER_FUNC("GetLocalInfo", MNF_GetLocalInfo);
 
 	REGISTER_FUNC("MessageBlock", MNF_MessageBlock);
+	REGISTER_FUNC("GetAmxScriptInfo", MNF_GetAmxScriptInfo);
+	REGISTER_FUNC("GetAmxVersion", MNF_GetAmxVersion);
+	REGISTER_FUNC("SetPluginFailState", MNF_SetAmxFailState);
 
 #ifdef MEMORY_TEST
 	REGISTER_FUNC("Allocator", m_allocator)

--- a/public/sdk/amxxmodule.cpp
+++ b/public/sdk/amxxmodule.cpp
@@ -2427,6 +2427,9 @@ PFN_AMX_REREGISTER			g_fn_AmxReRegister;
 PFN_REGISTERFUNCTIONEX		g_fn_RegisterFunctionEx;
 PFN_MESSAGE_BLOCK			g_fn_MessageBlock;
 PFN_GET_CONFIG_MANAGER		g_fn_GetConfigManager;
+PFN_GET_AMXSCRIPTINFO		g_fn_GetAmxScriptInfo;
+PFN_GET_AMX_VERSION			g_fn_GetAmxVersion;
+PFN_SET_FAILSTATE			g_fn_SetPluginFailState;
 
 // *** Exports ***
 C_DLLEXPORT int AMXX_Query(int *interfaceVersion, amxx_module_info_s *moduleInfo)
@@ -2566,6 +2569,11 @@ C_DLLEXPORT int AMXX_Attach(PFN_REQ_FNPTR reqFnptrFunc)
 	REQFUNC("AmxReregister", g_fn_AmxReRegister, PFN_AMX_REREGISTER);
 
 	REQFUNC("MessageBlock", g_fn_MessageBlock, PFN_MESSAGE_BLOCK);
+
+	//Newly added
+	REQFUNC("GetAmxVersion", g_fn_GetAmxVersion, PFN_GET_AMX_VERSION);
+	REQFUNC("GetAmxScriptInfo", g_fn_GetAmxScriptInfo, PFN_GET_AMXSCRIPTINFO);
+	REQFUNC("SetPluginFailState", g_fn_SetPluginFailState, PFN_SET_FAILSTATE);
 
 #ifdef MEMORY_TEST
 	// Memory
@@ -2717,6 +2725,9 @@ void ValidateMacros_DontCallThis_Smiley()
 	MF_OverrideNatives(NULL, NULL);
 	MF_MessageBlock(0, 0, NULL);
 	MF_GetConfigManager();
+	MF_GetScriptInfo(0, nullptr, nullptr, nullptr);
+	MF_GetAmxVersion();
+	MF_SetFailState(0, NULL);
 }
 #endif
 

--- a/public/sdk/amxxmodule.h
+++ b/public/sdk/amxxmodule.h
@@ -2222,6 +2222,9 @@ typedef int				(*PFN_AMX_REREGISTER)			(AMX * /*amx*/, AMX_NATIVE_INFO * /*list*
 typedef void *			(*PFN_REGISTERFUNCTIONEX)		(void * /*pfn*/, const char * /*desc*/);
 typedef void			(*PFN_MESSAGE_BLOCK)			(int /* mode */, int /* message */, int * /* opt */);
 typedef IGameConfigManager* (*PFN_GET_CONFIG_MANAGER)   ();
+typedef bool			(*PFN_GET_AMXSCRIPTINFO)		(const AMX* /*amx*/, const char** /*pszTitle*/, const char** /*pszAuthor*/, const char** /*pszVersion*/);
+typedef char*			(*PFN_GET_AMX_VERSION)			();
+typedef void			(*PFN_SET_FAILSTATE)			(const AMX* /*amx*/, const char* /*str*/);
 
 extern PFN_ADD_NATIVES				g_fn_AddNatives;
 extern PFN_ADD_NEW_NATIVES			g_fn_AddNewNatives;
@@ -2304,6 +2307,9 @@ extern PFN_AMX_REREGISTER			g_fn_AmxReRegister;
 extern PFN_REGISTERFUNCTIONEX		g_fn_RegisterFunctionEx;
 extern PFN_MESSAGE_BLOCK			g_fn_MessageBlock;
 extern PFN_GET_CONFIG_MANAGER		g_fn_GetConfigManager;
+extern PFN_GET_AMXSCRIPTINFO		g_fn_GetAmxScriptInfo;
+extern PFN_GET_AMX_VERSION			g_fn_GetAmxVersion;
+extern PFN_SET_FAILSTATE			g_fn_SetPluginFailState;
 
 #ifdef MAY_NEVER_BE_DEFINED
 // Function prototypes for intellisense and similar systems
@@ -2382,6 +2388,9 @@ int				MF_AmxReRegister			(AMX *amx, AMX_NATIVE_INFO *list, int number) { return
 void *			MF_RegisterFunctionEx		(void *pfn, const char *description) { }
 void *			MF_MessageBlock				(int mode, int msg, int *opt) { }
 IGameConfigManager* MF_GetConfigManager     (void) { }
+bool			MF_GetScriptInfo			(const AMX* amx, const char** pszTitle = nullptr, const char** pszAuthor = nullptr, const char** pszVersion = nullptr) { }
+const char*		MF_GetAmxVersion			(void) { }
+void			MF_SetFailState				(const AMX* amx, const char* str) { }
 #endif	// MAY_NEVER_BE_DEFINED
 
 #define MF_AddNatives g_fn_AddNatives
@@ -2466,6 +2475,9 @@ void MF_LogError(AMX *amx, int err, const char *fmt, ...);
 #define MF_RegisterFunctionEx g_fn_RegisterFunctionEx
 #define MF_MessageBlock g_fn_MessageBlock
 #define MF_GetConfigManager g_fn_GetConfigManager
+#define MF_GetScriptInfo g_fn_GetAmxScriptInfo
+#define MF_GetAmxVersion g_fn_GetAmxVersion
+#define MF_SetFailState g_fn_SetPluginFailState
 
 #ifdef MEMORY_TEST
 /*** Memory ***/


### PR DESCRIPTION
Description:

This PR introduces three new meta natives intended to expose more internal data and control to C++ module developers. These additions allow modules to query plugin metadata, check the core AMXX version, and handle plugin failures more discreetly.

Changes:

- MF_GetScriptInfo: Allows a module to retrieve the Title, Author, and Version of a running plugin by providing the AMX* pointer. Arguments can be passed as nullptr if specific fields are not needed. This native was added as currently there is no way to get a plugin name, version and author when writing a module, unlike is the case with SourceMod.

- MF_GetAmxVersion: Returns the current AMX Mod X version string.

- MF_SetFailState: Sets a plugin into a failed state (similar to the Pawn set_fail_state native). Key difference: This native does not automatically print or log the error message, allowing the module developer to handle logging customly or silently if required.