### PR TITLE
Fix build with GCC 14 and binutils >= 2.40 on Linux

### DIFF
--- a/amxmodx/AMBuilder
+++ b/amxmodx/AMBuilder
@@ -22,6 +22,11 @@ if builder.target_platform == 'mac':
   binary.compiler.postlink += [
     '-Wl,-read_only_relocs,suppress'
   ]
+elif builder.target_platform == 'linux':
+  # Assembly objects built without -fPIC; binutils >= 2.40 errors on text relocations
+  binary.compiler.postlink += [
+    '-Wl,-z,notext'
+  ]
 elif builder.target_platform == 'windows':
   binary.compiler.linkflags += [
     '/EXPORT:GiveFnptrsToDll=_GiveFnptrsToDll@8,@1',

--- a/compiler/libpc300/AMBuilder
+++ b/compiler/libpc300/AMBuilder
@@ -11,6 +11,8 @@ binary.compiler.includes += [
 if builder.target_platform in ['mac', 'linux']:
   binary.compiler.defines += ['ENABLE_BINRELOC']
   binary.compiler.postlink += ['-lm', '-lpthread']
+  # i386 sources compiled without -fPIC; binutils >= 2.40 errors on text relocations
+  binary.compiler.linkflags += ['-Wl,-z,notext']
 
 binary.compiler.defines += [
   'NO_MAIN',

--- a/compiler/libpc300/prefix.c
+++ b/compiler/libpc300/prefix.c
@@ -393,7 +393,8 @@ br_strndup (char *str, size_t size)
 char *
 br_extract_dir (const char *path)
 {
-	char *end, *result;
+	const char *end;
+	char *result;
 
 	br_return_val_if_fail (path != (char *) NULL, (char *) NULL);
 
@@ -428,7 +429,8 @@ br_extract_dir (const char *path)
 char *
 br_extract_prefix (const char *path)
 {
-	char *end, *tmp, *result;
+	const char *end;
+	char *tmp, *result;
 
 	br_return_val_if_fail (path != (char *) NULL, (char *) NULL);
 

--- a/modules/regex/AMBuilder
+++ b/modules/regex/AMBuilder
@@ -5,6 +5,9 @@ binary = AMXX.MetaModule(builder, 'regex')
 
 if builder.target_platform == 'linux':
   binary.compiler.postlink += [binary.Dep('lib_linux/libpcre.a')]
+  # lib_linux/libpcre.a was built without -fPIC; binutils >= 2.40 errors on
+  # text relocations in shared libs by default
+  binary.compiler.linkflags += ['-Wl,-z,notext']
 elif builder.target_platform == 'mac':
   binary.compiler.postlink += [binary.Dep('lib_darwin/libpcre.a')]
 elif builder.target_platform == 'windows':

--- a/modules/sqlite/AMBuilder
+++ b/modules/sqlite/AMBuilder
@@ -19,6 +19,12 @@ if builder.target_platform == 'linux' or builder.target_platform == 'mac':
   binary.compiler.defines += ['stricmp=strcasecmp']
   binary.compiler.postlink += ['-lpthread']
 
+if builder.target_platform == 'linux':
+  # i386 .so; binutils >= 2.40 errors on text relocations
+  binary.compiler.postlink += ['-Wl,-z,notext']
+  # sqlite3.c (vendored amalgamation) triggers false-positive warnings in GCC 14+
+  binary.compiler.cflags += ['-Wno-misleading-indentation', '-Wno-return-local-addr']
+
 binary.sources += [
   'basic_sql.cpp',
   'handles.cpp',


### PR DESCRIPTION
## Problem

Building AMX Mod X on modern Linux toolchains (GCC 14 + binutils 2.40+) fails with five distinct errors. GCC 14 tightened several diagnostics to hard errors, and binutils 2.40 made `--error-rwx-segments` the default, turning text relocations in shared libraries into linker errors (the same issue macOS already handles via `-Wl,-read_only_relocs,suppress`).

## Fixes

- **compiler/libpc300/prefix.c** — declare `end` as `const char *` in `br_extract_dir()` and `br_extract_prefix()`. `strrchr()` returns `const char *` when its input is `const char *`; GCC 14 promotes `-Wdiscarded-qualifiers` to an error.

- **compiler/libpc300/AMBuilder** — add `-Wl,-z,notext` on Linux. The i386 sources are compiled without `-fPIC`; binutils ≥ 2.40 made `--error-rwx-segments` the default, causing the link to fail with text relocation errors.

- **amxmodx/AMBuilder** — add an `elif builder.target_platform == 'linux'` block with `-Wl,-z,notext`. The macOS branch already uses `-Wl,-read_only_relocs,suppress` for the same reason; Linux now needs the equivalent.

- **modules/regex/AMBuilder** — add `-Wl,-z,notext` on Linux when linking the pre-built `lib_linux/libpcre.a`, which was built without `-fPIC` and therefore contains text relocations that binutils ≥ 2.40 rejects.

- **modules/sqlite/AMBuilder** — add `-Wl,-z,notext` on Linux and suppress `-Wno-misleading-indentation -Wno-return-local-addr` in `binary.compiler.cflags`. These are false-positive warnings triggered by the vendored SQLite amalgamation (`third_party/sqlite/sqlite3.c`) under GCC 14.

## Tested on

Gentoo Linux, GCC 14, binutils 2.46, targeting i386.