### PR TITLE
Fix CSX module hitgroup and cur. weapon detection; fix a bug when attacker disconnects during attack

### DIFF
--- a/modules/cstrike/csx/CMisc.cpp
+++ b/modules/cstrike/csx/CMisc.cpp
@@ -139,6 +139,7 @@ void CPlayer::Init( int pi, edict_t* pe )
     pEdict = pe;
     index = pi;
 	current = 0;
+    current_atk = 0;
 	clearStats = 0.0f;
 	rank = 0;
 }

--- a/modules/cstrike/csx/CMisc.h
+++ b/modules/cstrike/csx/CMisc.h
@@ -34,7 +34,8 @@ struct CPlayer {
 	char ip[32];
 	int index;
 	int aiming;
-	int current;
+	int current; /// cur. weapon
+    int current_atk; /// cur. weapon during TraceAttack()/ TakeDamage() calls
 	bool bot;
 	float clearStats;
 	RankSystem::RankStats*	rank;

--- a/modules/cstrike/csx/CRank.cpp
+++ b/modules/cstrike/csx/CRank.cpp
@@ -65,7 +65,7 @@ RankSystem::RankStats::~RankStats() {
 
 void RankSystem::RankStats::setName( const char* nn  )	{
 	delete[] name;
-	namelen = strlen(nn) + 1;
+	namelen = short(strlen(nn) + 1);
 	name = new char[namelen];
 	if ( name )
 		strcpy( name , nn );
@@ -75,7 +75,7 @@ void RankSystem::RankStats::setName( const char* nn  )	{
 
 void RankSystem::RankStats::setUnique( const char* nn  )	{
 	delete[] unique;
-	uniquelen = strlen(nn) + 1;
+	uniquelen = short(strlen(nn) + 1);
 	unique = new char[uniquelen];
 	if ( unique )
 		strcpy( unique , nn );	

--- a/modules/cstrike/csx/meta_api.cpp
+++ b/modules/cstrike/csx/meta_api.cpp
@@ -13,12 +13,17 @@
 
 #include "amxxmodule.h"
 #include "rank.h"
+#include <IGameConfigs.h>
 
 funEventCall modMsgsEnd[MAX_REG_MSGS];
 funEventCall modMsgs[MAX_REG_MSGS];
 
 void (*function)(void*);
 void (*endfunction)(void*);
+
+IGameConfigManager* ConfigManager;
+IGameConfig* CommonConfig = NULL;
+size_t m_LastHitGroup = 0;
 
 CPlayer players[33];
 
@@ -379,14 +384,10 @@ void TraceLine_Post(const float *v1, const float *v2, int fNoMonsters, edict_t *
 {
 	if (ptr->pHit && (ptr->pHit->v.flags & (FL_CLIENT|FL_FAKECLIENT))
 		&& e 
-		&& (e->v.flags & (FL_CLIENT|FL_FAKECLIENT)) 
-		&& ptr->iHitgroup)
+		&& (e->v.flags & (FL_CLIENT|FL_FAKECLIENT)))
 	{
 		CPlayer *pPlayer = GET_PLAYER_POINTER(e);
-		if (pPlayer->current != CSW_KNIFE)
-		{
-			pPlayer->aiming = ptr->iHitgroup;
-		}
+		pPlayer->aiming = ptr->iHitgroup;
 	}
 
 	RETURN_META(MRES_IGNORED);
@@ -417,12 +418,23 @@ int AmxxCheckGame(const char *game)
 }
 void OnAmxxAttach(){
 	MF_AddNatives(stats_Natives);
+
+    char error[256];
+	ConfigManager = MF_GetConfigManager();
+	if (!ConfigManager->LoadGameConfigFile("common.games", &CommonConfig, error, sizeof(error)))
+		MF_Log("Could not read common.games gamedata: %s", error);
+	else
+	{
+		TypeDescription ofs;
+		if (CommonConfig->GetOffsetByClass("CBaseMonster", "m_LastHitGroup", &ofs))
+			m_LastHitGroup = ofs.fieldOffset;
+        if (m_LastHitGroup < 1)
+            MF_Log("Could not read CBaseMonster::m_LastHitGroup ofs.");
+	}
+
 	const char* path =  get_localinfo("csstats_score");
 	if ( path && *path ) 
-	{
-		char error[128];
 		g_rank.loadCalc( MF_BuildPathname("%s",path) , error, sizeof(error));
-	}
 	
 	if ( !g_rank.begin() )
 	{		
@@ -435,6 +447,8 @@ void OnAmxxDetach() {
 	g_grenades.clear();
 	g_rank.clear();
 	g_rank.unloadCalc();
+    if (CommonConfig)
+        ConfigManager->CloseGameConfigFile(CommonConfig);
 }
 
 void OnPluginsLoaded(){

--- a/modules/cstrike/csx/meta_api.cpp
+++ b/modules/cstrike/csx/meta_api.cpp
@@ -15,6 +15,27 @@
 #include "rank.h"
 #include <IGameConfigs.h>
 
+#if !defined(WIN32) && !defined(_WINDOWS)
+#include <sys/mman.h> /// mprotect()
+#endif
+
+size_t** g_ppvtbl_CBasePlayer = NULL;
+size_t** g_ppvtbl_CBasePlayer_Bots = NULL;
+
+TraceAttack_Type g_origTraceAttack = NULL;
+TakeDamage_Type g_origTakeDamage = NULL;
+
+TraceAttack_Type g_origTraceAttack_Bots = NULL;
+TakeDamage_Type g_origTakeDamage_Bots = NULL;
+
+size_t g_ofsBaseclass; /// "base"
+size_t g_vfidxTraceAttack; /// "traceattack"
+size_t g_vfidxTakeDamage; /// "takedamage"
+
+bool g_virtualCfg = false;
+
+edict_t* g_pEdictList; /// from ServerActivate_Post()
+
 funEventCall modMsgsEnd[MAX_REG_MSGS];
 funEventCall modMsgs[MAX_REG_MSGS];
 
@@ -130,6 +151,20 @@ const char* get_localinfo( const char* name , const char* def = 0 )
 	return b;
 }
 
+void allowFullMemAccess(void* pAddr, size_t Size)
+{
+#if defined(WIN32) || defined(_WINDOWS) /// Windows
+    unsigned long oldAccess;
+    VirtualProtect(pAddr, Size, PAGE_EXECUTE_READWRITE, &oldAccess);
+#else /// Linux/ Mac
+    size_t Addr = (size_t)pAddr;
+    long pageMask = sysconf(_SC_PAGESIZE) - 1;
+    size_t Begin = Addr & ~pageMask; /// Would turn '0xABC777AB' into '0xABC77000'.
+    size_t End = (Addr + Size + pageMask) & ~pageMask; /// Would turn '0xABC777AB' into '0xABC78000', '0xABC79000', ...
+    mprotect((void*)Begin, End - Begin /** 0x1000(4096), 0x2000(8192), ... */, PROT_READ | PROT_WRITE | PROT_EXEC);
+#endif
+}
+
 static bool ClientKill_wasAlive;
 
 void ClientKill(edict_t *pEntity)
@@ -155,12 +190,88 @@ void ClientKill_Post(edict_t *pEntity)
 	RETURN_META(MRES_IGNORED);
 }
 
+void SetClientKeyValue(int playerIdx, char* pInfoBuffer, const char* pcszKey, const char* pcszValue)
+{ /// For bot CBasePlayer vtbl. hooking (i.e. CZ Bots).
+    if (false == g_virtualCfg || g_ppvtbl_CBasePlayer_Bots)
+    {
+        RETURN_META(MRES_IGNORED);
+    }
+	edict_t* pPlayer = MF_GetPlayerEdict(playerIdx);
+    if (!(pPlayer->v.flags & FL_FAKECLIENT))
+    {
+        RETURN_META(MRES_IGNORED);
+    }
+    const char* pcszAuth = GETPLAYERAUTHID(pPlayer); 	 
+    if (!pcszAuth || '\0' == *pcszAuth || strcmp(pcszAuth, "BOT") ||
+        strcmp(pcszKey, "*bot") || strcmp(pcszValue, "1"))
+    {
+        RETURN_META(MRES_IGNORED);
+    }
+    const unsigned char* pBase = (unsigned char*)pPlayer->pvPrivateData;
+    if (!pBase)
+    {
+        RETURN_META(MRES_IGNORED);
+    }
+	g_ppvtbl_CBasePlayer_Bots = *((size_t***) (pBase + g_ofsBaseclass));
+    if (!g_ppvtbl_CBasePlayer_Bots)
+    {
+        RETURN_META(MRES_IGNORED);
+    }
+    /// Assign original vf. addr. only once.
+    if (!g_origTraceAttack_Bots)
+        g_origTraceAttack_Bots = (TraceAttack_Type)g_ppvtbl_CBasePlayer_Bots[g_vfidxTraceAttack];
+    if (!g_origTakeDamage_Bots)
+        g_origTakeDamage_Bots = (TakeDamage_Type)g_ppvtbl_CBasePlayer_Bots[g_vfidxTakeDamage];
+    allowFullMemAccess(&g_ppvtbl_CBasePlayer_Bots[g_vfidxTraceAttack], sizeof(size_t*));
+    allowFullMemAccess(&g_ppvtbl_CBasePlayer_Bots[g_vfidxTakeDamage], sizeof(size_t*));
+    g_ppvtbl_CBasePlayer_Bots[g_vfidxTraceAttack] = (size_t*)Hook_TraceAttack_Bots;
+    g_ppvtbl_CBasePlayer_Bots[g_vfidxTakeDamage] = (size_t*)Hook_TakeDamage_Bots;
+	RETURN_META(MRES_IGNORED);
+}
+
 void ServerActivate_Post( edict_t *pEdictList, int edictCount, int clientMax ){
 
 	rankBots = (int)csstats_rankbots->value ? true:false;
 
 	for( int i = 1; i <= gpGlobals->maxClients; ++i)
 		GET_PLAYER_POINTER_I(i)->Init( i , pEdictList + i );
+
+    g_pEdictList = pEdictList;
+
+    /// For human CBasePlayer vtbl. hooking.
+    if (false == g_virtualCfg || g_ppvtbl_CBasePlayer)
+    {
+        RETURN_META(MRES_IGNORED);
+    }
+    edict_t* pPlayer = CREATE_ENTITY();
+    if (!pPlayer)
+    {
+        RETURN_META(MRES_IGNORED);
+    }
+    CALL_GAME_ENTITY(PLID, "player", &pPlayer->v);
+    const unsigned char* pBase = (unsigned char*)pPlayer->pvPrivateData;
+    if (!pBase)
+    {
+        REMOVE_ENTITY(pPlayer);
+        RETURN_META(MRES_IGNORED);
+    }
+	g_ppvtbl_CBasePlayer = *((size_t***) (pBase + g_ofsBaseclass));
+    if (!g_ppvtbl_CBasePlayer)
+    {
+        REMOVE_ENTITY(pPlayer); /// Also frees pvPrivateData.
+        RETURN_META(MRES_IGNORED);
+    }
+    /// Assign original vf. addr. only once.
+    if (!g_origTraceAttack)
+        g_origTraceAttack = (TraceAttack_Type)g_ppvtbl_CBasePlayer[g_vfidxTraceAttack];
+    if (!g_origTakeDamage)
+        g_origTakeDamage = (TakeDamage_Type)g_ppvtbl_CBasePlayer[g_vfidxTakeDamage];
+    allowFullMemAccess(&g_ppvtbl_CBasePlayer[g_vfidxTraceAttack], sizeof(size_t*));
+    allowFullMemAccess(&g_ppvtbl_CBasePlayer[g_vfidxTakeDamage], sizeof(size_t*));
+    g_ppvtbl_CBasePlayer[g_vfidxTraceAttack] = (size_t*)Hook_TraceAttack;
+    g_ppvtbl_CBasePlayer[g_vfidxTakeDamage] = (size_t*)Hook_TakeDamage;
+    REMOVE_ENTITY(pPlayer); /// Also frees pvPrivateData.
+
 	RETURN_META(MRES_IGNORED);
 }
 
@@ -181,6 +292,92 @@ void PlayerPreThink_Post( edict_t *pEntity ) {
 		}
 	}
 	RETURN_META(MRES_IGNORED);
+}
+
+#if defined(WIN32) || defined(_WINDOWS)
+void __fastcall Hook_TraceAttack(void* pThis, void* /** ignored */, entvars_s* pAtk, float Dmg, Vector Dir, TraceResult* pRes, int dmgType)
+#else
+void Hook_TraceAttack(void* pThis, entvars_s* pAtk, float Dmg, Vector Dir, TraceResult* pRes, int dmgType)
+#endif
+{
+    g_origTraceAttack(pThis, pAtk, Dmg, Dir, pRes, dmgType);
+    if (!pAtk)
+        return;
+    edict_t* pAtkEntity = pAtk->pContainingEntity;
+    if (!pAtkEntity || pAtkEntity->v.deadflag || pAtkEntity->v.health <= 0.f)
+        return;
+    int atkEntity = F_EToI(pAtkEntity);
+    if (atkEntity < 1 || atkEntity > gpGlobals->maxClients)
+        return;
+    CPlayer* pAtkPlayer = GET_PLAYER_POINTER(pAtkEntity);
+    if (!pAtkPlayer)
+        return;
+    pAtkPlayer->current_atk = pAtkPlayer->current; // Attacker attacked with this weapon last time.
+}
+
+#if defined(WIN32) || defined(_WINDOWS)
+int __fastcall Hook_TakeDamage(void* pThis, void* /** ignored */, entvars_s* pInflictor, entvars_s* pAtk, float Dmg, int dmgType)
+#else
+int Hook_TakeDamage(void* pThis, entvars_s* pInflictor, entvars_s* pAtk, float Dmg, int dmgType)
+#endif
+{
+    int Res = g_origTakeDamage(pThis, pInflictor, pAtk, Dmg, dmgType);
+    if (!pAtk)
+        return Res;
+    edict_t* pAtkEntity = pAtk->pContainingEntity;
+    if (!pAtkEntity || pAtkEntity->v.deadflag || pAtkEntity->v.health <= 0.f)
+        return Res;
+    int atkEntity = F_EToI(pAtkEntity);
+    if (atkEntity < 1 || atkEntity > gpGlobals->maxClients)
+        return Res;
+    CPlayer* pAtkPlayer = GET_PLAYER_POINTER(pAtkEntity);
+    if (!pAtkPlayer)
+        return Res;
+    pAtkPlayer->current_atk = pAtkPlayer->current; // Attacker attacked with this weapon last time.
+    return Res;
+}
+
+#if defined(WIN32) || defined(_WINDOWS)
+void __fastcall Hook_TraceAttack_Bots(void* pThis, void* /** ignored */, entvars_s* pAtk, float Dmg, Vector Dir, TraceResult* pRes, int dmgType)
+#else
+void Hook_TraceAttack_Bots(void* pThis, entvars_s* pAtk, float Dmg, Vector Dir, TraceResult* pRes, int dmgType)
+#endif
+{
+    g_origTraceAttack_Bots(pThis, pAtk, Dmg, Dir, pRes, dmgType);
+    if (!pAtk)
+        return;
+    edict_t* pAtkEntity = pAtk->pContainingEntity;
+    if (!pAtkEntity || pAtkEntity->v.deadflag || pAtkEntity->v.health <= 0.f)
+        return;
+    int atkEntity = F_EToI(pAtkEntity);
+    if (atkEntity < 1 || atkEntity > gpGlobals->maxClients)
+        return;
+    CPlayer* pAtkPlayer = GET_PLAYER_POINTER(pAtkEntity);
+    if (!pAtkPlayer)
+        return;
+    pAtkPlayer->current_atk = pAtkPlayer->current; // Attacker attacked with this weapon last time.
+}
+
+#if defined(WIN32) || defined(_WINDOWS)
+int __fastcall Hook_TakeDamage_Bots(void* pThis, void* /** ignored */, entvars_s* pInflictor, entvars_s* pAtk, float Dmg, int dmgType)
+#else
+int Hook_TakeDamage_Bots(void* pThis, entvars_s* pInflictor, entvars_s* pAtk, float Dmg, int dmgType)
+#endif
+{
+    int Res = g_origTakeDamage_Bots(pThis, pInflictor, pAtk, Dmg, dmgType);
+    if (!pAtk)
+        return Res;
+    edict_t* pAtkEntity = pAtk->pContainingEntity;
+    if (!pAtkEntity || pAtkEntity->v.deadflag || pAtkEntity->v.health <= 0.f)
+        return Res;
+    int atkEntity = F_EToI(pAtkEntity);
+    if (atkEntity < 1 || atkEntity > gpGlobals->maxClients)
+        return Res;
+    CPlayer* pAtkPlayer = GET_PLAYER_POINTER(pAtkEntity);
+    if (!pAtkPlayer)
+        return Res;
+    pAtkPlayer->current_atk = pAtkPlayer->current; // Attacker attacked with this weapon last time.
+    return Res;
 }
 
 void ServerDeactivate() 
@@ -375,7 +572,7 @@ void SetModel_Post(edict_t *e, const char *m){
 void EmitSound_Post(edict_t *entity, int channel, const char *sample, /*int*/float volume, float attenuation, int fFlags, int pitch) {
 	if (sample[0]=='w'&&sample[1]=='e'&&sample[8]=='k'&&sample[9]=='n'&&sample[14]!='d'){
 		CPlayer*pPlayer = GET_PLAYER_POINTER(entity);
-		pPlayer->saveShot(pPlayer->current);
+		pPlayer->saveShot(CSW_KNIFE); /// Player attacks using their knife.
 	}
 	RETURN_META(MRES_IGNORED);
 }
@@ -430,6 +627,25 @@ void OnAmxxAttach(){
 			m_LastHitGroup = ofs.fieldOffset;
         if (m_LastHitGroup < 1)
             MF_Log("Could not read CBaseMonster::m_LastHitGroup ofs.");
+
+        if (CommonConfig->GetOffset("base", &ofs))
+        {
+            g_ofsBaseclass = ofs.fieldOffset;
+
+            if (CommonConfig->GetOffset("traceattack", &ofs))
+            {
+                g_vfidxTraceAttack = ofs.fieldOffset;
+
+                if (CommonConfig->GetOffset("takedamage", &ofs))
+                {
+                    g_vfidxTakeDamage = ofs.fieldOffset;
+                    g_virtualCfg = true; /// Virtual cfg. successfully loaded.
+                }
+            }
+        }
+
+        if (false == g_virtualCfg)
+            MF_Log("Could not read virtual data from common.games gamedata.");
 	}
 
 	const char* path =  get_localinfo("csstats_score");
@@ -447,6 +663,32 @@ void OnAmxxDetach() {
 	g_grenades.clear();
 	g_rank.clear();
 	g_rank.unloadCalc();
+
+    /**
+     * Restore orig. vfunc. addr. on module detach.
+     */
+    if (g_origTraceAttack)
+    {
+        allowFullMemAccess(&g_ppvtbl_CBasePlayer[g_vfidxTraceAttack], sizeof(size_t*));
+        g_ppvtbl_CBasePlayer[g_vfidxTraceAttack] = (size_t*)g_origTraceAttack;
+    }
+    if (g_origTakeDamage)
+    {
+        allowFullMemAccess(&g_ppvtbl_CBasePlayer[g_vfidxTakeDamage], sizeof(size_t*));
+        g_ppvtbl_CBasePlayer[g_vfidxTakeDamage] = (size_t*)g_origTakeDamage;
+    }
+
+    if (g_origTraceAttack_Bots)
+    {
+        allowFullMemAccess(&g_ppvtbl_CBasePlayer_Bots[g_vfidxTraceAttack], sizeof(size_t*));
+        g_ppvtbl_CBasePlayer_Bots[g_vfidxTraceAttack] = (size_t*)g_origTraceAttack_Bots;
+    }
+    if (g_origTakeDamage_Bots)
+    {
+        allowFullMemAccess(&g_ppvtbl_CBasePlayer_Bots[g_vfidxTakeDamage], sizeof(size_t*));
+        g_ppvtbl_CBasePlayer_Bots[g_vfidxTakeDamage] = (size_t*)g_origTakeDamage_Bots;
+    }
+
     if (CommonConfig)
         ConfigManager->CloseGameConfigFile(CommonConfig);
 }

--- a/modules/cstrike/csx/moduleconfig.h
+++ b/modules/cstrike/csx/moduleconfig.h
@@ -315,7 +315,7 @@
 // #define FN_GetInfoKeyBuffer					GetInfoKeyBuffer
 // #define FN_InfoKeyValue						InfoKeyValue
 // #define FN_SetKeyValue						SetKeyValue
-// #define FN_SetClientKeyValue					SetClientKeyValue
+#define FN_SetClientKeyValue					SetClientKeyValue
 // #define FN_IsMapValid						IsMapValid
 // #define FN_StaticDecal						StaticDecal
 // #define FN_PrecacheGeneric					PrecacheGeneric

--- a/modules/cstrike/csx/rank.h
+++ b/modules/cstrike/csx/rank.h
@@ -18,6 +18,9 @@
 #include "CMisc.h"
 #include "CRank.h"
 
+/// safe to use after ServerActive_Post() execution
+#define F_EToI(e)               ((int) (e - g_pEdictList))
+
 #define GET_PLAYER_POINTER(e)   (&players[ENTINDEX(e)])
 #define GET_PLAYER_POINTER_I(i) (&players[i])
 
@@ -30,6 +33,43 @@ struct weaponsVault {
   bool used;
   bool melee;
 };
+
+extern size_t** g_ppvtbl_CBasePlayer;
+extern size_t** g_ppvtbl_CBasePlayer_Bots;
+
+extern size_t g_ofsBaseclass; /// "base"
+extern size_t g_vfidxTraceAttack; /// "traceattack"
+extern size_t g_vfidxTakeDamage; /// "takedamage"
+
+extern bool g_virtualCfg;
+
+#if defined(WIN32) || defined(_WINDOWS) /// Windows
+typedef void (__thiscall* TraceAttack_Type) (void* pThis, entvars_s* pAtk, float Dmg, Vector Dir, TraceResult* pRes, int dmgType);
+typedef int (__thiscall* TakeDamage_Type) (void* pThis, entvars_s* pInflictor, entvars_s* pAtk, float Dmg, int dmgType);
+
+void __fastcall Hook_TraceAttack(void* pThis, void* /** ignored */, entvars_s* pAtk, float Dmg, Vector Dir, TraceResult* pRes, int dmgType);
+int __fastcall Hook_TakeDamage(void* pThis, void* /** ignored */, entvars_s* pInflictor, entvars_s* pAtk, float Dmg, int dmgType);
+
+void __fastcall Hook_TraceAttack_Bots(void* pThis, void* /** ignored */, entvars_s* pAtk, float Dmg, Vector Dir, TraceResult* pRes, int dmgType);
+int __fastcall Hook_TakeDamage_Bots(void* pThis, void* /** ignored */, entvars_s* pInflictor, entvars_s* pAtk, float Dmg, int dmgType);
+#else /// Linux/ Mac
+typedef void (*TraceAttack_Type) (void* pThis, entvars_s* pAtk, float Dmg, Vector Dir, TraceResult* pRes, int dmgType);
+typedef int (*TakeDamage_Type) (void* pThis, entvars_s* pInflictor, entvars_s* pAtk, float Dmg, int dmgType);
+
+void Hook_TraceAttack(void* pThis, entvars_s* pAtk, float Dmg, Vector Dir, TraceResult* pRes, int dmgType);
+int Hook_TakeDamage(void* pThis, entvars_s* pInflictor, entvars_s* pAtk, float Dmg, int dmgType);
+
+void Hook_TraceAttack_Bots(void* pThis, entvars_s* pAtk, float Dmg, Vector Dir, TraceResult* pRes, int dmgType);
+int Hook_TakeDamage_Bots(void* pThis, entvars_s* pInflictor, entvars_s* pAtk, float Dmg, int dmgType);
+#endif
+
+extern TraceAttack_Type g_origTraceAttack;
+extern TakeDamage_Type g_origTakeDamage;
+
+extern TraceAttack_Type g_origTraceAttack_Bots;
+extern TakeDamage_Type g_origTakeDamage_Bots;
+
+extern edict_t* g_pEdictList; /// from ServerActive_Post()
 
 extern bool rankBots;
 extern cvar_t* csstats_rankbots;
@@ -110,6 +150,7 @@ void Client_DeathMsg(void*);
 
 bool ignoreBots (edict_t *pEnt, edict_t *pOther = NULL );
 bool isModuleActive();
+void allowFullMemAccess(void* pAddr, size_t Size); /// cross-platform
 
 #define CHECK_ENTITY(x) \
 	if (x < 0 || x > gpGlobals->maxEntities) { \

--- a/modules/cstrike/csx/rank.h
+++ b/modules/cstrike/csx/rank.h
@@ -35,6 +35,8 @@ extern bool rankBots;
 extern cvar_t* csstats_rankbots;
 extern cvar_t* csstats_pause;
 
+extern size_t m_LastHitGroup;
+
 extern int iFGrenade;
 extern int iFDeath;
 extern int iFDamage;

--- a/modules/cstrike/csx/usermsg.cpp
+++ b/modules/cstrike/csx/usermsg.cpp
@@ -33,37 +33,17 @@ void Client_ResetHUD(void* mValue){
 void Client_DeathMsg(void *mValue)
 {
 	static int killer_id;
-	//static int victim_id;
-	static int is_headshot;
-	const char *name;
 
 	switch (mState++)
 	{
 	case 0:
-		{
-			killer_id = *(int *)mValue;
-			break;
-		}
-	//case 1:
-	//	{
-	//		victim_id = *(int *)mValue;
-	//		break;
-	//	}
+		killer_id = *(int *)mValue;
+		break;
 	case 2:
+		if (killer_id && *(int *)mValue)
 		{
-			is_headshot = *(int *)mValue;
-			break;
-		}
-	case 3:
-		{
-			name = (const char *)mValue;
-			if (killer_id 
-				&& (strcmp(name, "knife") == 0))
-			{
-				CPlayer *pPlayer = GET_PLAYER_POINTER_I(killer_id);
-				pPlayer->aiming = is_headshot ? 1 : 0;
-			}
-			break;
+			CPlayer *pPlayer = GET_PLAYER_POINTER_I(killer_id);
+			pPlayer->aiming = 1;
 		}
 	}
 }
@@ -130,9 +110,21 @@ void Client_Damage(void* mValue){
 	if (enemy->v.flags & (FL_CLIENT | FL_FAKECLIENT) ) {
 		pAttacker = GET_PLAYER_POINTER(enemy);
 		aim = pAttacker->aiming;
+		if (m_LastHitGroup > 0)
+		{
+			const unsigned char* pBase = (unsigned char*)mPlayer->pEdict->pvPrivateData;
+			if (pBase)
+				aim = *(int*)(pBase + m_LastHitGroup);
+		}
 		weapon = pAttacker->current;
 		pAttacker->saveHit( mPlayer , weapon , damage, aim);
 		break;
+	}
+	if (m_LastHitGroup > 0)
+	{
+		const unsigned char* pBase = (unsigned char*)mPlayer->pEdict->pvPrivateData;
+		if (pBase)
+			aim = *(int*)(pBase + m_LastHitGroup);
 	}
     if( g_grenades.find(enemy , &pAttacker , &weapon ) )
         pAttacker->saveHit( mPlayer , weapon , damage, aim );

--- a/modules/cstrike/csx/usermsg.cpp
+++ b/modules/cstrike/csx/usermsg.cpp
@@ -107,7 +107,15 @@ void Client_Damage(void* mValue){
 	weapon = 0;
 	pAttacker = NULL;
 
-	if (enemy->v.flags & (FL_CLIENT | FL_FAKECLIENT) ) {
+	//if (enemy->v.flags & (FL_CLIENT | FL_FAKECLIENT)) {
+    /**
+     * When attacker/ killer gets kicked by the server while dealing damage to/ killing
+     * others, allow CSX module show the damage/ kill as a normal damage/ kill event
+     * (otherwise, by using the condition above, attacker's/ killer's victim will be
+     * recognized as they dealt damage to themselves/ commit suicide instead).
+     */
+    int enemyIdx = F_EToI(enemy);
+    if (enemyIdx > 0 && enemyIdx <= gpGlobals->maxClients) {
 		pAttacker = GET_PLAYER_POINTER(enemy);
 		aim = pAttacker->aiming;
 		if (m_LastHitGroup > 0)
@@ -116,7 +124,11 @@ void Client_Damage(void* mValue){
 			if (pBase)
 				aim = *(int*)(pBase + m_LastHitGroup);
 		}
-		weapon = pAttacker->current;
+        /// If traceattack and takedamage vfuncs. hooked, use weaponidx from these calls
+        /// rather than the one originating from UpdateClientData() (the moment when
+        /// gmsgDamage is sent in CS/ CZ); fixes when killer presses Q (lastinv) shortly
+        /// after killing their victim (won't show knife kills instead of awp kills anymore).
+		weapon = g_virtualCfg ? pAttacker->current_atk : pAttacker->current;
 		pAttacker->saveHit( mPlayer , weapon , damage, aim);
 		break;
 	}
@@ -129,7 +141,7 @@ void Client_Damage(void* mValue){
     if( g_grenades.find(enemy , &pAttacker , &weapon ) )
         pAttacker->saveHit( mPlayer , weapon , damage, aim );
 	else if ( strcmp("grenade",STRING(enemy->v.classname))==0 ) // ? more checks ?
-			weapon = CSW_C4;
+			weapon = CSW_C4; /// tested and works (victims are taken as suiciding with c4)
   }
 }
 


### PR DESCRIPTION
- Fix **CSX** module hitgroup detection. Use ofs. from gamedata dir.
- Fix when attacker/ killer quickly presses **Q** key (`lastinv` cmd.) and **CSX** tells the plugins a different weapon was used to cause damage/ to kill (as `Damage` msg. is sent in `UpdateClientData()` in **CS**/ **CZ** case [instead of `TraceAttack()` - **DoD**'s case]).
- Fix when attacker disconnects/ gets kicked during the attack and **CSX** tells plugins that the victim committed suicide rather than being killed by a different player on the server.