### PR TITLE
Validate client edict bounds/free state in SV_DropClient_PreHook

### DIFF
--- a/amxmodx/meta_api.cpp
+++ b/amxmodx/meta_api.cpp
@@ -953,7 +953,18 @@ void C_ClientDisconnect(edict_t *pEntity)
 
 CPlayer* SV_DropClient_PreHook(edict_s *client, qboolean crash, const char *buffer, size_t buffer_size)
 {
-	auto pPlayer = client ? GET_PLAYER_POINTER(client) : nullptr;
+	CPlayer *pPlayer = nullptr;
+
+	if (client)
+	{
+		edict_t *pWorld = INDEXENT(0);
+		int ent = client - pWorld;
+
+		if (ent > 0 && ent <= gpGlobals->maxEntities && !client->free)
+		{
+			pPlayer = GET_PLAYER_POINTER(client);
+		}
+	}
 
 	if (pPlayer)
 	{


### PR DESCRIPTION
GET_PLAYER_POINTER was being called on the raw edict without confirming it was valid.

This would occasionally cause an "Bad entity in IndexOfEdict()" crash after a client disconnected unexpectedly (e.g. a timeout or other network drop).

I extracted a stacktrace from one of these crashes which helped point to this being the cause


```
...
L 08/08/2026 - 04:22:00: #4 addons/metamod/dlls/metamod.so(+0xa690) [0xe60cc690] mm_Sys_Error(char const*)
L 08/08/2026 - 04:22:00: #5 engine_i486.so(+0x69c4e) [0xee1cdc4e]
L 08/08/2026 - 04:22:00: #6 engine_i486.so(+0x65636) [0xee1c9636]
L 08/08/2026 - 04:22:00: #7 addons/amxmodx/dlls/amxmodx_mm_i386.so(+0x2068e) [0xe546968e] SV_DropClient(client_s*, int, char const*, ...)
```

I wasn't able to reliably repro this, although it happened relatively frequently, but I have not seen another crash of this type since applying this patch.