### PR TITLE
Fix debug info limits in amxxpc and speed up the compiler

### DIFF
--- a/amxmodx/amxdbg.cpp
+++ b/amxmodx/amxdbg.cpp
@@ -61,34 +61,55 @@ void memread(void *dest, char **src, size_t size)
 	*src += size;
 }
 
-const char *ClipFileName(const char *inp)
+static int ValidateCount(int count, size_t element_size, const unsigned char *ptr, const unsigned char *end)
 {
-	static char buffer[256];
+	if (count < 0)
+		return AMX_ERR_FORMAT;
+
+	if ((size_t)count > (size_t)(end - ptr) / element_size)
+		return AMX_ERR_FORMAT;
+
+	return AMX_ERR_NONE;
+}
+
+static unsigned char *FindStringEnd(unsigned char *ptr, const unsigned char *end)
+{
+	while (ptr < end && *ptr != '\0')
+		ptr++;
+
+	return (ptr < end) ? ptr : NULL;
+}
+
+static void ClipFileNameInPlace(char *inp)
+{
 	size_t len = strlen(inp);
-	const char *ptr = inp;
+	char *ptr = inp;
 
 	for (size_t i=0; i<len; i++)
 	{
 		if ((inp[i] == '\\' || inp[i] == '/') && (i != len-1))
 			ptr = inp + i + 1;
 	}
-	strcpy(buffer, ptr);
 
-	return buffer;
+	memmove(inp, ptr, strlen(ptr) + 1);
 }
 
 //Note - I changed this function to read from memory instead.
 // -- BAILOPAN
-int AMXAPI dbg_LoadInfo(AMX_DBG *amxdbg, void *dbg_addr)
+int AMXAPI dbg_LoadInfo(AMX_DBG *amxdbg, void *dbg_addr, size_t dbg_size)
 {
   AMX_DBG_HDR dbghdr;
   unsigned char *ptr;
+  unsigned char *end;
   int index, dim;
   AMX_DBG_SYMDIM *symdim;
 
   assert(amxdbg != NULL);
 
   char *addr = (char *)(dbg_addr);
+
+  if (dbg_addr == NULL || dbg_size < sizeof(AMX_DBG_HDR))
+    return AMX_ERR_FORMAT;
 
   memset(&dbghdr, 0, sizeof(AMX_DBG_HDR));
   memread(&dbghdr, &addr, sizeof(AMX_DBG_HDR));
@@ -107,6 +128,11 @@ int AMXAPI dbg_LoadInfo(AMX_DBG *amxdbg, void *dbg_addr)
   #endif
 
   if (dbghdr.magic != AMX_DBG_MAGIC)
+    return AMX_ERR_FORMAT;
+  if (dbghdr.size < (int32_t)sizeof(AMX_DBG_HDR) || (size_t)dbghdr.size > dbg_size)
+    return AMX_ERR_FORMAT;
+  if (dbghdr.files < 0 || dbghdr.lines < 0 || dbghdr.symbols < 0 || dbghdr.tags < 0
+      || dbghdr.automatons < 0 || dbghdr.states < 0)
     return AMX_ERR_FORMAT;
 
   /* allocate all memory */
@@ -137,27 +163,33 @@ int AMXAPI dbg_LoadInfo(AMX_DBG *amxdbg, void *dbg_addr)
   memcpy(amxdbg->hdr, &dbghdr, sizeof dbghdr);
   ptr = (unsigned char *)(amxdbg->hdr + 1);
   memread(ptr, &addr, (size_t)(dbghdr.size-sizeof(dbghdr)));
+  end = (unsigned char *)amxdbg->hdr + dbghdr.size;
 
   /* file table */
   for (index = 0; index < dbghdr.files; index++) {
     assert(amxdbg->filetbl != NULL);
+    if (ptr + sizeof(AMX_DBG_FILE) > end)
+      goto invalid_debug_info;
     amxdbg->filetbl[index] = (AMX_DBG_FILE *)ptr;
     #if BYTE_ORDER==BIG_ENDIAN
       amx_AlignCell(&amxdbg->filetbl[index]->address);
     #endif
-    for (ptr = ptr + sizeof(AMX_DBG_FILE); *ptr != '\0'; ptr++)
-      /* nothing */;
+    ptr = FindStringEnd(ptr + sizeof(AMX_DBG_FILE), end);
+    if (ptr == NULL)
+      goto invalid_debug_info;
     ptr++;              /* skip '\0' too */
   } /* for */
 
   //debug("Files: %d\n", amxdbg->hdr->files);
   for (index=0;index<amxdbg->hdr->files; index++)
   {
-	  strcpy((char *)amxdbg->filetbl[index]->name, ClipFileName(amxdbg->filetbl[index]->name));
+	  ClipFileNameInPlace((char *)amxdbg->filetbl[index]->name);
 	  //debug(" [%d] %s\n", index, amxdbg->filetbl[index]->name);
   }
 
   /* line table */
+  if (ValidateCount(dbghdr.lines, sizeof(AMX_DBG_LINE), ptr, end) != AMX_ERR_NONE)
+    goto invalid_debug_info;
   amxdbg->linetbl = (AMX_DBG_LINE*)ptr;
   #if BYTE_ORDER==BIG_ENDIAN
     for (index = 0; index < dbghdr.lines; index++) {
@@ -170,6 +202,8 @@ int AMXAPI dbg_LoadInfo(AMX_DBG *amxdbg, void *dbg_addr)
   /* symbol table (plus index tags) */
   for (index = 0; index < dbghdr.symbols; index++) {
     assert(amxdbg->symboltbl != NULL);
+    if (ptr + sizeof(AMX_DBG_SYMBOL) > end)
+      goto invalid_debug_info;
     amxdbg->symboltbl[index] = (AMX_DBG_SYMBOL *)ptr;
     #if BYTE_ORDER==BIG_ENDIAN
       amx_AlignCell(&amxdbg->symboltbl[index]->address);
@@ -178,9 +212,14 @@ int AMXAPI dbg_LoadInfo(AMX_DBG *amxdbg, void *dbg_addr)
       amx_AlignCell(&amxdbg->symboltbl[index]->codeend);
       amx_Align16((uint16_t*)&amxdbg->symboltbl[index]->dim);
     #endif
-    for (ptr = ptr + sizeof(AMX_DBG_SYMBOL); *ptr != '\0'; ptr++)
-      /* nothing */;
+    ptr = FindStringEnd(ptr + sizeof(AMX_DBG_SYMBOL), end);
+    if (ptr == NULL)
+      goto invalid_debug_info;
     ptr++;              /* skip '\0' too */
+    if (amxdbg->symboltbl[index]->dim < 0)
+      goto invalid_debug_info;
+    if (ValidateCount(amxdbg->symboltbl[index]->dim, sizeof(AMX_DBG_SYMDIM), ptr, end) != AMX_ERR_NONE)
+      goto invalid_debug_info;
     for (dim = 0; dim < amxdbg->symboltbl[index]->dim; dim++) {
       symdim = (AMX_DBG_SYMDIM *)ptr;
       amx_Align16((uint16_t*)&symdim->tag);
@@ -192,42 +231,58 @@ int AMXAPI dbg_LoadInfo(AMX_DBG *amxdbg, void *dbg_addr)
   /* tag name table */
   for (index = 0; index < dbghdr.tags; index++) {
     assert(amxdbg->tagtbl != NULL);
+    if (ptr + sizeof(AMX_DBG_TAG) > end)
+      goto invalid_debug_info;
     amxdbg->tagtbl[index] = (AMX_DBG_TAG *)ptr;
     #if BYTE_ORDER==BIG_ENDIAN
       amx_Align16(&amxdbg->tagtbl[index]->tag);
     #endif
-    for (ptr = ptr + sizeof(AMX_DBG_TAG) - 1; *ptr != '\0'; ptr++)
-      /* nothing */;
+    ptr = FindStringEnd(ptr + sizeof(AMX_DBG_TAG) - 1, end);
+    if (ptr == NULL)
+      goto invalid_debug_info;
     ptr++;              /* skip '\0' too */
   } /* for */
 
   /* automaton name table */
   for (index = 0; index < dbghdr.automatons; index++) {
     assert(amxdbg->automatontbl != NULL);
+    if (ptr + sizeof(AMX_DBG_MACHINE) > end)
+      goto invalid_debug_info;
     amxdbg->automatontbl[index] = (AMX_DBG_MACHINE *)ptr;
     #if BYTE_ORDER==BIG_ENDIAN
       amx_Align16(&amxdbg->automatontbl[index]->automaton);
       amx_AlignCell(&amxdbg->automatontbl[index]->address);
     #endif
-    for (ptr = ptr + sizeof(AMX_DBG_MACHINE) - 1; *ptr != '\0'; ptr++)
-      /* nothing */;
+    ptr = FindStringEnd(ptr + sizeof(AMX_DBG_MACHINE) - 1, end);
+    if (ptr == NULL)
+      goto invalid_debug_info;
     ptr++;              /* skip '\0' too */
   } /* for */
 
   /* state name table */
   for (index = 0; index < dbghdr.states; index++) {
     assert(amxdbg->statetbl != NULL);
+    if (ptr + sizeof(AMX_DBG_STATE) > end)
+      goto invalid_debug_info;
     amxdbg->statetbl[index] = (AMX_DBG_STATE *)ptr;
     #if BYTE_ORDER==BIG_ENDIAN
       amx_Align16(&amxdbg->statetbl[index]->state);
-      amx_Align16(&amxdbg->automatontbl[index]->automaton);
+      amx_Align16(&amxdbg->statetbl[index]->automaton);
     #endif
-    for (ptr = ptr + sizeof(AMX_DBG_STATE) - 1; *ptr != '\0'; ptr++)
-      /* nothing */;
+    ptr = FindStringEnd(ptr + sizeof(AMX_DBG_STATE) - 1, end);
+    if (ptr == NULL)
+      goto invalid_debug_info;
     ptr++;              /* skip '\0' too */
   } /* for */
 
+  if (ptr > end)
+    goto invalid_debug_info;
+
   return AMX_ERR_NONE;
+
+invalid_debug_info:
+  dbg_FreeInfo(amxdbg);
+  return AMX_ERR_FORMAT;
 }
 
 int AMXAPI dbg_LookupFile(AMX_DBG *amxdbg, ucell address, const char **filename)

--- a/amxmodx/amxdbg.cpp
+++ b/amxmodx/amxdbg.cpp
@@ -119,12 +119,12 @@ int AMXAPI dbg_LoadInfo(AMX_DBG *amxdbg, void *dbg_addr, size_t dbg_size)
     amx_Align32((uint32_t*)&dbghdr.size);
     amx_Align16(&dbghdr.magic);
     amx_Align16(&dbghdr.flags);
-    amx_Align16(&dbghdr.files);
-    amx_Align16(&dbghdr.lines);
-    amx_Align16(&dbghdr.symbols);
-    amx_Align16(&dbghdr.tags);
-    amx_Align16(&dbghdr.automatons);
-    amx_Align16(&dbghdr.states);
+    amx_Align32((uint32_t*)&dbghdr.files);
+    amx_Align32((uint32_t*)&dbghdr.lines);
+    amx_Align32((uint32_t*)&dbghdr.symbols);
+    amx_Align32((uint32_t*)&dbghdr.tags);
+    amx_Align32((uint32_t*)&dbghdr.automatons);
+    amx_Align32((uint32_t*)&dbghdr.states);
   #endif
 
   if (dbghdr.magic != AMX_DBG_MAGIC)

--- a/amxmodx/amxdbg.h
+++ b/amxmodx/amxdbg.h
@@ -67,14 +67,14 @@ typedef struct tagAMX_DBG_HDR {
   char    file_version;         /* file format version */
   char    amx_version;          /* required version of the AMX */
   int16_t flags         PACKED; /* currently unused */
-  int16_t files         PACKED; /* number of entries in the "file" table */
-  int16_t lines         PACKED; /* number of entries in the "line" table */
-  int16_t symbols       PACKED; /* number of entries in the "symbol" table */
-  int16_t tags          PACKED; /* number of entries in the "tag" table */
-  int16_t automatons    PACKED; /* number of entries in the "automaton" table */
-  int16_t states        PACKED; /* number of entries in the "state" table */
+  int32_t files         PACKED; /* number of entries in the "file" table */
+  int32_t lines         PACKED; /* number of entries in the "line" table */
+  int32_t symbols       PACKED; /* number of entries in the "symbol" table */
+  int32_t tags          PACKED; /* number of entries in the "tag" table */
+  int32_t automatons    PACKED; /* number of entries in the "automaton" table */
+  int32_t states        PACKED; /* number of entries in the "state" table */
 } PACKED AMX_DBG_HDR;
-#define AMX_DBG_MAGIC   0xf1ef
+#define AMX_DBG_MAGIC   0xf1f0  /* AMXX large-debug extension */
 
 typedef struct tagAMX_DBG_FILE {
   ucell   address       PACKED; /* address in the code segment where generated code (for this file) starts */

--- a/amxmodx/amxdbg.h
+++ b/amxmodx/amxdbg.h
@@ -28,6 +28,7 @@
 #ifndef AMX_H_INCLUDED
   #include "amx.h"
 #endif
+#include <stddef.h>
 
 #ifdef  __cplusplus
 extern  "C" {
@@ -138,7 +139,7 @@ typedef struct tagAMX_DBG {
 
 
 int AMXAPI dbg_FreeInfo(AMX_DBG *amxdbg);
-int AMXAPI dbg_LoadInfo(AMX_DBG *amxdbg, void *dbg_addr);
+int AMXAPI dbg_LoadInfo(AMX_DBG *amxdbg, void *dbg_addr, size_t dbg_size);
 
 int AMXAPI dbg_LookupFile(AMX_DBG *amxdbg, ucell address, const char **filename);
 int AMXAPI dbg_LookupFunction(AMX_DBG *amxdbg, ucell address, const char **funcname);

--- a/amxmodx/modules.cpp
+++ b/amxmodx/modules.cpp
@@ -200,10 +200,10 @@ int load_amxscript_internal(AMX *amx, void **program, const char *filename, char
 
 			if (hdr->size < 0 || static_cast<size_t>(hdr->size) >= bufSize)
 			{
-				delete[] *program;
+				delete[] (char *)*program;
 				*program = nullptr;
 				AMXXLOG_Log("[AMXX] Plugin \"%s\" has invalid debug data offset", filename);
-				return (amxx_DONTLOAD);
+				return (amx->error = AMX_ERR_FORMAT);
 			}
 
 			char *addr = (char *)hdr + hdr->size;

--- a/amxmodx/modules.cpp
+++ b/amxmodx/modules.cpp
@@ -198,12 +198,21 @@ int load_amxscript_internal(AMX *amx, void **program, const char *filename, char
 		{
 			will_be_debugged = true;
 
+			if (hdr->size < 0 || static_cast<size_t>(hdr->size) >= bufSize)
+			{
+				delete[] *program;
+				*program = nullptr;
+				AMXXLOG_Log("[AMXX] Plugin \"%s\" has invalid debug data offset", filename);
+				return (amxx_DONTLOAD);
+			}
+
 			char *addr = (char *)hdr + hdr->size;
+			size_t dbgSize = bufSize - static_cast<size_t>(hdr->size);
 			pDbg = new tagAMX_DBG;
 
 			memset(pDbg, 0, sizeof(AMX_DBG));
 
-			int err = dbg_LoadInfo(pDbg, addr);
+			int err = dbg_LoadInfo(pDbg, addr, dbgSize);
 
 			if (err != AMX_ERR_NONE)
 			{

--- a/compiler/amxxpc/amxdbg.h
+++ b/compiler/amxxpc/amxdbg.h
@@ -66,14 +66,14 @@ typedef struct tagAMX_DBG_HDR {
   char    file_version; 		/* file format version */
   char    amx_version; 			/* required version of the AMX */
   int16_t flags         PACKED; /* currently unused */
-  int16_t files         PACKED; /* number of entries in the "file" table */
-  int16_t lines         PACKED; /* number of entries in the "line" table */
-  int16_t symbols       PACKED; /* number of entries in the "symbol" table */
-  int16_t tags          PACKED; /* number of entries in the "tag" table */
-  int16_t automatons    PACKED; /* number of entries in the "automaton" table */
-  int16_t states        PACKED; /* number of entries in the "state" table */
+  int32_t files         PACKED; /* number of entries in the "file" table */
+  int32_t lines         PACKED; /* number of entries in the "line" table */
+  int32_t symbols       PACKED; /* number of entries in the "symbol" table */
+  int32_t tags          PACKED; /* number of entries in the "tag" table */
+  int32_t automatons    PACKED; /* number of entries in the "automaton" table */
+  int32_t states        PACKED; /* number of entries in the "state" table */
 } AMX_DBG_HDR;
-#define AMX_DBG_MAGIC   0xf1ef
+#define AMX_DBG_MAGIC   0xf1f0  /* AMXX large-debug extension */
 
 typedef struct tagAMX_DBG_FILE {
   ucell   address       PACKED; /* address in the code segment where generated code (for this file) starts */

--- a/compiler/libpc300/amxdbg.h
+++ b/compiler/libpc300/amxdbg.h
@@ -66,14 +66,14 @@ typedef struct tagAMX_DBG_HDR {
   char    file_version; 		/* file format version */
   char    amx_version; 			/* required version of the AMX */
   int16_t flags         PACKED; /* currently unused */
-  int16_t files         PACKED; /* number of entries in the "file" table */
-  int16_t lines         PACKED; /* number of entries in the "line" table */
-  int16_t symbols       PACKED; /* number of entries in the "symbol" table */
-  int16_t tags          PACKED; /* number of entries in the "tag" table */
-  int16_t automatons    PACKED; /* number of entries in the "automaton" table */
-  int16_t states        PACKED; /* number of entries in the "state" table */
+  int32_t files         PACKED; /* number of entries in the "file" table */
+  int32_t lines         PACKED; /* number of entries in the "line" table */
+  int32_t symbols       PACKED; /* number of entries in the "symbol" table */
+  int32_t tags          PACKED; /* number of entries in the "tag" table */
+  int32_t automatons    PACKED; /* number of entries in the "automaton" table */
+  int32_t states        PACKED; /* number of entries in the "state" table */
 } AMX_DBG_HDR;
-#define AMX_DBG_MAGIC   0xf1ef
+#define AMX_DBG_MAGIC   0xf1f0  /* AMXX large-debug extension */
 
 typedef struct tagAMX_DBG_FILE {
   ucell   address       PACKED; /* address in the code segment where generated code (for this file) starts */

--- a/compiler/libpc300/sc.h
+++ b/compiler/libpc300/sc.h
@@ -268,6 +268,7 @@ enum {
 
 typedef struct s_stringlist {
   struct s_stringlist *next;
+  struct s_stringlist *tail;
   char *line;
 } stringlist;
 

--- a/compiler/libpc300/sc.h
+++ b/compiler/libpc300/sc.h
@@ -714,6 +714,7 @@ SC_FUNC stringlist *insert_dbgfile(const char *filename);
 SC_FUNC stringlist *insert_dbgline(int linenr);
 SC_FUNC stringlist *insert_dbgsymbol(symbol *sym);
 SC_FUNC char *get_dbgstring(int index);
+SC_FUNC stringlist *get_dbgstring_next(stringlist *prev);
 SC_FUNC void delete_dbgstringtable(void);
 
 /* function prototypes in SCMEMFILE.C */

--- a/compiler/libpc300/sc.h
+++ b/compiler/libpc300/sc.h
@@ -706,6 +706,7 @@ SC_FUNC void delete_docstring(int index);
 SC_FUNC void delete_docstringtable(void);
 SC_FUNC stringlist *insert_autolist(char *string);
 SC_FUNC char *get_autolist(int index);
+SC_FUNC stringlist *get_autolist_next(stringlist *prev);
 SC_FUNC void delete_autolisttable(void);
 SC_FUNC valuepair *push_heaplist(long first, long second);
 SC_FUNC int popfront_heaplist(long *first, long *second);

--- a/compiler/libpc300/sc.h
+++ b/compiler/libpc300/sc.h
@@ -274,6 +274,7 @@ typedef struct s_stringlist {
 
 typedef struct s_stringpair {
   struct s_stringpair *next;
+  struct s_stringpair *hnext;   /* next entry in the substitution hash bucket */
   char *first;
   char *second;
   int matchlength;

--- a/compiler/libpc300/sc.h
+++ b/compiler/libpc300/sc.h
@@ -152,6 +152,11 @@ typedef struct s_symbol {
   struct s_symbol **refer;  /* referrer list, functions that "use" this symbol */
   int numrefers;        /* number of entries in the referrer list */
   char *documentation;  /* optional documentation string */
+  int has_child;        /* set (and never cleared) when a child symbol ever
+                         * points here; lets finddepend() skip the full table
+                         * scan for the overwhelmingly common childless case.
+                         * A stale TRUE only costs a scan; FALSE is reliable
+                         * because every parent assignment sets it. */
 } symbol;
 
 

--- a/compiler/libpc300/sc1.c
+++ b/compiler/libpc300/sc1.c
@@ -5631,7 +5631,7 @@ static void dostate(void)
   int islabel;
   symbol *sym;
   #if !defined SC_LIGHT
-    int length,index,listid,listindex,stateindex;
+    int length,listid,listindex,stateindex;
     char *doc;
   #endif
 
@@ -5722,8 +5722,8 @@ static void dostate(void)
       listindex=0;
       length=strlen(name)+70; /* +70 for the fixed part "<transition ... />\n" */
       /* see if there are any condition strings to attach */
-      for (index=0; (str=get_autolist(index))!=NULL; index++)
-        length+=strlen(str);
+      for (stringlist *item=get_autolist_next(NULL); item!=NULL; item=get_autolist_next(item))
+        length+=strlen(item->line);
       if ((doc=(char*)malloc(length*sizeof(char)))!=NULL) {
         do {
           sprintf(doc,"<transition target=\"%s\"",name);
@@ -5734,12 +5734,13 @@ static void dostate(void)
             assert(state!=NULL);
             sprintf(doc+strlen(doc)," source=\"%s\"",state->name);
           } /* if */
-          if (get_autolist(0)!=NULL) {
+          if (get_autolist_next(NULL)!=NULL) {
             /* add the condition */
             strcat(doc," condition=\"");
-            for (index=0; (str=get_autolist(index))!=NULL; index++) {
+            for (stringlist *item=get_autolist_next(NULL); item!=NULL; item=get_autolist_next(item)) {
+              str=item->line;
               /* remove the ')' token that may be appended before detecting that the expression has ended */
-              if (*str!=')' || *(str+1)!='\0' || get_autolist(index+1)!=NULL)
+              if (*str!=')' || *(str+1)!='\0' || get_autolist_next(item)!=NULL)
                 strcat(doc,str);
             } /* for */
             strcat(doc,"\"");

--- a/compiler/libpc300/sc1.c
+++ b/compiler/libpc300/sc1.c
@@ -2766,6 +2766,8 @@ static void decl_enum(int vclass)
     sym->dim.array.length=size;
     sym->dim.array.level=0;
     sym->parent=enumsym;
+    if (enumsym!=NULL)
+      enumsym->has_child=TRUE;
     /* add the constant to a separate list as well */
     if (enumroot!=NULL) {
       sym->usage |= uENUMFIELD;
@@ -3334,6 +3336,7 @@ static void funcstub(int native)
     assert(sym!=NULL);
     sub=addvariable(symbolname,0,iREFARRAY,sGLOBAL,tag,dim,numdim,idxtag);
     sub->parent=sym;
+    sym->has_child=TRUE;
   } /* if */
 
   litidx=0;                     /* clear the literal pool */
@@ -5507,6 +5510,7 @@ static void doreturn(void)
           /* nothing */;
         sub=addvariable(curfunc->name,(argcount+3)*sizeof(cell),iREFARRAY,sGLOBAL,curfunc->tag,dim,numdim,idxtag);
         sub->parent=curfunc;
+        curfunc->has_child=TRUE;
         /* Function that returns array can be used before it is defined, so at
          * the call point (if it is before definition) we may not know if this
          * function returns array and what is its size (for example inside the

--- a/compiler/libpc300/sc2.c
+++ b/compiler/libpc300/sc2.c
@@ -2794,7 +2794,7 @@ SC_FUNC void markusage(symbol *sym,int usage)
  */
 SC_FUNC symbol *findglb(const char *name)
 {
-  return find_symbol(&glbtab,name,fcurrent,FALSE);
+  return FindGlobalInHashTable(sp_Globals,name,fcurrent);
 }
 
 /*  findloc

--- a/compiler/libpc300/sc2.c
+++ b/compiler/libpc300/sc2.c
@@ -2825,6 +2825,12 @@ SC_FUNC symbol *finddepend(const symbol *parent)
 {
   symbol *sym;
 
+  /* the overwhelming majority of symbols never has children; skip the
+   * full table scans for those (a stale TRUE flag merely costs a scan)
+   */
+  if (!parent->has_child)
+    return NULL;
+
   sym=find_symbol_child(&loctab,parent);    /* try local symbols first */
   if (sym==NULL)                            /* not found */
     sym=find_symbol_child(&glbtab,parent);
@@ -2869,6 +2875,7 @@ SC_FUNC symbol *addsym(const char *name,cell addr,int ident,int vclass,int tag,i
   entry.numrefers=1;
   entry.refer=refer;
   entry.parent=NULL;
+  entry.has_child=FALSE;
   entry.fieldtag=0;
   entry.documentation=NULL;
 
@@ -2903,6 +2910,8 @@ SC_FUNC symbol *addvariable(const char *name,cell addr,int ident,int vclass,int 
       top->dim.array.level=(short)(numdim-level-1);
       top->x.idxtag=idxtag[level];
       top->parent=parent;
+      if (parent!=NULL)
+        parent->has_child=TRUE;
       parent=top;
       if (level==0)
         sym=top;

--- a/compiler/libpc300/sc6.c
+++ b/compiler/libpc300/sc6.c
@@ -53,18 +53,16 @@ static int debugerror;
 static int bytes_in, bytes_out;
 static jmp_buf compact_err;
 
-static int inc_dbg_count(int32_t *count)
-{
-  if (*count == 2147483647) {
-    error(102,"debug information");
-    debugerror=TRUE;
-    writeerror=TRUE;
-    return FALSE;
-  } /* if */
-
-  (*count)++;
-  return TRUE;
-}
+#define INC_DBG_COUNT(field)                                      \
+  do {                                                            \
+    if ((field) == 2147483647) {                                  \
+      error(102,"debug information");                             \
+      debugerror=TRUE;                                            \
+      writeerror=TRUE;                                            \
+      return;                                                     \
+    }                                                             \
+    (field)=(field)+1;                                            \
+  } while (0)
 
 /* apparently, strtol() does not work correctly on very large (unsigned)
  * hexadecimal values */
@@ -1005,8 +1003,7 @@ static void append_dbginfo(FILE *fout)
       if (codeidx!=previdx) {
         if (prevstr!=NULL) {
           assert(prevname!=NULL);
-          if (!inc_dbg_count(&dbghdr.files))
-            return;
+          INC_DBG_COUNT(dbghdr.files);
           dbghdr.size+=sizeof(cell)+strlen(prevname)+1;
         } /* if */
         previdx=codeidx;
@@ -1017,8 +1014,7 @@ static void append_dbginfo(FILE *fout)
   } /* for */
   if (prevstr!=NULL) {
     assert(prevname!=NULL);
-    if (!inc_dbg_count(&dbghdr.files))
-      return;
+    INC_DBG_COUNT(dbghdr.files);
     dbghdr.size+=sizeof(cell)+strlen(prevname)+1;
   } /* if */
 
@@ -1027,8 +1023,7 @@ static void append_dbginfo(FILE *fout)
     assert(str!=NULL);
     assert(str[0]!='\0' && str[1]==':');
     if (str[0]=='L') {
-      if (!inc_dbg_count(&dbghdr.lines))
-        return;
+      INC_DBG_COUNT(dbghdr.lines);
       dbghdr.size+=sizeof(AMX_DBG_LINE);
     } /* if */
   } /* for */
@@ -1038,8 +1033,7 @@ static void append_dbginfo(FILE *fout)
     assert(str!=NULL);
     assert(str[0]!='\0' && str[1]==':');
     if (str[0]=='S') {
-      if (!inc_dbg_count(&dbghdr.symbols))
-        return;
+      INC_DBG_COUNT(dbghdr.symbols);
       name=strchr(str+2,':');
       assert(name!=NULL);
       dbghdr.size+=sizeof(AMX_DBG_SYMBOL)+strlen(skipwhitespace(name+1));
@@ -1052,24 +1046,21 @@ static void append_dbginfo(FILE *fout)
   /* tag table */
   for (constptr=tagname_tab.next; constptr!=NULL; constptr=constptr->next) {
     assert(strlen(constptr->name)>0);
-    if (!inc_dbg_count(&dbghdr.tags))
-      return;
+    INC_DBG_COUNT(dbghdr.tags);
     dbghdr.size+=sizeof(AMX_DBG_TAG)+strlen(constptr->name);
   } /* for */
 
   /* automaton table */
   for (constptr=sc_automaton_tab.next; constptr!=NULL; constptr=constptr->next) {
     assert(constptr->index==0 && strlen(constptr->name)==0 || strlen(constptr->name)>0);
-    if (!inc_dbg_count(&dbghdr.automatons))
-      return;
+    INC_DBG_COUNT(dbghdr.automatons);
     dbghdr.size+=sizeof(AMX_DBG_MACHINE)+strlen(constptr->name);
   } /* for */
 
   /* state table */
   for (constptr=sc_state_tab.next; constptr!=NULL; constptr=constptr->next) {
     assert(strlen(constptr->name)>0);
-    if (!inc_dbg_count(&dbghdr.states))
-      return;
+    INC_DBG_COUNT(dbghdr.states);
     dbghdr.size+=sizeof(AMX_DBG_STATE)+strlen(constptr->name);
   } /* for */
 

--- a/compiler/libpc300/sc6.c
+++ b/compiler/libpc300/sc6.c
@@ -49,8 +49,22 @@ typedef struct {
 static cell codeindex;  /* similar to "code_idx" */
 static cell *lbltab;    /* label table */
 static int writeerror;
+static int debugerror;
 static int bytes_in, bytes_out;
 static jmp_buf compact_err;
+
+static int inc_dbg_count(int16_t *count)
+{
+  if (*count == 32767) {
+    error(102,"debug information");
+    debugerror=TRUE;
+    writeerror=TRUE;
+    return FALSE;
+  } /* if */
+
+  (*count)++;
+  return TRUE;
+}
 
 /* apparently, strtol() does not work correctly on very large (unsigned)
  * hexadecimal values */
@@ -602,6 +616,7 @@ SC_FUNC int assemble(FILE *fout,FILE *fin)
   #endif
 
   writeerror=FALSE;
+  debugerror=FALSE;
   nametablesize=sizeof(int16_t);
   numpublics=0;
   numnatives=0;
@@ -924,7 +939,7 @@ SC_FUNC int assemble(FILE *fout,FILE *fin)
   if (!writeerror && (sc_debug & sSYMBOLIC)!=0)
     append_dbginfo(fout);       /* optionally append debug file */
 
-  if (writeerror)
+  if (writeerror && !debugerror)
     error(101,"disk full");
 
   /* adjust the header */
@@ -990,7 +1005,8 @@ static void append_dbginfo(FILE *fout)
       if (codeidx!=previdx) {
         if (prevstr!=NULL) {
           assert(prevname!=NULL);
-          dbghdr.files++;
+          if (!inc_dbg_count(&dbghdr.files))
+            return;
           dbghdr.size+=sizeof(cell)+strlen(prevname)+1;
         } /* if */
         previdx=codeidx;
@@ -1001,7 +1017,8 @@ static void append_dbginfo(FILE *fout)
   } /* for */
   if (prevstr!=NULL) {
     assert(prevname!=NULL);
-    dbghdr.files++;
+    if (!inc_dbg_count(&dbghdr.files))
+      return;
     dbghdr.size+=sizeof(cell)+strlen(prevname)+1;
   } /* if */
 
@@ -1010,7 +1027,8 @@ static void append_dbginfo(FILE *fout)
     assert(str!=NULL);
     assert(str[0]!='\0' && str[1]==':');
     if (str[0]=='L') {
-      dbghdr.lines++;
+      if (!inc_dbg_count(&dbghdr.lines))
+        return;
       dbghdr.size+=sizeof(AMX_DBG_LINE);
     } /* if */
   } /* for */
@@ -1020,7 +1038,8 @@ static void append_dbginfo(FILE *fout)
     assert(str!=NULL);
     assert(str[0]!='\0' && str[1]==':');
     if (str[0]=='S') {
-      dbghdr.symbols++;
+      if (!inc_dbg_count(&dbghdr.symbols))
+        return;
       name=strchr(str+2,':');
       assert(name!=NULL);
       dbghdr.size+=sizeof(AMX_DBG_SYMBOL)+strlen(skipwhitespace(name+1));
@@ -1033,21 +1052,24 @@ static void append_dbginfo(FILE *fout)
   /* tag table */
   for (constptr=tagname_tab.next; constptr!=NULL; constptr=constptr->next) {
     assert(strlen(constptr->name)>0);
-    dbghdr.tags++;
+    if (!inc_dbg_count(&dbghdr.tags))
+      return;
     dbghdr.size+=sizeof(AMX_DBG_TAG)+strlen(constptr->name);
   } /* for */
 
   /* automaton table */
   for (constptr=sc_automaton_tab.next; constptr!=NULL; constptr=constptr->next) {
     assert(constptr->index==0 && strlen(constptr->name)==0 || strlen(constptr->name)>0);
-    dbghdr.automatons++;
+    if (!inc_dbg_count(&dbghdr.automatons))
+      return;
     dbghdr.size+=sizeof(AMX_DBG_MACHINE)+strlen(constptr->name);
   } /* for */
 
   /* state table */
   for (constptr=sc_state_tab.next; constptr!=NULL; constptr=constptr->next) {
     assert(strlen(constptr->name)>0);
-    dbghdr.states++;
+    if (!inc_dbg_count(&dbghdr.states))
+      return;
     dbghdr.size+=sizeof(AMX_DBG_STATE)+strlen(constptr->name);
   } /* for */
 

--- a/compiler/libpc300/sc6.c
+++ b/compiler/libpc300/sc6.c
@@ -974,8 +974,9 @@ static void append_dbginfo(FILE *fout)
   AMX_DBG_LINE dbgline;
   AMX_DBG_SYMBOL dbgsym;
   AMX_DBG_SYMDIM dbgidxtag[sDIMEN_MAX];
-  int index,dim;
+  int dim;
   char *str,*prevstr,*name,*prevname,*dimstr;
+  stringlist *dbgstr;
   ucell codeidx,previdx;
   constvalue *constptr;
   char symname[2*sNAMEMAX+16];
@@ -993,7 +994,8 @@ static void append_dbginfo(FILE *fout)
   previdx=0;
   prevstr=NULL;
   prevname=NULL;
-  for (index=0; (str=get_dbgstring(index))!=NULL; index++) {
+  for (dbgstr=get_dbgstring_next(NULL); dbgstr!=NULL; dbgstr=get_dbgstring_next(dbgstr)) {
+    str=dbgstr->line;
     assert(str!=NULL);
     assert(str[0]!='\0' && str[1]==':');
     switch (str[0]) {
@@ -1061,7 +1063,8 @@ static void append_dbginfo(FILE *fout)
   previdx=0;
   prevstr=NULL;
   prevname=NULL;
-  for (index=0; (str=get_dbgstring(index))!=NULL; index++) {
+  for (dbgstr=get_dbgstring_next(NULL); dbgstr!=NULL; dbgstr=get_dbgstring_next(dbgstr)) {
+    str=dbgstr->line;
     assert(str!=NULL);
     assert(str[0]!='\0' && str[1]==':');
     if (str[0]=='F') {
@@ -1085,7 +1088,8 @@ static void append_dbginfo(FILE *fout)
   } /* if */
 
   /* line number table */
-  for (index=0; (str=get_dbgstring(index))!=NULL; index++) {
+  for (dbgstr=get_dbgstring_next(NULL); dbgstr!=NULL; dbgstr=get_dbgstring_next(dbgstr)) {
+    str=dbgstr->line;
     assert(str!=NULL);
     assert(str[0]!='\0' && str[1]==':');
     if (str[0]=='L') {
@@ -1096,7 +1100,8 @@ static void append_dbginfo(FILE *fout)
   } /* for */
 
   /* symbol table */
-  for (index=0; (str=get_dbgstring(index))!=NULL; index++) {
+  for (dbgstr=get_dbgstring_next(NULL); dbgstr!=NULL; dbgstr=get_dbgstring_next(dbgstr)) {
+    str=dbgstr->line;
     assert(str!=NULL);
     assert(str[0]!='\0' && str[1]==':');
     if (str[0]=='S') {

--- a/compiler/libpc300/sc6.c
+++ b/compiler/libpc300/sc6.c
@@ -975,7 +975,7 @@ static void append_dbginfo(FILE *fout)
   AMX_DBG_SYMBOL dbgsym;
   AMX_DBG_SYMDIM dbgidxtag[sDIMEN_MAX];
   int dim;
-  char *str,*prevstr,*name,*prevname,*dimstr;
+  char *str,*prevstr,*name,*prevname,*nameend,*dimstr;
   stringlist *dbgstr;
   ucell codeidx,previdx;
   constvalue *constptr;
@@ -1020,8 +1020,11 @@ static void append_dbginfo(FILE *fout)
         INC_DBG_COUNT(dbghdr.symbols);
         name=strchr(str+2,':');
         assert(name!=NULL);
-        dbghdr.size+=sizeof(AMX_DBG_SYMBOL)+strlen(skipwhitespace(name+1));
-        if ((dimstr=strchr(name,'['))!=NULL)
+        name=skipwhitespace(name+1);
+        nameend=strchr(name,' ');
+        assert(nameend!=NULL);
+        dbghdr.size+=sizeof(AMX_DBG_SYMBOL)+(nameend-name);
+        if ((dimstr=strchr(nameend,'['))!=NULL)
           while ((dimstr=strchr(dimstr+1,':'))!=NULL)
             dbghdr.size+=sizeof(AMX_DBG_SYMDIM);
         break;

--- a/compiler/libpc300/sc6.c
+++ b/compiler/libpc300/sc6.c
@@ -53,9 +53,9 @@ static int debugerror;
 static int bytes_in, bytes_out;
 static jmp_buf compact_err;
 
-static int inc_dbg_count(int16_t *count)
+static int inc_dbg_count(int32_t *count)
 {
-  if (*count == 32767) {
+  if (*count == 2147483647) {
     error(102,"debug information");
     debugerror=TRUE;
     writeerror=TRUE;

--- a/compiler/libpc300/sc6.c
+++ b/compiler/libpc300/sc6.c
@@ -975,7 +975,7 @@ static void append_dbginfo(FILE *fout)
   AMX_DBG_SYMBOL dbgsym;
   AMX_DBG_SYMDIM dbgidxtag[sDIMEN_MAX];
   int index,dim;
-  char *str,*prevstr,*name,*prevname;
+  char *str,*prevstr,*name,*prevname,*dimstr;
   ucell codeidx,previdx;
   constvalue *constptr;
   char symname[2*sNAMEMAX+16];
@@ -989,59 +989,47 @@ static void append_dbginfo(FILE *fout)
   dbghdr.file_version=CUR_FILE_VERSION;
   dbghdr.amx_version=MIN_AMX_VERSION;
 
-  /* first pass: collect the number of items in various tables */
-
-  /* file table */
+  /* first pass: collect the number of items in the debug string tables */
   previdx=0;
   prevstr=NULL;
   prevname=NULL;
   for (index=0; (str=get_dbgstring(index))!=NULL; index++) {
     assert(str!=NULL);
     assert(str[0]!='\0' && str[1]==':');
-    if (str[0]=='F') {
-      codeidx=hex2long(str+2,&name);
-      if (codeidx!=previdx) {
-        if (prevstr!=NULL) {
-          assert(prevname!=NULL);
-          INC_DBG_COUNT(dbghdr.files);
-          dbghdr.size+=sizeof(cell)+strlen(prevname)+1;
+    switch (str[0]) {
+    case 'F':
+        codeidx=hex2long(str+2,&name);
+        if (codeidx!=previdx) {
+          if (prevstr!=NULL) {
+            assert(prevname!=NULL);
+            INC_DBG_COUNT(dbghdr.files);
+            dbghdr.size+=sizeof(cell)+strlen(prevname)+1;
+          } /* if */
+          previdx=codeidx;
         } /* if */
-        previdx=codeidx;
-      } /* if */
-      prevstr=str;
-      prevname=skipwhitespace(name);
-    } /* if */
+        prevstr=str;
+        prevname=skipwhitespace(name);
+        break;
+    case 'L':
+        INC_DBG_COUNT(dbghdr.lines);
+        dbghdr.size+=sizeof(AMX_DBG_LINE);
+        break;
+    case 'S':
+        INC_DBG_COUNT(dbghdr.symbols);
+        name=strchr(str+2,':');
+        assert(name!=NULL);
+        dbghdr.size+=sizeof(AMX_DBG_SYMBOL)+strlen(skipwhitespace(name+1));
+        if ((dimstr=strchr(name,'['))!=NULL)
+          while ((dimstr=strchr(dimstr+1,':'))!=NULL)
+            dbghdr.size+=sizeof(AMX_DBG_SYMDIM);
+        break;
+    } /* switch */
   } /* for */
   if (prevstr!=NULL) {
     assert(prevname!=NULL);
     INC_DBG_COUNT(dbghdr.files);
     dbghdr.size+=sizeof(cell)+strlen(prevname)+1;
   } /* if */
-
-  /* line number table */
-  for (index=0; (str=get_dbgstring(index))!=NULL; index++) {
-    assert(str!=NULL);
-    assert(str[0]!='\0' && str[1]==':');
-    if (str[0]=='L') {
-      INC_DBG_COUNT(dbghdr.lines);
-      dbghdr.size+=sizeof(AMX_DBG_LINE);
-    } /* if */
-  } /* for */
-
-  /* symbol table */
-  for (index=0; (str=get_dbgstring(index))!=NULL; index++) {
-    assert(str!=NULL);
-    assert(str[0]!='\0' && str[1]==':');
-    if (str[0]=='S') {
-      INC_DBG_COUNT(dbghdr.symbols);
-      name=strchr(str+2,':');
-      assert(name!=NULL);
-      dbghdr.size+=sizeof(AMX_DBG_SYMBOL)+strlen(skipwhitespace(name+1));
-      if ((prevstr=strchr(name,'['))!=NULL)
-        while ((prevstr=strchr(prevstr+1,':'))!=NULL)
-          dbghdr.size+=sizeof(AMX_DBG_SYMDIM);
-    } /* if */
-  } /* for */
 
   /* tag table */
   for (constptr=tagname_tab.next; constptr!=NULL; constptr=constptr->next) {

--- a/compiler/libpc300/sc7.c
+++ b/compiler/libpc300/sc7.c
@@ -537,9 +537,26 @@ static void stgopt(char *start,char *end)
       matches=0;
       start=debut;
       while (start<end) {
+        const char *first;
+        char firstc,findc;
+        /* first significant character of the current line: a pattern that
+         * opens with a different literal character cannot match, because
+         * matchsequence() would fail its very first (case-insensitive)
+         * comparison; skipping it here is a pure shortcut with an identical
+         * outcome, so the generated code stays byte-for-byte the same
+         */
+        first=start;
+        while (*first=='\t' || *first==' ')
+          first++;
+        firstc=(char)tolower(*first);
         seq=0;
         while (sequences[seq].find!=NULL) {
           assert(seq>=0);
+          findc=sequences[seq].find[0];
+          if (findc!='%' && findc!='!' && findc!=' ' && findc!='-' && (char)tolower(findc)!=firstc) {
+            seq++;
+            continue;
+          } /* if */
           if (matchsequence(start,end,sequences[seq].find,symbols,&match_length)) {
             char *replace=replacesequence(sequences[seq].replace,symbols,&repl_length);
             /* If the replacement is bigger than the original section, we may need
@@ -558,6 +575,11 @@ static void stgopt(char *start,char *end)
               code_idx-=sequences[seq].savesize;
               seq=0;                      /* restart search for matches */
               matches++;
+              /* the line changed: refresh the first-character shortcut */
+              first=start;
+              while (*first=='\t' || *first==' ')
+                first++;
+              firstc=(char)tolower(*first);
             } else {
               /* actually, we should never get here (match_length<repl_length) */
               assert(0);

--- a/compiler/libpc300/sclist.c
+++ b/compiler/libpc300/sclist.c
@@ -439,6 +439,11 @@ SC_FUNC char *get_autolist(int index)
   return get_string(&autolist,index);
 }
 
+SC_FUNC stringlist *get_autolist_next(stringlist *prev)
+{
+  return prev!=NULL ? prev->next : autolist.next;
+}
+
 SC_FUNC void delete_autolisttable(void)
 {
   delete_stringtable(&autolist);

--- a/compiler/libpc300/sclist.c
+++ b/compiler/libpc300/sclist.c
@@ -579,6 +579,11 @@ SC_FUNC char *get_dbgstring(int index)
   return get_string(&dbgstrings,index);
 }
 
+SC_FUNC stringlist *get_dbgstring_next(stringlist *prev)
+{
+  return prev!=NULL ? prev->next : dbgstrings.next;
+}
+
 SC_FUNC void delete_dbgstringtable(void)
 {
   delete_stringtable(&dbgstrings);

--- a/compiler/libpc300/sclist.c
+++ b/compiler/libpc300/sclist.c
@@ -133,19 +133,20 @@ static int delete_stringpair(stringpair *root,stringpair *item)
 /* ----- string list functions ----------------------------------- */
 static stringlist *insert_string(stringlist *root,char *string)
 {
-  stringlist *cur;
+  stringlist *cur,*tail;
 
   assert(string!=NULL);
   if ((cur=(stringlist*)malloc(sizeof(stringlist)))==NULL)
     error(103);       /* insufficient memory (fatal error) */
   if ((cur->line=duplicatestring(string))==NULL)
     error(103);       /* insufficient memory (fatal error) */
+  cur->next=NULL;
+  cur->tail=NULL;
   /* insert as "last" */
   assert(root!=NULL);
-  while (root->next!=NULL)
-    root=root->next;
-  cur->next=root->next;
-  root->next=cur;
+  tail=root->tail!=NULL ? root->tail : root;
+  tail->next=cur;
+  root->tail=cur;
   return cur;
 }
 
@@ -174,6 +175,8 @@ static int delete_string(stringlist *root,int index)
   if (cur->next!=NULL) {
     item=cur->next;
     cur->next=item->next;       /* unlink from list */
+    if (root->tail==item)
+      root->tail=cur!=root ? cur : NULL;
     assert(item->line!=NULL);
     free(item->line);
     free(item);

--- a/compiler/libpc300/sclist.c
+++ b/compiler/libpc300/sclist.c
@@ -34,7 +34,7 @@
 
 /* a "private" implementation of strdup(), so that porting
  * to other memory allocators becomes easier.
- * By Søren Hannibal.
+ * By Sï¿½ren Hannibal.
  */
 SC_FUNC char* duplicatestring(const char* sourcestring)
 {
@@ -57,6 +57,7 @@ static stringpair *insert_stringpair(stringpair *root,char *first,char *second,i
   cur->first=duplicatestring(first);
   cur->second=duplicatestring(second);
   cur->matchlength=matchlength;
+  cur->hnext=NULL;
   if (cur->first==NULL || cur->second==NULL) {
     if (cur->first!=NULL)
       free(cur->first);
@@ -259,6 +260,54 @@ SC_FUNC void delete_pathtable(void)
 static stringpair substpair = { NULL, NULL, NULL};  /* list of substitution pairs */
 
 static stringpair *substindex['z'-PUBLIC_CHAR+1]; /* quick index to first character */
+
+/* hash table over the macro name prefix: find_subst() runs for every
+ * identifier prefix of every source line, so the per-letter index above
+ * degenerates to a linear scan when many macros share a first letter */
+#define SUBSTHASH_BUCKETS 4096  /* power of 2 */
+static stringpair *substhash[SUBSTHASH_BUCKETS];
+
+static unsigned int substhash_bucket(const char *name,int length)
+{
+  unsigned int h=2166136261u;   /* FNV-1a */
+  int i;
+  for (i=0; i<length; i++) {
+    h^=(unsigned char)name[i];
+    h*=16777619u;
+  } /* for */
+  return h & (SUBSTHASH_BUCKETS-1);
+}
+
+static stringpair *substhash_find(const char *name,int length)
+{
+  stringpair *item=substhash[substhash_bucket(name,length)];
+  while (item!=NULL) {
+    if (item->matchlength==length && strncmp(item->first,name,length)==0)
+      return item;
+    item=item->hnext;
+  } /* while */
+  return NULL;
+}
+
+static void substhash_insert(stringpair *item)
+{
+  unsigned int bucket=substhash_bucket(item->first,item->matchlength);
+  item->hnext=substhash[bucket];
+  substhash[bucket]=item;
+}
+
+static void substhash_remove(stringpair *item)
+{
+  stringpair **link=&substhash[substhash_bucket(item->first,item->matchlength)];
+  while (*link!=NULL) {
+    if (*link==item) {
+      *link=item->hnext;
+      return;
+    } /* if */
+    link=&(*link)->hnext;
+  } /* while */
+}
+
 static void adjustindex(char c)
 {
   stringpair *cur;
@@ -278,6 +327,7 @@ SC_FUNC stringpair *insert_subst(char *pattern,char *substitution,int prefixlen)
   assert(substitution!=NULL);
   if ((cur=insert_stringpair(&substpair,pattern,substitution,prefixlen))==NULL)
     error(103);       /* insufficient memory (fatal error) */
+  substhash_insert(cur);
   adjustindex(*pattern);
 
   if (pc_deprecate != NULL) {
@@ -308,9 +358,7 @@ SC_FUNC stringpair *find_subst(char *name,int length)
   assert(name!=NULL);
   assert(length>0);
   assert(*name>='A' && *name<='Z' || *name>='a' && *name<='z' || *name=='_' || *name==PUBLIC_CHAR);
-  item=substindex[(int)*name-PUBLIC_CHAR];
-  if (item!=NULL)
-    item=find_stringpair(item,name,length);
+  item=substhash_find(name,length);
 
   if (item && (item->flags & flgDEPRECATED) != 0) {
     static char macro[128];
@@ -336,11 +384,10 @@ SC_FUNC int delete_subst(char *name,int length)
   assert(name!=NULL);
   assert(length>0);
   assert(*name>='A' && *name<='Z' || *name>='a' && *name<='z' || *name=='_' || *name==PUBLIC_CHAR);
-  item=substindex[(int)*name-PUBLIC_CHAR];
-  if (item!=NULL)
-    item=find_stringpair(item,name,length);
+  item=substhash_find(name,length);
   if (item==NULL)
     return FALSE;
+  substhash_remove(item);
   delete_stringpair(&substpair,item);
   adjustindex(*name);
   return TRUE;
@@ -352,6 +399,7 @@ SC_FUNC void delete_substtable(void)
   delete_stringpairtable(&substpair);
   for (i=0; i<sizeof substindex/sizeof substindex[0]; i++)
     substindex[i]=NULL;
+  memset(substhash,0,sizeof substhash);
 }
 
 #endif /* !defined NO_SUBST */

--- a/compiler/libpc300/sp_symhash.c
+++ b/compiler/libpc300/sp_symhash.c
@@ -135,8 +135,8 @@ FindTaggedInHashTable(HashTable *ht, const char *name, int fnumber,
     return firstmatch;
 }
 
-SC_FUNC symbol *
-FindInHashTable(HashTable *ht, const char *name, int fnumber)
+static symbol *
+find_in_hash_table(HashTable *ht, const char *name, int fnumber, int allowenumfields)
 {
     uint32_t hash = NameHash(name);
     uint32_t bucket = hash & ht->bucketmask;
@@ -144,7 +144,7 @@ FindInHashTable(HashTable *ht, const char *name, int fnumber)
 
     while (he != NULL) {
         symbol *sym = he->sym;
-        if ((sym->parent==NULL || sym->ident==iCONSTEXPR) &&
+        if ((sym->parent==NULL || (allowenumfields && sym->ident==iCONSTEXPR)) &&
             (sym->fnumber<0 || sym->fnumber==fnumber) &&
             (strcmp(sym->name, name) == 0))
         {
@@ -154,6 +154,20 @@ FindInHashTable(HashTable *ht, const char *name, int fnumber)
     }
 
     return NULL;
+}
+
+SC_FUNC symbol *
+FindInHashTable(HashTable *ht, const char *name, int fnumber)
+{
+    return find_in_hash_table(ht, name, fnumber, TRUE);
+}
+
+/* strict variant for findglb(): never returns parented symbols (enum
+ * fields), matching the filter of the original find_symbol() list walk */
+SC_FUNC symbol *
+FindGlobalInHashTable(HashTable *ht, const char *name, int fnumber)
+{
+    return find_in_hash_table(ht, name, fnumber, FALSE);
 }
 
 static void

--- a/compiler/libpc300/sp_symhash.h
+++ b/compiler/libpc300/sp_symhash.h
@@ -21,6 +21,7 @@ SC_FUNC void DestroyHashTable(HashTable *ht);
 SC_FUNC void AddToHashTable(HashTable *ht, symbol *sym);
 SC_FUNC void RemoveFromHashTable(HashTable *ht, symbol *sym);
 SC_FUNC symbol *FindInHashTable(HashTable *ht, const char *name, int fnumber);
+SC_FUNC symbol *FindGlobalInHashTable(HashTable *ht, const char *name, int fnumber);
 SC_FUNC symbol *FindTaggedInHashTable(HashTable *ht, const char *name, int fnumber,
                                       int *cmptag);
 


### PR DESCRIPTION
Two related sets of changes to the compiler and to the runtime that reads what the compiler writes. Both are about plugins built with `-debug`: the first half fixes the debug info itself, the second half makes `amxxpc` faster (compiling with `-debug` is where the old code hurt most, since the debug string list is the largest list the compiler keeps).

## Debug info: size limit and bounds checking

`AMX_DBG_HDR` counted every table with an `int16_t`. A plugin with more than 32767 line entries wraps the counter, and `append_dbginfo()` then writes a table the runtime cannot read back. That is reachable with a normal large plugin compiled with `-debug`, not just with generated code.

The counts are now `int32_t`, and the counting loops go through a macro that raises `error 102` (table overflow) instead of wrapping. The header layout changed, so the magic goes from `0xf1ef` to `0xf1f0` — see Compatibility below.

On the loading side, `dbg_LoadInfo()` had no idea where the buffer ended. The name scans were plain `for (ptr = ptr + sizeof(...); *ptr != '\0'; ptr++)` loops, and the table counts from the header were trusted as-is, so truncated or corrupt debug data read past the allocation. It now takes the buffer size, checks each entry and each count against the end pointer, and returns `AMX_ERR_FORMAT` instead. `modules.cpp` validates `hdr->size` against the file size before deriving that buffer, so a bad offset is rejected with a log line rather than pointing the loader at arbitrary memory.

`ClipFileName()` copied into a `static char[256]` with `strcpy()`, which a longer path overflows. It clips in place now, which also drops the shared static buffer.

`append_dbginfo()` also wrote a `hdr.size` larger than the data it actually emitted: the symbol pass counted `strlen()` of the whole rest of the debug string instead of just the symbol name. The loader allocates and copies `hdr.size` bytes out of the plugin buffer, so that overcount is read past the end of the file. It is a few KB on a small plugin and hundreds of KB on a large one. `size` is exact now.

The counting pass in `append_dbginfo()` walked the debug string list three times, once per table; it is a single `switch` over one walk now. The counters also stopped being incremented through the address of a packed struct member, which is undefined behaviour and warns on GCC/Clang.

## Compiler speed

Nothing here changes generated code. The changes are all lookup and iteration:

- `insert_string()` walked the whole list to append, so building the debug string list, the autolist and the path list was quadratic in the number of entries. Each list root now keeps a tail pointer.
- `get_dbgstring(index)` and `get_autolist(index)` walk from the head on every call, so the loops that iterate them with an increasing index were quadratic too. Added `get_dbgstring_next()` / `get_autolist_next()` and used them at the call sites.
- `find_subst()` indexed macros by first character only, which degenerates into a linear scan once many macros share a letter (`_` in particular). It uses an FNV-1a hash over the name prefix now. This runs for every identifier of every line, so it shows up on any plugin with a large include set.
- `findglb()` used the linear `find_symbol()` walk over `glbtab` while the hash table was already there and maintained. It uses the hash table now, through a variant that keeps `find_symbol()`'s filter: `FindInHashTable()` also returns parented `iCONSTEXPR` symbols (enum fields), which `findglb()` must not return, so the shared implementation takes a flag instead of loosening the existing behaviour.
- `finddepend()` scanned both symbol tables in full for every symbol, but almost no symbol has a child. Symbols now carry a `has_child` flag set wherever a `parent` is assigned. The flag is never cleared, so a stale `TRUE` only costs the scan that used to happen anyway; `FALSE` is the reliable direction.
- `stgopt()` tried every peephole pattern against every line. If a pattern starts with a literal character, the first comparison in `matchsequence()` decides it, so that case is now short-circuited before the call. Patterns starting with `%`, `!`, `-` or a space are excluded from the shortcut and still go through the full match, so the output is unchanged.

## Compatibility

This is a debug-format break and I would rather call it out than bury it.

A `.amxx` compiled with an older `amxxpc` carries magic `0xf1ef` and 16-bit counts, so the new loader rejects it with `AMX_ERR_FORMAT`, and the reverse is also true. It only matters for plugins actually loaded in debug mode (`amx_debug 2`, or the plugin marked debug in `plugins.ini`); normal loading never touches the debug table. Still, it means existing binaries have to be recompiled to keep debug output.

If you would rather not break that, the loader can keep reading `0xf1ef` with the old 16-bit header as a fallback and only use the wide format for `0xf1f0`. Say the word and I will add it to this branch.

## Notes

The commits are kept separate and each one stands on its own, so anything here can be dropped without touching the rest. I did not run the full build matrix locally, so CI is the first real check on the non-Windows compilers.
