### PR TITLE
Svengine Compatibility Fix

### DIFF
--- a/amxmodx/CvarManager.cpp
+++ b/amxmodx/CvarManager.cpp
@@ -151,7 +151,7 @@ void CvarManager::CreateCvarHook(void)
 		{
 			// Disabled by default.
 
-			#if defined(__linux__)
+#if defined(__linux__)
 			const char* raw = CommonConfig->GetKeyValue("RegParm");
 			bool useRegParm = raw ? (atoi(raw) != 0) : false; 
 			if(useRegParm)
@@ -162,9 +162,9 @@ void CvarManager::CreateCvarHook(void)
 			{
 				m_HookDetour = DETOUR_CREATE_STATIC_FIXED(Cvar_DirectSet, functionAddress);
 			}
-			#else 
+#else 
 			m_HookDetour = DETOUR_CREATE_STATIC_FIXED(Cvar_DirectSet, functionAddress);
-			#endif
+#endif
 		}
 		else
 		{

--- a/amxmodx/CvarManager.cpp
+++ b/amxmodx/CvarManager.cpp
@@ -17,7 +17,9 @@ CvarManager g_CvarManager;
 
 void (*Cvar_DirectSet_Actual)(struct cvar_s* var, const char *value) = nullptr;
 
-void Cvar_DirectSet_Custom(struct cvar_s *var, const char *value, IRehldsHook_Cvar_DirectSet *chain = nullptr)
+void (*Cvar_DirectSet_RegParm_Actual)(struct cvar_s* var, const char *value) __attribute__((regparm(3))) = nullptr;
+
+void Cvar_DirectSet_Custom(struct cvar_s *var, const char *value, IRehldsHook_Cvar_DirectSet *chain = nullptr, bool useRegParm = false)
 {
 	CvarInfo* info = nullptr;
 
@@ -25,7 +27,7 @@ void Cvar_DirectSet_Custom(struct cvar_s *var, const char *value, IRehldsHook_Cv
 		|| strcmp(var->string, value) == 0                // Make sure old and new values are different to not trigger callbacks.
 		|| !g_CvarManager.CacheLookup(var->name, &info))  // No data in cache, nothing to do.
 	{
-		chain ? chain->callNext(var, value) : Cvar_DirectSet_Actual(var, value);
+		chain ? chain->callNext(var, value) : (useRegParm ? Cvar_DirectSet_RegParm_Actual(var, value) : Cvar_DirectSet_Actual(var, value));
 		return;
 	}
 
@@ -59,7 +61,7 @@ void Cvar_DirectSet_Custom(struct cvar_s *var, const char *value, IRehldsHook_Cv
 		oldValue = var->string;
 	}
 
-	chain ? chain->callNext(var, value) : Cvar_DirectSet_Actual(var, value);
+	chain ? chain->callNext(var, value) : (useRegParm ? Cvar_DirectSet_RegParm_Actual(var, value) : Cvar_DirectSet_Actual(var, value));
 
 	if (!info->binds.empty())
 	{
@@ -103,6 +105,11 @@ void Cvar_DirectSet_Custom(struct cvar_s *var, const char *value, IRehldsHook_Cv
 	}
 }
 
+void __attribute__((regparm(3))) Cvar_DirectSet_RegParm(struct cvar_s *var, const char *value)
+{
+    Cvar_DirectSet_Custom(var, value, nullptr, true);
+}
+
 void Cvar_DirectSet(struct cvar_s *var, const char *value)
 {
 	Cvar_DirectSet_Custom(var, value);
@@ -137,7 +144,17 @@ void CvarManager::CreateCvarHook(void)
 		if (CommonConfig && CommonConfig->GetMemSig("Cvar_DirectSet", &functionAddress) && functionAddress)
 		{
 			// Disabled by default.
-			m_HookDetour = DETOUR_CREATE_STATIC_FIXED(Cvar_DirectSet, functionAddress);
+
+			const char* raw = CommonConfig->GetKeyValue("RegParm");
+			bool useRegParm = raw ? (atoi(raw) != 0) : false; 
+			if(useRegParm)
+			{
+				m_HookDetour = DETOUR_CREATE_STATIC_FIXED(Cvar_DirectSet_RegParm, functionAddress);
+			}
+			else
+			{
+				m_HookDetour = DETOUR_CREATE_STATIC_FIXED(Cvar_DirectSet, functionAddress);
+			}
 		}
 		else
 		{

--- a/amxmodx/CvarManager.cpp
+++ b/amxmodx/CvarManager.cpp
@@ -17,7 +17,11 @@ CvarManager g_CvarManager;
 
 void (*Cvar_DirectSet_Actual)(struct cvar_s* var, const char *value) = nullptr;
 
+#if defined(__linux__)
 void (*Cvar_DirectSet_RegParm_Actual)(struct cvar_s* var, const char *value) __attribute__((regparm(3))) = nullptr;
+#else 
+#define Cvar_DirectSet_RegParm_Actual Cvar_DirectSet_Actual
+#endif
 
 void Cvar_DirectSet_Custom(struct cvar_s *var, const char *value, IRehldsHook_Cvar_DirectSet *chain = nullptr, bool useRegParm = false)
 {
@@ -105,10 +109,12 @@ void Cvar_DirectSet_Custom(struct cvar_s *var, const char *value, IRehldsHook_Cv
 	}
 }
 
+#if defined(__linux__)
 void __attribute__((regparm(3))) Cvar_DirectSet_RegParm(struct cvar_s *var, const char *value)
 {
     Cvar_DirectSet_Custom(var, value, nullptr, true);
 }
+#endif
 
 void Cvar_DirectSet(struct cvar_s *var, const char *value)
 {
@@ -145,6 +151,7 @@ void CvarManager::CreateCvarHook(void)
 		{
 			// Disabled by default.
 
+			#if defined(__linux__)
 			const char* raw = CommonConfig->GetKeyValue("RegParm");
 			bool useRegParm = raw ? (atoi(raw) != 0) : false; 
 			if(useRegParm)
@@ -155,6 +162,9 @@ void CvarManager::CreateCvarHook(void)
 			{
 				m_HookDetour = DETOUR_CREATE_STATIC_FIXED(Cvar_DirectSet, functionAddress);
 			}
+			#else 
+			m_HookDetour = DETOUR_CREATE_STATIC_FIXED(Cvar_DirectSet, functionAddress);
+			#endif
 		}
 		else
 		{

--- a/gamedata/common.games/functions.engine.txt
+++ b/gamedata/common.games/functions.engine.txt
@@ -32,6 +32,45 @@
 		}
 	}
 
+    "*" // Svengine - July 19, 2026
+    {
+        "CRC"
+        {
+            "engine"
+            {
+                "linux" "48E4E4D5" //engine_i686.so
+				"windows" "F3A7F2F1" //hw.dll
+            }
+            
+        }
+
+        // "RegParm" "N": number of leading integer/pointer arguments passed via
+        // EAX, ECX, EDX (in that order) per GCC's -mregparm=N. Absent or "0" means
+        // standard cdecl (stack-passed args) which most games use at the moment. 
+		// Currently only 0 vs non-zero is consumed by hook code; intermediate values (1, 2) 
+		// are accepted by AMXX for forward compatibility purposes but not yet distinguished.
+        "Keys"
+        {
+            "RegParm"    "3"
+        }
+
+        "Signatures"
+        {
+            "SV_DropClient" // void SV_DropClient(client_t *cl, qboolean crash, const char *fmt, ...);
+            {
+                "library"   "engine"
+                "windows"   "\x81\xEC\x2A\x2A\x2A\x2A\xA1\x2A\x2A\x2A\x2A\x33\xC4\x89\x84\x24\x2A\x2A\x2A\x2A\x56\x57\x8B\xBC\x24\x2A\x2A\x2A\x2A\x8D\x84\x24"
+                "linux"     "\x55\x57\x56\x53\x81\xEC\x2C\x06\x00\x00\x8D\x84\x24\x4C\x06\x00\x00\x8B\xBC\x24\x44\x06\x00\x00\xE8\xC3\xBC\xFD\xFF"
+            }
+            "Cvar_DirectSet" // void Cvar_DirectSet(struct cvar_s *var, char *value);
+            {
+                "library"   "engine"
+                "windows"   "\x81\xEC\x2A\x2A\x2A\x2A\xA1\x2A\x2A\x2A\x2A\x33\xC4\x89\x84\x24\x2A\x2A\x2A\x2A\x53\x8B\x9C\x24\x2A\x2A\x2A\x2A\x57\x8B\xBC\x24\x2A\x2A\x2A\x2A\x85\xDB\x0F\x84\x2A\x2A\x2A\x2A\x85\xFF\x0F\x84\x2A\x2A\x2A\x2A\xF6\x43\x08\x80\x56"
+                "linux"     "\x55\x57\x89\xC7\x56\x89\xD6\x53\x81\xEC\x2C\x04\x00\x00\x8B\x40\x08\xE8\x2A\x2A\xFF\xFF\x81\xC3\xDA\xE4\x0B\x00\xA8\x80\x0F\x85\x0C\x01\x00\x00\xF6\xC4\x02\x0F\x85\xD3\x00"
+            }
+        }
+    }
+
 	"*" // Build 8684 - Windows
 	{
 		"CRC"


### PR DESCRIPTION
Sven Co-op's own Svengine variant, has its engine function `Cvar_DirectSet` declared as regparm3, meaning its first three integer/pointer arguments are passed in registers (EAX, ECX, EDX) instead of on the stack. AMXX's existing hook assumes the standard cdecl calling convention, so calling into (or being called from) this function through a cdecl-typed pointer read garbage off the stack and crashed AMXX instantly on Sven Co-op Linux servers if one were to provide the proper function signatures.

This PR adds regparm-aware hooking support for `Cvar_DirectSet`, gated by a new `RegParm` gamedata key (So far, this is only needed for Sven Co-op), and adds validated Sven Co-op engine signatures for both Windows and Linux using the recently implemented CRC mechanism. Svengine's `SV_DropClient` is not affected by this regparm calling convention and doesn't require this special handling. Broader Sven Co-op gamedata support is still pending, but this is a step closer for full support. 

Windows signatures worked, but testing was done only in a Wine environment due to the fact I do not have a Windows machine, so further testing on an actual Windows machine may be required for full validity. 

The provided .sma plugin was used for testing to demonstrate the functionality works:
```pawn
#include <amxmodx>

new g_cvarTest = 0;
new Float:g_fCvarTest = 0.0;

public plugin_init()
{
    register_plugin("Sven Cvar Test", "szGabu", "1.0.0");

    //any of these would instantly crash sven if Cvar_DirectSet signatures were provided in Linux, register_cvar wasn't affected mostly due to the fact it did not use cvar limits
    g_cvarTest = create_cvar("amx_sven_test", "1.0", FCVAR_NONE, "Tests Sven Co-op Cvar Hooking Functionality", true, 0.0, true, 5.0);
    bind_pcvar_float(g_cvarTest, g_fCvarTest);
    hook_cvar_change(g_cvarTest, "AmxSvenTestChanged");

    register_concmd("amx_show_test", "ServerCommand_ShowTestCvar");
    register_concmd("amx_change_test", "ServerCommand_ChangeTestCvar");
}

public AmxSvenTestChanged(cvarTest, const szOldValue[], const szNewValue[])
{
    server_print("[DEBUG] %s::AmxSvenTestChanged() - Cvar amx_sven_test changed from %s to %s", __BINARY__, szOldValue, szNewValue);
    server_print("[DEBUG] %s::AmxSvenTestChanged() - Value of g_fCvarTest is now %f", __BINARY__, g_fCvarTest);
}

public ServerCommand_ChangeTestCvar()
{
    server_print("[DEBUG] %s::ServerCommand_ChangeTestCvar() - Changing amx_sven_test to fixed value 5.0", __BINARY__);
    set_pcvar_float(g_cvarTest, 5.0);
    return PLUGIN_HANDLED;
}

public ServerCommand_ShowTestCvar()
{
    server_print("[DEBUG] %s::ServerCommand_ShowTestCvar() - Value of g_fCvarTest is %f", __BINARY__, g_fCvarTest);
    return PLUGIN_HANDLED;
}
```

```
L 07/30/2026 - 11:50:23: -------- Mapchange to stadium4 --------
L 07/30/2026 - 11:50:23: [FAKEMETA] get/set_gamerules_* natives have been disabled because g_pGameRules address could not be found. 
Executing Common Settings 
Writing banned.cfg.
Writing listip.cfg.
[AMXX] Loaded 2 admins from file
Can't precache excluded file: maps/stadium4.cfg
Executing AMX Mod X Configuration File 
Executing Common Settings 
Writing banned.cfg.
Writing listip.cfg.
   VAC secure mode disabled.
amx_sven_test
"amx_sven_test" is "1.0"
amx_sven_test 3.0
[DEBUG] sven_cvar_test.amx::AmxSvenTestChanged() - Cvar amx_sven_test changed from 1.0 to 3.0
[DEBUG] sven_cvar_test.amx::AmxSvenTestChanged() - Value of g_fCvarTest is now 3.000000
amx_show_test
[DEBUG] sven_cvar_test.amx::ServerCommand_ShowTestCvar() - Value of g_fCvarTest is 3.000000
amx_change_test
[DEBUG] sven_cvar_test.amx::ServerCommand_ChangeTestCvar() - Changing amx_sven_test to fixed value 5.0
[DEBUG] sven_cvar_test.amx::AmxSvenTestChanged() - Cvar amx_sven_test changed from 3.0 to 5.000000
[DEBUG] sven_cvar_test.amx::AmxSvenTestChanged() - Value of g_fCvarTest is now 5.000000
amx_show_test
[DEBUG] sven_cvar_test.amx::ServerCommand_ShowTestCvar() - Value of g_fCvarTest is 5.000000
amx_sven_test 4.0
[DEBUG] sven_cvar_test.amx::AmxSvenTestChanged() - Cvar amx_sven_test changed from 5.000000 to 4.0
[DEBUG] sven_cvar_test.amx::AmxSvenTestChanged() - Value of g_fCvarTest is now 4.000000
```

AI Disclosure:
AI Agent (Claude Sonnet 5) was used to find the root cause of the crash, the suggested fix was tested and implemented by a person.