### PR TITLE
Allow operators use custom gamedll

### DIFF
--- a/amxmodx/CGameConfigs.cpp
+++ b/amxmodx/CGameConfigs.cpp
@@ -13,9 +13,6 @@
 #include "sm_crc32.h"
 #include <stdio.h>
 #include <stdlib.h>
-#if defined(LINUX) || defined(_LINUX)
-#include <link.h> /// struct link_map*
-#endif
 
 CGameConfigManager ConfigManager;
 static CGameMasterReader MasterReader;
@@ -124,19 +121,11 @@ static void* OrigGamedllAddrByFileName(const char* fileName)
     void* pAddr = reinterpret_cast<void*>(GetModuleHandle(fileName));
     if (pAddr)
         return pAddr;
-#elif defined(LINUX) || defined(_LINUX)
-    void* pModule = dlopen(fileName, RTLD_NOLOAD | RTLD_NOW);
-    if (pModule)
-    {
-        void* pAddr = reinterpret_cast<void*>(((struct link_map*)pModule)->l_addr);
-        dlclose(pModule);
-        return pAddr;
-    }
 #else
     void* pModule = dlopen(fileName, RTLD_NOLOAD | RTLD_NOW);
     if (pModule)
     {
-        void* pAddr = dlsym(fileName, "GiveFnptrsToDll");
+        void* pAddr = dlsym(pModule, "GiveFnptrsToDll");
         dlclose(pModule);
         return pAddr;
     }

--- a/amxmodx/CGameConfigs.cpp
+++ b/amxmodx/CGameConfigs.cpp
@@ -13,6 +13,9 @@
 #include "sm_crc32.h"
 #include <stdio.h>
 #include <stdlib.h>
+#if defined(LINUX) || defined(_LINUX)
+#include <link.h> /// struct link_map*
+#endif
 
 CGameConfigManager ConfigManager;
 static CGameMasterReader MasterReader;
@@ -68,6 +71,77 @@ static bool DoesGameMatch(const char *value)
 static bool DoesEngineMatch(const char* value)
 {
 	return strcmp(ParseEngine, value) == 0;
+}
+
+/**
+ * Retrieves orig. gamedll file name (if clearly specified).
+ * A result is always returned and must be released using free().
+ * Strips single quotes when needed.
+ * On Linux/ Mac, a short path is returned (starting with game dir. name).
+ */
+static char* OrigGamedllFileName()
+{
+    char* Res;
+#if defined(WIN32) || defined(_WINDOWS)
+    const char* fileName = get_localinfo("orig_gamedll_windows", "");
+#elif defined(LINUX) || defined(_LINUX)
+    const char* fileName = get_localinfo("orig_gamedll_linux", "");
+#else
+    const char* fileName = get_localinfo("orig_gamedll_mac", "");
+#endif
+    if (*fileName == '\0')
+    {
+        Res = (char*)malloc(1);
+        *Res = '\0';
+        return Res;
+    }
+    size_t resLen, Iter, fileNameLen = strlen(fileName);
+    Res = (char*)malloc(fileNameLen + 1);
+    for (Iter = resLen = 0; Iter < fileNameLen; Iter++)
+        if ('\'' != fileName[Iter])
+            Res[resLen++] = fileName[Iter];
+    Res[resLen] = '\0';
+#if !defined(WIN32) && !defined(_WINDOWS) /// On Linux/ Mac, a path is required for dlopen().
+    if (resLen < 1)
+        return Res; /// Do not prepend a path if module file name not specified.
+    size_t pathResLen = g_mod_name.length() + resLen + 6 /** /dlls/ */;
+	char* pathRes = (char*)malloc(pathResLen + 1);
+	sprintf(pathRes, "%s/dlls/%s", g_mod_name.chars(), Res); /// Auto null-terminates.
+	free(Res);
+	return pathRes;
+#else
+    return Res;
+#endif
+}
+
+/**
+ * Returns an orig. gamedll-related address by orig. gamedll file name.
+ * Returns NULL if gamedll file name does not point to a loaded gamedll.
+ */
+static void* OrigGamedllAddrByFileName(const char* fileName)
+{
+#if defined(WIN32) || defined(_WINDOWS)
+    void* pAddr = reinterpret_cast<void*>(GetModuleHandle(fileName));
+    if (pAddr)
+        return pAddr;
+#elif defined(LINUX) || defined(_LINUX)
+    void* pModule = dlopen(fileName, RTLD_NOLOAD | RTLD_NOW);
+    if (pModule)
+    {
+        void* pAddr = reinterpret_cast<void*>(((struct link_map*)pModule)->l_addr);
+        dlclose(pModule);
+        return pAddr;
+    }
+#else
+    void* pModule = dlopen(fileName, RTLD_NOLOAD | RTLD_NOW);
+    if (pModule)
+    {
+        void* pAddr = dlsym(fileName, "GiveFnptrsToDll");
+        dlclose(pModule);
+        return pAddr;
+    }
+#endif
+    return NULL;
 }
 
 CGameConfig::CGameConfig(const char *path) : m_FoundOffset(false), m_CustomLevel(0), m_CustomHandler(nullptr)
@@ -645,7 +719,15 @@ SMCResult CGameConfig::ReadSMC_LeavingSection(const SMCStates *states)
 			{
 				if (strcmp(TempSig.library, "server") == 0)
 				{
-					addressInBase = reinterpret_cast<void*>(MDLL_Spawn);
+                    char* desiredGamedll = OrigGamedllFileName();
+                    if ('\0' == *desiredGamedll)
+                        addressInBase = reinterpret_cast<void*>(MDLL_Spawn);
+                    else
+                    {
+                        void* gamedllAddr = OrigGamedllAddrByFileName(desiredGamedll);
+                        addressInBase = gamedllAddr ? gamedllAddr : reinterpret_cast<void*>(MDLL_Spawn);
+                    }
+                    free(desiredGamedll);
 				}
 				else if (strcmp(TempSig.library, "engine") == 0)
 				{
@@ -1267,7 +1349,15 @@ bool CGameConfigManager::ResolveLibraryInfo(const char *library, void **baseAddr
 
 	if (!strcmp(library, "server"))
 	{
-		symbol = reinterpret_cast<void*>(MDLL_Spawn);
+        char* desiredGamedll = OrigGamedllFileName();
+        if ('\0' == *desiredGamedll)
+            symbol = reinterpret_cast<void*>(MDLL_Spawn);
+        else
+        {
+            void* gamedllAddr = OrigGamedllAddrByFileName(desiredGamedll);
+            symbol = gamedllAddr ? gamedllAddr : reinterpret_cast<void*>(MDLL_Spawn);
+        }
+        free(desiredGamedll);
 	}
 	else if (!strcmp(library, "engine"))
 	{

--- a/configs/core.ini
+++ b/configs/core.ini
@@ -45,3 +45,12 @@ optimizer 7
 ; 0 - enabled
 ; 1 - disabled
 disableflagman 0
+
+; If using a custom game dll (like DoD Shrikebot),
+; please name your original game dll(s) below.
+; Useful for sig./ sym. scanning, those can be
+; found in "dlls" folder of your server (i.e.
+; dod_i386.so, tfc.so, mp.dll, ...)
+orig_gamedll_windows ''
+orig_gamedll_linux ''
+orig_gamedll_mac ''

--- a/configs/cstrike/core.ini
+++ b/configs/cstrike/core.ini
@@ -48,3 +48,12 @@ optimizer 7
 ; 0 - enabled
 ; 1 - disabled
 disableflagman 0
+
+; If using a custom game dll (like DoD Shrikebot),
+; please name your original game dll(s) below.
+; Useful for sig./ sym. scanning, those can be
+; found in "dlls" folder of your server (i.e.
+; dod_i386.so, tfc.so, mp.dll, ...)
+orig_gamedll_windows ''
+orig_gamedll_linux ''
+orig_gamedll_mac ''

--- a/configs/dod/core.ini
+++ b/configs/dod/core.ini
@@ -48,3 +48,12 @@ optimizer 7
 ; 0 - enabled
 ; 1 - disabled
 disableflagman 0
+
+; If using a custom game dll (like DoD Shrikebot),
+; please name your original game dll(s) below.
+; Useful for sig./ sym. scanning, those can be
+; found in "dlls" folder of your server (i.e.
+; dod_i386.so, tfc.so, mp.dll, ...)
+orig_gamedll_windows ''
+orig_gamedll_linux ''
+orig_gamedll_mac ''

--- a/configs/tfc/core.ini
+++ b/configs/tfc/core.ini
@@ -48,3 +48,12 @@ optimizer 7
 ; 0 - enabled
 ; 1 - disabled
 disableflagman 0
+
+; If using a custom game dll (like DoD Shrikebot),
+; please name your original game dll(s) below.
+; Useful for sig./ sym. scanning, those can be
+; found in "dlls" folder of your server (i.e.
+; dod_i386.so, tfc.so, mp.dll, ...)
+orig_gamedll_windows ''
+orig_gamedll_linux ''
+orig_gamedll_mac ''

--- a/configs/ts/core.ini
+++ b/configs/ts/core.ini
@@ -48,3 +48,12 @@ optimizer 7
 ; 0 - enabled
 ; 1 - disabled
 disableflagman 0
+
+; If using a custom game dll (like DoD Shrikebot),
+; please name your original game dll(s) below.
+; Useful for sig./ sym. scanning, those can be
+; found in "dlls" folder of your server (i.e.
+; dod_i386.so, tfc.so, mp.dll, ...)
+orig_gamedll_windows ''
+orig_gamedll_linux ''
+orig_gamedll_mac ''


### PR DESCRIPTION
Allow operators use custom gamedll, without altering **AMXX**'s sig./ sym. scanning process.

- To be more specific, a game server may load via `metamod/config.ini` a non-**Metamod** plugin (as gamedll), which will subsequently load the original gamedll. This PR is meant to help **AMXX** deal with it.

Before:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/edc9f950-b1e3-4cac-a81c-d6840651924b" />

After:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e0f7c014-88e3-49d4-a849-1d7e87b90f28" />
